### PR TITLE
Broken Link Fixes in Docs

### DIFF
--- a/docs/developers/device/mesh-alg.md
+++ b/docs/developers/device/mesh-alg.md
@@ -163,7 +163,7 @@ TODO:
 - REJECTED - seems dying - possibly dash7? <https://www.slideshare.net/MaartenWeyn1/dash7-alliance-protocol-technical-presentation> <https://github.com/MOSAIC-LoPoW/dash7-ap-open-source-stack> - does the open source stack implement multi-hop routing? flooding? their discussion mailing list looks dead-dead
 - update duty cycle spreadsheet for our typical use case
 
-a description of DSR: <https://t>ools.ietf.org/html/rfc4728 good slides here: <https://www.slideshare.net/ashrafmath/dynamic-source-routing>
+a description of DSR: <https://tools.ietf.org/html/rfc4728> good slides here: <https://www.slideshare.net/ashrafmath/dynamic-source-routing>
 good description of batman protocol: <https://www.open-mesh.org/projects/open-mesh/wiki/BATMANConcept>
 
 interesting paper on LoRa mesh: <https://portal.research.lu.se/portal/files/45735775/paper.pdf>

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -78,7 +78,7 @@ Q: What are Plugins?
 
 Q: What plugins do we have available?
 
-- To see the list of available plugins, please go to: https://meshtastic.org/docs/software/plugins/plugins
+- To see the list of available plugins, please go to: https://meshtastic.org/docs/software/plugins/
 
 Q: I'd like to write a plugin. How do I get started?
 
@@ -173,4 +173,4 @@ Q: How do I find out more about installing (and using) Meshtastic via command li
 
 Q: How do I find out more about using python to interact?
 
-- See https://meshtastic.org/docs/software/python/python-usage
+- See https://meshtastic.org/docs/software/python/python-uses

--- a/docs/hardware/antenna/non-aerial.md
+++ b/docs/hardware/antenna/non-aerial.md
@@ -16,9 +16,9 @@ Unless you're using your devices in a vacuum with clear line of sight between ae
 ### Environmental factors
 
 For a bit of light reading on environmental research:
