### PR TITLE
Add Getting Started & Firmware Flashing

### DIFF
--- a/website/docs/getting_started/about.md
+++ b/website/docs/getting_started/about.md
@@ -1,10 +1,10 @@
 ---
-id: overview
+id: about
 title: What is Meshtastic?
-sidebar_label: Overview
-slug: /getting_started
+sidebar_label: About
+slug: /about
 ---
-
+<!--- TODO create new about page and remove it from the "documentation" section --->
 Meshtastic® is a project that lets you use
 inexpensive ($30 ish) GPS radios as an extensible, long battery life, secure, mesh GPS communicator. These radios are great for hiking, skiing, paragliding - essentially any hobby where you don't have reliable internet access. Each member of your private mesh can always see the location and distance of all other members and any text messages sent to your group chat.
 

--- a/website/docs/getting_started/flashing_firmware.md
+++ b/website/docs/getting_started/flashing_firmware.md
@@ -1,6 +1,0 @@
----
-id: flashing_firmware
-title: Flashing Firmware
-sidebar_label: Flashing
-slug: /getting_started/flashing_firmware
----

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_cli.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_cli.md
@@ -4,6 +4,11 @@ title: Flashing Firmware – CLI
 sidebar_label: Command Line Interface
 slug: /getting_started/flashing_firmware/cli
 ---
