### PR TITLE
fix typo

### DIFF
--- a/website/docs/getting-started/flashing-esp32.md
+++ b/website/docs/getting-started/flashing-esp32.md
@@ -158,7 +158,7 @@ pip --version
   <TabItem value="linux">
 
   ```bash
-  pip install --upgrade esptool
+  pip3 install --upgrade esptool
   ```
 
   </TabItem>


### PR DESCRIPTION
Changed Linux command from 'pip' to 'pip3' fixes issue logged under Meshtastic-device [[Doc] Install esptool - Issue #856](https://github.com/meshtastic/Meshtastic-device/issues/856).