### PR TITLE
Missing dependency

### DIFF
--- a/website/docs/software/python/installation.md
+++ b/website/docs/software/python/installation.md
@@ -140,7 +140,7 @@ Installation is easily done through the [Python package installer pip](https://p
     ```
 * Upgrade pip and installed meshtastic and its dependancies
     ```
-    pip install --upgrade pip pytap2 wheel mesthtastic
+    pip install --upgrade pip pygatt pytap2 wheel mesthtastic
     ```
 
 :::note 


### PR DESCRIPTION
Android client also requires pygatt to be installed.