-- [RF attenuation in vegetation](https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.833-9-201609-I!!PDF-E.pdf) (yes really); if you wander through the woods wondering how your RF is bouncing off leaves dependent on their variety, and wind speed … well you do, now.
+- [RF attenuation in vegetation](https://web.archive.org/web/20201216041455/https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.833-9-201609-I!!PDF-E.pdf) (yes really); if you wander through the woods wondering how your RF is bouncing off leaves dependent on their variety, and wind speed … well you do, now.
 - [RF attenuation with various building materials](https://www.ofcom.org.uk/__data/assets/pdf_file/0016/84022/building_materials_and_propagation.pdf).
-- This one by ITU again is very detailed in its [analysis of the drivers of attenuation](https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.2040-1-201507-I!!PDF-E.pdf) (I wasn’t aware that all EMF radiation exhibits reflection / transmission characteristics akin to light hitting a material boundary. So, depending on the angle of incidence, material and the EMF wavelength, it will be reflected and / or transmitted through).
+- This one by ITU again is very detailed in its [analysis of the drivers of attenuation](https://web.archive.org/web/20211005174833/https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.2040-1-201507-I!!PDF-E.pdf) (I wasn’t aware that all EMF radiation exhibits reflection / transmission characteristics akin to light hitting a material boundary. So, depending on the angle of incidence, material and the EMF wavelength, it will be reflected and / or transmitted through).
 - These RF bands are also made more [noisy by adjacent LTE](https://www.ofcom.org.uk/__data/assets/pdf_file/0023/55922/lte-coexistence.pdf)
 
 In summary - wavelengths in Europe fair well in plain sight, curve over not-so-tall obstacles (including trees), reflect of surfaces at low angles of incidence. They go through humans without much attenuation; but not brick or stone or anything much above glass / Kevlar. Oh, and don’t sit under an LTE tower and expect it to be plain sailing.

--- a/docs/software/device/remote-hardware-service.md
+++ b/docs/software/device/remote-hardware-service.md
@@ -47,20 +47,20 @@ Now both devices can talk over the `gpio` channel.
 
 ## Doing GPIO operations
 
-You can programmatically do operations from your own python code by using the meshtastic `RemoteHardwareClient` class. See the [python API](https://meshtastic.github.io/Meshtastic-python) documentation for more details.
+You can programmatically do operations from your own python code by using the meshtastic `RemoteHardwareClient` class. See the [python API](https://meshtastic.org/docs/software/python/python-installation) documentation for more details.
 
 ## Using GPIOs from the python CLI
 
 Writing a GPIO
 ```bash title="Expected output"
-$ meshtastic  --port /dev/ttyUSB0 --gpio-wrb 4 1 --dest \!28979058 
+$ meshtastic  --port /dev/ttyUSB0 --gpio-wrb 4 1 --dest \!28979058
 Connected to radio
 Writing GPIO mask 0x10 with value 0x10 to !28979058
 ```
 
 Reading a GPIO
 ```bash title="Expected output"
-$ meshtastic --port /dev/ttyUSB0 --gpio-rd 0x10 --dest \!28979058 
+$ meshtastic --port /dev/ttyUSB0 --gpio-rd 0x10 --dest \!28979058
 Connected to radio
 Reading GPIO mask 0x10 from !28979058
 GPIO read response gpio_value=16
@@ -68,7 +68,7 @@ GPIO read response gpio_value=16
 
 Watching for GPIO changes:
 ```bash title="Expected output"
-$ meshtastic --port /dev/ttyUSB0 --gpio-watch 0x10 --dest \!28979058 
+$ meshtastic --port /dev/ttyUSB0 --gpio-watch 0x10 --dest \!28979058
 Connected to radio
 Watching GPIO mask 0x10 from !28979058
 Received RemoteHardware typ=GPIOS_CHANGED, gpio_value=16

--- a/docs/software/other/mqtt.md
+++ b/docs/software/other/mqtt.md
@@ -67,7 +67,7 @@ FIXME, discuss possible attacks by griefers and how they can be prevented
 
 #### Service Envelope
 
-The payload published on mesh/... will always be wrapped in a [ServiceEnvelope protobuf](https://github.com/meshtastic/Meshtastic-protobufs/blob/master/docs/docs.md#.ServiceEnvelope).
+The payload published on mesh/... will always be wrapped in a [ServiceEnvelope protobuf](https://meshtastic.org/docs/developers/protobufs/api#serviceenvelope).
 
 ServiceEnvelope will include the message, and full information about arrival time, who forwarded it, source channel, source mesh id, etc...
 

--- a/docs/software/python/installation.md
+++ b/docs/software/python/installation.md
@@ -8,9 +8,9 @@ import TabItem from '@theme/TabItem';
 
 This library provides a command line interface for Meshtastic nodes and provides an easy API for sending and receiving messages over mesh radios, in addition to changing user settings. Using the command line is currently the most powerful. Events are delivered using a publish-subscribe model, and you can subscribe to only the message types you are interested in.
 
-[Full documentation](https://meshtastic.github.io/Meshtastic-python) for the library, including examples, is available.
+[Full documentation](https://meshtastic.org/docs/software/python/python-installation) for the library, including examples, is available.
 
-If you wish to view the code or contribute to development of the python library or the command line interface, please visit the Meshtastic python <a href="https://github.com/meshtastic/Meshtastic-python">GitHub page</a>.
+If you wish to view the code or contribute to development of the python library or the command line interface, please visit the Meshtastic python <a href="https://meshtastic.org/docs/software/python/python-installation">GitHub page</a>.
 
 Installation is easily done through the [Python package installer pip](https://pypi.org/project/meshtastic/):
 :::note

--- a/docs/software/web/partitions.md
+++ b/docs/software/web/partitions.md
@@ -42,7 +42,7 @@ esptool.py --baud 921600 write_flash 0x10000 firmware-tbeam-EU865-1.1.42.bin
 Requires: [Python](https://www.python.org/) and [esptool.py](https://github.com/espressif/esptool)
 
 ### Visual Studio & PlatformIO
-There is also the method of using the Visual Studio IDE. This requires having Visual Studio and PlatformIO installed, along with having cloned the meshtastic-device code as per the [build instructions](https://github.com/meshtastic/Meshtastic-device/blob/master/docs/software/build-instructions.md)<!-- link to be changed once build page is completed -->. After loading the project in Visual Studio, select the PlatformIO alien icon, then find the appropriate device, and then click the Erase Flash command.
+There is also the method of using the Visual Studio IDE. This requires having Visual Studio and PlatformIO installed, along with having cloned the meshtastic-device code as per the [build instructions](https://meshtastic.org/docs/software/other/build-instructions). After loading the project in Visual Studio, select the PlatformIO alien icon, then find the appropriate device, and then click the Erase Flash command.
 
 ![Erasing the flash using PlatformIO in Visual Studio Code](/img/platformio-erase.png)
 


### PR DESCRIPTION
Found a few broken/outdated links in the docs and fixed them.

For the two links to ITU docs (1ecafbb), they seem to have been moved, so I linked to the Internet Archive versions. This may be a good idea to do for external links to content that's expected to remain static.