### PR TITLE
Update range-test.mdx

### DIFF
--- a/docs/software/modules/range-test.mdx
+++ b/docs/software/modules/range-test.mdx
@@ -10,7 +10,7 @@ This module allows you to test the range of your Meshtastic nodes. It uses two n
 
 ## Configuration
 
-<PluginModule name="range_test_" rename="range_test_" />
+<PluginModule name="range_test_module_" rename="range_test_plugin_" />
 
 These are the settings that can be configured.
 


### PR DESCRIPTION
Has wrong 1.2 vs 1.3 "the name of this option has changed" ... just said "1.3 is range_test_ and 1.2 is range_test_" .... wasted 30 mins figuring this out -- should be 1.3 range_test_module_ and 1.2 is range_test_plugin_