+
+:::caution
+Be very careful to install the correct load for your board. In particular the popular 'T-BEAM' radio from TTGO is not called 'TTGO-Lora' (that is a different board). So don't install the 'TTGO-Lora' build on a TBEAM, it won't work correctly.
+:::
+
 ## Linux
 
 Requires `Python` and `pip`

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_cli.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_cli.md
@@ -1,0 +1,72 @@
+---
+id: flashing_firmware_cli
+title: Flashing Firmware – CLI
+sidebar_label: Command Line Interface
+slug: /flashing_firmware_cli
+---
+## Linux
+
+Requires `Python` and `pip`
+
+1. Download and unzip the latest Meshtastic firmware [release](https://github.com/meshtastic/Meshtastic-esp32/releases).
+2. `pip install --upgrade esptool` - Installs esptool on your machine
+3. Connect your radio to your USB port
+4. `esptool.py chip_id` - Confirm that your device is talking to your PC by running
+You should see something like:
+```
+mydir$ esptool.py chip_id
+esptool.py v2.6
+Found 2 serial ports
+Serial port /dev/ttyUSB0
+Connecting....
+Detecting chip type... ESP32
+Chip is ESP32D0WDQ6 (revision 1)
+Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
+MAC: 24:6f:28:b5:36:71
+Uploading stub...
+Running stub...
+Stub running...
+Warning: ESP32 has no Chip ID. Reading MAC instead.
+MAC: 24:6f:28:b5:36:71
+Hard resetting via RTS pin...
+```
+5. `cd` into the directory where you unzipped the latest release.
+6. Install the correct firmware for your board with `device-install.sh -f firmware-BOARD-VERSION.bin`
+```
+./device-install.sh -f firmware-heltec-1.2.x.bin
+```
+7. To update a the firmware on an existing Meshtastic device, run `device-update.sh -f firmware-BOARD-VERSION.bin`
+```
+./device-update.sh -f firmware-heltec-1.2.x.bin
+```
+
+
+
+## MacOS
+
+Installing on OS X through the commandline uses the same method as linux, but requires a slightly different method to install Python, pip and esptool.
+
+OS X (10.15.3/Catalina) comes with Python 2.7 installed, but not pip.
+
+:::note
+If you don't know if Homebrew is installed on your Mac, open terminal and enter the command `brew -v` if it doesn't work [install Homebrew](https://brew.sh) before continuing.
+:::
+
+1. `brew install pyenv` - Installs PyEnv
+2. `pyenv install 3.7.7` - To install and select Python 3.7.7
+3. `pyenv global 3.7.7` - Selects the new version of Python
+4. `brew install pip` - Installs pip3
+5. `pip3 install --upgrade esptool` - Installs esptool
+
+You may need to install a driver from Silicon Labs for the [CP210X USB to UART bridge](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
+
+6. Now install as per installing on the Linux commandline. Replace `pip` with `pip3` in your commands.
+
+## Windows
+
+Requires `Python`, `pip`, `Gitbash`
+
+1. Download and install [Python](https://www.python.org/)
+2. If you have a recent version of Python, pip should be installed by default. Check using the command `py -m pip --version`. This will display the installed version of pip. If it returns an error, you will need to [install pip](https://pip.pypa.io/en/stable/installing/).
+3. Download and install [Gitbash](https://gitforwindows.org/) (or other appropriate shell)
+4. Run `gitbash` and complete the installation as per the instructions for linux commandline.

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_cli.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_cli.md
@@ -2,7 +2,7 @@
 id: flashing_firmware_cli
 title: Flashing Firmware – CLI
 sidebar_label: Command Line Interface
-slug: /flashing_firmware_cli
+slug: /getting_started/flashing_firmware/cli
 ---
 ## Linux
 

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_gui.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_gui.md
@@ -1,0 +1,19 @@
+---
+id: flashing_firmware_gui
+title: Flashing Firmware – GUI
+sidebar_label: Graphic User Interface
+slug: /flashing_firmware_gui
+---
+### Windows & MacOS
+
+1. Download and unzip the latest Meshtastic firmware [release](https://github.com/meshtastic/meshtastic-device/releases/latest).
+2. Download [ESPHome Flasher](https://github.com/esphome/esphome-flasher) following their installation instructions.
+3. Connect your radio to your USB port and open ESPHome Flasher.
+4. If your board is not showing under Serial Port then you likely need to install the drivers for the CP210X serial chip. In Windows you can check by searching “Device Manager” and ensuring the device is shown under “Ports”.
+5. If there is an error, download the [drivers](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers), then unzip and run the Installer application.
+6. In ESPHome Flasher, refresh the serial ports and select the port to which your board is connected.
+7. Browse to the previously downloaded firmware and select the correct firmware based on the board type.
+8. Select Flash ESP.
+9. Once complete, “Done! Flashing is complete!” will be shown.
+10. The board will boot and show the Meshtastic logo.
+11. Debug messages sent from the Meshtastic device can be viewed with a terminal program such as PuTTY. Within PuTTY, click “Serial”, enter the “Serial line” com port (can be found at step 4), enter “Speed” as `921600`, then click “Open”.

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_gui.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_gui.md
@@ -2,7 +2,7 @@
 id: flashing_firmware_gui
 title: Flashing Firmware – GUI
 sidebar_label: Graphic User Interface
-slug: /flashing_firmware_gui
+slug: /getting_started/flashing_firmware/gui
 ---
 ### Windows & MacOS
 

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_gui.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_gui.md
@@ -4,7 +4,12 @@ title: Flashing Firmware – GUI
 sidebar_label: Graphic User Interface
 slug: /getting_started/flashing_firmware/gui
 ---
-### Windows & MacOS
+
+:::caution
+Be very careful to install the correct load for your board. In particular the popular 'T-BEAM' radio from TTGO is not called 'TTGO-Lora' (that is a different board). So don't install the 'TTGO-Lora' build on a TBEAM, it won't work correctly.
+:::
+
+## Windows & MacOS
 
 1. Download and unzip the latest Meshtastic firmware [release](https://github.com/meshtastic/meshtastic-device/releases/latest).
 2. Download [ESPHome Flasher](https://github.com/esphome/esphome-flasher) following their installation instructions.

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_ota.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_ota.md
@@ -2,5 +2,5 @@
 id: flashing_firmware_ota
 title: Flashing Firmware – OTA
 sidebar_label: Over The Air
-slug: /flashing_firmware_ota
+slug: /getting_started/flashing_firmware/ota
 ---

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_ota.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_ota.md
@@ -1,0 +1,6 @@
+---
+id: flashing_firmware_ota
+title: Flashing Firmware – OTA
+sidebar_label: Over The Air
+slug: /flashing_firmware_ota
+---

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_ota.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_ota.md
@@ -4,3 +4,6 @@ title: Flashing Firmware – OTA
 sidebar_label: Over The Air
 slug: /getting_started/flashing_firmware/ota
 ---
+:::caution
+Be very careful to install the correct load for your board. In particular the popular 'T-BEAM' radio from TTGO is not called 'TTGO-Lora' (that is a different board). So don't install the 'TTGO-Lora' build on a TBEAM, it won't work correctly.
+:::

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
@@ -2,7 +2,7 @@
 id: flashing_firmware_overview
 title: Overview
 sidebar_label: Overview
-slug: /flashing_firmware_overview
+slug: /getting_started/flashing_firmware/overview
 ---
 ## Download Firmware
 

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
@@ -1,0 +1,27 @@
+---
+id: flashing_firmware_overview
+title: Overview
+sidebar_label: Overview
+slug: /flashing_firmware_overview
+---
+## Download Firmware
+
+Prebuilt binaries for the supported radios are available in our releases. Your initial installation has to happen over USB from your Mac, Windows or Linux PC. Once our software is installed, all future software updates happen over bluetooth from your phone.
+
+:::caution
+Be very careful to install the correct load for your board. In particular the popular 'T-BEAM' radio from TTGO is not called 'TTGO-Lora' (that is a different board). So don't install the 'TTGO-Lora' build on a TBEAM, it won't work correctly.
+:::
+
+
+<!--- TODO I'd like to create prettier buttons for this than just a table --->
+| [Current Firmware](https://github.com/meshtastic/meshtastic-device/releases/latest) | [List of Firmware Versions](https://github.com/meshtastic/meshtastic-device/releases/) |
+| :--------------: | :-----------------------: |
+
+Firmware Flashing Methods
+- [Command line interface](flashing_firmware_cli)
+- [Graphic user interface](flashing_firmware_gui)
+- [Over the air](flashing_firmware_ota)
+
+## Troubleshooting
+
+For any issues during setup, search [our forum](https://meshtastic.discourse.group) to find a solution. If you can't find one, please post your problem, providing as much detail as possible.

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
@@ -18,9 +18,9 @@ Be very careful to install the correct load for your board. In particular the po
 | :--------------: | :-----------------------: |
 
 Firmware Flashing Methods
-- [Command line interface](/getting_started/flashing_firmware/cli)
-- [Graphic user interface](/getting_started/flashing_firmware/gui)
-- [Over the air](/getting_started/flashing_firmware/ota)
+- [Command line interface](cli)
+- [Graphic user interface](gui)
+- [Over the air](ota)
 
 ## Troubleshooting
 

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
@@ -12,7 +12,6 @@ Prebuilt binaries for the supported radios are available in our releases. Your i
 Be very careful to install the correct load for your board. In particular the popular 'T-BEAM' radio from TTGO is not called 'TTGO-Lora' (that is a different board). So don't install the 'TTGO-Lora' build on a TBEAM, it won't work correctly.
 :::
 
-
 <!--- TODO I'd like to create prettier buttons for this than just a table --->
 | [Current Firmware](https://github.com/meshtastic/meshtastic-device/releases/latest) | [List of Firmware Versions](https://github.com/meshtastic/meshtastic-device/releases/) |
 | :--------------: | :-----------------------: |

--- a/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
+++ b/website/docs/getting_started/flashing_firmware/flashing_firmware_overview.md
@@ -18,9 +18,9 @@ Be very careful to install the correct load for your board. In particular the po
 | :--------------: | :-----------------------: |
 
 Firmware Flashing Methods
-- [Command line interface](flashing_firmware_cli)
-- [Graphic user interface](flashing_firmware_gui)
-- [Over the air](flashing_firmware_ota)
+- [Command line interface](/getting_started/flashing_firmware/cli)
+- [Graphic user interface](/getting_started/flashing_firmware/gui)
+- [Over the air](/getting_started/flashing_firmware/ota)
 
 ## Troubleshooting
 

--- a/website/docs/getting_started/getting_started.md
+++ b/website/docs/getting_started/getting_started.md
@@ -1,0 +1,163 @@
+---
+id: overview
+title: Overview
+sidebar_label: Overview
+slug: /getting_started
+---
+
+## Purchase a Radio
+
+The easiest way is to [buy a device with the software already installed](https://www.aliexpress.com/item/4001178678568.html) In the Americas get the 915mhz version, In Europe the 868Mhz or Asia 923Mhz see [here](https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html).
+
+## Setup the Radio
+
+When it arrives, install your antenna and make sure you install the battery correctly. Reversing the battery can damage your device. Make sure the antenna is on when you power up the board.
+
+:::caution
+Make sure not to power the radio on without first attaching the antenna! You could damage the radio chip!
+:::
+
+## Download Firmware
+
+Prebuilt binaries for the supported radios are available in our releases. Your initial installation has to happen over USB from your Mac, Windows or Linux PC. Once our software is installed, all future software updates happen over bluetooth from your phone.
+
+:::caution
+Be very careful to install the correct load for your board. In particular the popular 'T-BEAM' radio from TTGO is not called 'TTGO-Lora' (that is a different board). So don't install the 'TTGO-Lora' build on a TBEAM, it won't work correctly.
+:::
+
+<!--- TODO I'd like to create prettier buttons for this than just a table --->
+| [Current Firmware](https://github.com/meshtastic/meshtastic-device/releases/latest) | [List of Firmware Versions](https://github.com/meshtastic/meshtastic-device/releases/) |
+| :--------------: | :-----------------------: |
+
+## Flashing Firmware
+
+If your device already has Meshtastic flashed to it, You can update over the air (OTA). Otherwise you'll need a computer and a **data** USB cable.
+
+- [Install using over-the-air (OTA)](/flashing-firmware-ota)
+- [Install using a graphical user interface (GUI)](/flashing-firmware-gui)
+- [Install using the command line interface (CLI)](/flashing-firmware-cli)
+
+## Connect to your Device
+
+There are many ways to connect to your new radio! Using the command line interface
+
+- Command line interface (CLI)
+- Graphic user interface (GUI)
+- Serial connection
+- Bluetooth
+- Web (in development)
+
+## Troubleshooting
+
+For any issues during setup, search [our forum](https://meshtastic.discourse.group) to find a solution. If you can't find one, please post your problem, providing as much detail as possible.
+
+<!--- A guide to setting up your Meshtastic device.
+
+The easiest way is to [buy a device with the software already installed](https://www.aliexpress.com/item/4001178678568.html) In the Americas get the 915mhz version, In Europe the 868Mhz or Asia 923Mhz [Frequency details](https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html).
+
+Or you can install the software yourself using the instructions below.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Firmware Installation](#firmware-installation)
+  - [Using GUI](#firmware-installation-gui)
+  - [Using Commandline](#firmware-installation-cli)
+- [Troubleshooting](#Troubleshooting)
+
+<a name="prerequisites"></a>
+## Prerequisites
+
+- Purchased radios
+- Appropriate batteries (18650)
+- Computer
+- Data MicroUSB Cable (not a charge only one)
+
+<a name="firmware-installation"></a>
+## Firmware Installation
+
+
+
+<a name="firmware-installation-gui"></a>
+### Installing from a GUI - Windows & MacOS
+
+1. Download and unzip the latest Meshtastic firmware [release](https://github.com/meshtastic/Meshtastic-esp32/releases).
+2. Download [ESPHome Flasher](https://github.com/esphome/esphome-flasher/releases).
+3. Connect your radio to your USB port and open ESPHome Flasher.
+4. If your board is not showing under Serial Port then you likely need to install the drivers for the CP210X serial chip. In Windows you can check by searching “Device Manager” and ensuring the device is shown under “Ports”.
+5. If there is an error, download the [drivers](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers), then unzip and run the Installer application.
+6. In ESPHome Flasher, refresh the serial ports and select the port to which your board is connected.
+7. Browse to the previously downloaded firmware and select the correct firmware based on the board type.
+8. Select Flash ESP.
+9. Once complete, “Done! Flashing is complete!” will be shown.
+10. The board will boot and show the Meshtastic logo.
+11. Debug messages sent from the Meshtastic device can be viewed with a terminal program such as PuTTY. Within PuTTY, click “Serial”, enter the “Serial line” com port (can be found at step 4), enter “Speed” as 921600, then click “Open”.
+
+
+<a name="firmware-installation-cli"></a>
+### Installing from a Commandline - Linux
+
+Requires `Python` and `pip`
+
+1. Download and unzip the latest Meshtastic firmware [release](https://github.com/meshtastic/Meshtastic-esp32/releases).
+2. `pip install --upgrade esptool` - Installs esptool on your machine
+3. Connect your radio to your USB port
+4. `esptool.py chip_id` - Confirm that your device is talking to your PC by running
+You should see something like:
+```
+mydir$ esptool.py chip_id
+esptool.py v2.6
+Found 2 serial ports
+Serial port /dev/ttyUSB0
+Connecting....
+Detecting chip type... ESP32
+Chip is ESP32D0WDQ6 (revision 1)
+Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
+MAC: 24:6f:28:b5:36:71
+Uploading stub...
+Running stub...
+Stub running...
+Warning: ESP32 has no Chip ID. Reading MAC instead.
+MAC: 24:6f:28:b5:36:71
+Hard resetting via RTS pin...
+```
+5. `cd` into the directory where you unzipped the latest release.
+6. Install the correct firmware for your board with `device-install.sh -f firmware-BOARD-VERSION.bin`
+   * Example: `./device-install.sh -f firmware-heltec-1.2.x.bin`
+7. To update a the firmware on an existing Meshtastic device, run `device-update.sh -f firmware-BOARD-VERSION.bin`
+   * Example: `./device-update.sh -f firmware-heltec-1.2.x.bin`
+
+
+
+### Installing from a Commandline - Mac
+
+Installing on OS X through the commandline uses the same method as linux, but requires a slightly different method to install Python, pip and esptool.
+
+OS X (10.15.3/Catalina) comes with Python 2.7 installed, but not pip.
+
+1. `brew install pyenv` - Installs PyEnv
+2. `pyenv install 3.7.7` - To install and select Python 3.7.7
+3. `pyenv global 3.7.7` - Selects the new version of Python
+4. `brew install pip` - Installs pip3
+5. `pip3 install --upgrade esptool` - Installs esptool
+
+You may need to install a driver from Silicon Labs for the [CP210X USB to UART bridge](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
+
+6. Now install as per installing on the Linux commandline.
+
+### Installing from a Commandline - Windows
+
+Requires Python, pip, Gitbash
+
+1. Download and install [Python](https://www.python.org/)
+2. If you have a recent version of Python, pip should be installed by default. Check using the command `py -m pip --version`. This will display the installed version of pip. If it returns an error, you will need to [install pip](https://pip.pypa.io/en/stable/installing/).
+3. Download and install [Gitbash](https://gitforwindows.org/) (or other appropriate shell)
+4. Run `gitbash` and complete the installation as per the instructions for linux commandline.
+
+<a name="troubleshooting"></a>
+## Troubleshooting
+
+For any issues during setup, search [our forum](https://meshtastic.discourse.group) to find a solution. If you can't find one, please post your problem, providing as much detail as possible.
+
+
+--->

--- a/website/docs/getting_started/getting_started.md
+++ b/website/docs/getting_started/getting_started.md
@@ -33,9 +33,9 @@ Be very careful to install the correct load for your board. In particular the po
 
 If your device already has Meshtastic flashed to it, You can update over the air (OTA). Otherwise you'll need a computer and a **data** USB cable.
 
-- [Install using over-the-air (OTA)](/flashing-firmware-ota)
-- [Install using a graphical user interface (GUI)](/flashing-firmware-gui)
-- [Install using the command line interface (CLI)](/flashing-firmware-cli)
+- [Install using over-the-air (OTA)](getting_started/flashing_firmware/ota)
+- [Install using a graphical user interface (GUI)](getting_started/flashing_firmware/gui)
+- [Install using the command line interface (CLI)](getting_started/flashing_firmware/cli)
 
 ## Connect to your Device
 

--- a/website/docs/getting_started/getting_started.md
+++ b/website/docs/getting_started/getting_started.md
@@ -21,10 +21,6 @@ Make sure not to power the radio on without first attaching the antenna! You cou
 
 Prebuilt binaries for the supported radios are available in our releases. Your initial installation has to happen over USB from your Mac, Windows or Linux PC. Once our software is installed, all future software updates happen over bluetooth from your phone.
 
-:::caution
-Be very careful to install the correct load for your board. In particular the popular 'T-BEAM' radio from TTGO is not called 'TTGO-Lora' (that is a different board). So don't install the 'TTGO-Lora' build on a TBEAM, it won't work correctly.
-:::
-
 <!--- TODO I'd like to create prettier buttons for this than just a table --->
 | [Current Firmware](https://github.com/meshtastic/meshtastic-device/releases/latest) | [List of Firmware Versions](https://github.com/meshtastic/meshtastic-device/releases/) |
 | :--------------: | :-----------------------: |

--- a/website/docs/getting_started/getting_started.md
+++ b/website/docs/getting_started/getting_started.md
@@ -33,9 +33,9 @@ Be very careful to install the correct load for your board. In particular the po
 
 If your device already has Meshtastic flashed to it, You can update over the air (OTA). Otherwise you'll need a computer and a **data** USB cable.
 
-- [Install using over-the-air (OTA)](getting_started/flashing_firmware/ota)
-- [Install using a graphical user interface (GUI)](getting_started/flashing_firmware/gui)
 - [Install using the command line interface (CLI)](getting_started/flashing_firmware/cli)
+- [Install using a graphical user interface (GUI)](getting_started/flashing_firmware/gui)
+- [Install using over-the-air (OTA)](getting_started/flashing_firmware/ota)
 
 ## Connect to your Device
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -8,6 +8,7 @@ module.exports = {
       {
         "Howto's": [],
       },
+      "getting_started/concepts",
     ],
     Software: [
       "software/overview",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -84,9 +84,4 @@ module.exports = {
       },
     ],
   },
-  Showcase: {
-    "Jungle Project": [
-      "software/other/mesh-alg",
-    ]
-  },
 };

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,6 +1,7 @@
 module.exports = {
   Sidebar: {
     "Getting Started": [
+      "getting_started/about",
       "getting_started/overview",
       "getting_started/flashing_firmware",
       "getting_started/concepts",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -3,9 +3,13 @@ module.exports = {
     "Getting Started": [
       "getting_started/about",
       "getting_started/overview",
-      "getting_started/flashing_firmware",
-      "getting_started/concepts",
       {
+        "Flashing Firmware": [
+          "getting_started/flashing_firmware/flashing_firmware_overview",
+          "getting_started/flashing_firmware/flashing_firmware_cli",
+          "getting_started/flashing_firmware/flashing_firmware_gui",
+          "getting_started/flashing_firmware/flashing_firmware_ota",
+        ],
         "Howto's": [],
       },
       "getting_started/concepts",
@@ -79,5 +83,10 @@ module.exports = {
         ],
       },
     ],
+  },
+  Showcase: {
+    "Jungle Project": [
+      "software/other/mesh-alg",
+    ]
   },
 };


### PR DESCRIPTION
There may be some polishing required, but I've added the Firmware Instructions for GUI/CLI. I don't have an android phone to perform OTA firmware installation, so I'll need someone else to take a look at that placeholder document.

I'm pretty happy with the structure of the documents.

I've began moving the "about" section out of the getting started guide. Ultimately I hope that we will move that to it's own page.