### PR TITLE
Initial About pages

### DIFF
--- a/docs/about/concepts/channels.md
+++ b/docs/about/concepts/channels.md
@@ -1,0 +1,28 @@
+---
+id: channels
+title: Channels
+sidebar_label: Channels
+---
+## Overview
+
+## Channels
+
+### Primary Channel
+
+### Secondary Channel
+
+### Admin Channel
+
+## Data
+
+### Environmental Measurment Data
+
+### MQTT Bridges
+
+## Encryption
+
+## Messages
+
+### Broadcast Messages
+
+### Direct Messages (DMs)

--- a/docs/about/concepts/clients.md
+++ b/docs/about/concepts/clients.md
@@ -1,0 +1,18 @@
+---
+id: clients
+title: Clients
+sidebar_label: Clients
+---
+## Overview
+
+## Available Clients
+
+### Android
+
+### Commandline Interface (CLI)
+
+### iOS
+
+### MacOS
+
+### Web Interface

--- a/docs/about/concepts/external-devices.md
+++ b/docs/about/concepts/external-devices.md
@@ -1,0 +1,34 @@
+---
+id: external-devices
+title: External Devices
+sidebar_label: External Devices
+---
+## Overview
+
+External hardware can be connected to your device using a GPIO (General Purpose Input/Output) interface. Using GPIO, you are able to connect external buttons, circuits, rotary encoders, environmental sensors and more. Many of our plugins offer solutions to implement additional functionality.
+
+Soldering is likely required when attaching items to your device, so practice your skills elsewhere before trying on your radio. If you're not careful or don't know what your doing, you can damage your hardware.
+
+## Features using External Devices
+
+Many of our plugins require external hardware to be attached to the device.
+
+### Canned Message Plugin
+
+Requires use of the [rotary encoder plugin](#rotary-encoder-plugin). The rotary encoder acts as an input to select one of up to 50 customizable messages. This way you can send canned messages without needing to pair your device to a phone.
+
+### Environmental Measurment Plugin
+
+Broadcast environmental measurments to your mesh! Temperature, Humidity, Pressure, & VOC Gas are all options that are currently available with the supported sensors.
+
+### External Notifications Plugin
+
+Use lights, buzzers, or speakers to alert you of incoming messages.
+
+### Rotary Encoder Plugin
+
+Currently used only for the [canned message plugin](#canned-message-plugin), this plugin allows you to connect a rotary encoder to be used as an additional input to the device.
+
+### Serial Plugin
+
+Available for ESP32 based devices, the serial plugin allows you to send messages over the mesh by sending strings over a serial port.

--- a/docs/about/concepts/internet.md
+++ b/docs/about/concepts/internet.md
@@ -1,0 +1,12 @@
+---
+id: internet
+title: Internet Connectivity
+sidebar_label: Internet Connectivity
+---
+## Overview
+
+## Features using Internet Connectivity
+
+### MQTT
+
+### Web Interface

--- a/docs/about/concepts/mesh.md
+++ b/docs/about/concepts/mesh.md
@@ -1,0 +1,10 @@
+---
+id: mesh
+title: Mesh Routing
+sidebar_label: Mesh Routing
+---
+## Overview
+
+## Devices
+
+## Routers

--- a/docs/about/concepts/overview.md
+++ b/docs/about/concepts/overview.md
@@ -1,0 +1,6 @@
+---
+id: overview
+title: Meshtastic Concepts
+sidebar_label: Concepts Overview
+---
+## Overview

--- a/docs/about/expectations.md
+++ b/docs/about/expectations.md
@@ -1,0 +1,5 @@
+---
+id: expectations
+title: Expectations
+sidebar_label: Expectations
+---

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -1,0 +1,30 @@
+---
+id: overview
+title: About Meshtastic
+sidebar_label: About Meshtastic
+slug: /about
+---
+:::info
+This section is new and is still being developed. If you'd like to contribute, please do!
+:::
+
+## What is Meshtastic
+
+Meshtastic is an off-grid, encrypted communication platform that runs open source software on affordable radios. These radios rebroadcast messages they receive in order to create a mesh network. The underlying technology, LoRa is a long range radio protocol that is available to most regions without needing certification like ham operators.
+
+Paired with the Meshtastic companion app, you are able to send and receive encrypted messages on your personal mesh. These radios have low power draw so they have excellent battery life. Perfect for outdoor excursions like backpacking, hiking, paragliding, and skiing where communication can be sparse.
+
+Radios can be paired to a single phone so that you're able to message your friends and family, and they can address your specific radio.
+
+## How does it work
+
+When you send a message on your Meshtastic companion app, it is relayed to the radio using bluetooth. That message is then broadcast by the radio three times over a certain interval in order to create redundancy for lost packets.
+
+When a receiving radio captures a packet, it checks to see if it has heard that message before. If it has it ignores the message. If it hasn't heard the message, it will rebroadcast it at a certain interval three times.
+
+For each message a radio rebroadcasts, it marks the "hop limit" down by one. When a radio receives a packet with a hop limit of zero, it will not rebroadcast the message.
+
+## Who develops Meshtastic
+<!--- FIXME add Github organization list/contributor list --->
+
+Meshtastic is an open source project available on GitHub. Our generous volunteers donate their personal time to write and maintain this codebase. If you would like to contribute see our [GitHub](https://github.com/meshtastic), join our [Discord server](https://discord.com/invite/UQJ5QuM7vq), and read up on our [forum](https://meshtastic.discourse.group).

--- a/docs/faq/antenna.md
+++ b/docs/faq/antenna.md
@@ -1,0 +1,6 @@
+---
+id: antenna
+title: FAQs - Antenna
+sidebar_label: Antenna
+---
+## Overview

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -1,0 +1,23 @@
+---
+id: faq
+title: FAQs - General
+sidebar_label: General
+slug: /faq
+---
+<!---
+Note to Contributors:
+
+Best Practices for the FAQ:
+
+- Keep the answers Non-Technical. The FAQ should be targeted to non-geeks.
+- This FAQ is not the authoritative document. Provide a short answer and a link to learn more.
+
+Format should be:
+## Overview
+Details about FAQ page
+
+### Question
+Answer (Include links to settings/developers/supported hardware etc)
+
+ --->
+## Overview

--- a/docs/faq/mesh.md
+++ b/docs/faq/mesh.md
@@ -1,0 +1,6 @@
+---
+id: mesh
+title: FAQs - Mesh
+sidebar_label: Mesh
+---
+## Overview

--- a/docs/faq/wifi.md
+++ b/docs/faq/wifi.md
@@ -1,0 +1,6 @@
+---
+id: wifi
+title: FAQs - WiFi
+sidebar_label: WiFi
+---
+## Overview

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -34,13 +34,11 @@ const config = {
           activeBasePath: "docs/academy",
         },
 */
-/*
         {
           label: "About Meshtastic",
           to: "docs/about",
           activeBasePath: "docs/about",
         },
-*/
 /*
         {
           label: "Showcase",
@@ -51,6 +49,10 @@ const config = {
         {
           label: "Documentation",
           items: [
+            {
+              label: "About",
+              to: "docs/about",
+            },
             {
               label: "Getting Started",
               to: "docs/getting-started",
@@ -118,13 +120,13 @@ const config = {
           title: 'Learn',
           items: [
             {
+              label: 'About',
+              to: 'docs/about',
+            },
+            {
               label: 'Getting Started',
               to: 'docs/getting-started',
             },
-            // {
-            //   label: 'About',
-            //   to: 'docs/about',
-            // },
             {
               label: 'Hardware',
               to: 'docs/hardware',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,4 +1,28 @@
 module.exports = {
+  About: {
+    "About Meshtastic": [
+      "about/overview",
+      {
+        "Concepts": [
+          "about/concepts/overview",
+          "about/concepts/channels",
+          "about/concepts/clients",
+          "about/concepts/external-devices",
+          "about/concepts/internet",
+          "about/concepts/mesh",
+        ],
+      },
+      "about/expectations",
+      {
+        "FAQs": [
+          "faq/faq",
+          "faq/antenna",
+          "faq/mesh",
+          "faq/wifi",
+        ],
+      }
+    ],
+  },
   Software: {
     Software: [
       "software/overview",


### PR DESCRIPTION
I think I'm happy with the scaffolding of the about pages now, but I'd like other people to be able to help in writing it so I think I'll submit this PR with minimal content so we can go about filling it.

Next steps for these pages would be move the FAQ over, and populate with content. This should be ELI15 content that links outwardly to the pages in software, settings, and developer