### PR TITLE
Tidying up hardware section

### DIFF
--- a/docs/hardware/antenna/aerials.mdx
+++ b/docs/hardware/antenna/aerials.mdx
@@ -3,6 +3,7 @@ id: aerials
 title: Aerial selection
 sidebar_label: Aerial selection
 slug: /hardware/aerials
+sidebar_position: 1
 ---
 
 The stock aerials provided bundled with the t-Beam and other boards are a 'mixed bag'. They may not have been designed or tuned for your given frequency range, and they may not be of a quality design.

--- a/docs/hardware/antenna/antenna.mdx
+++ b/docs/hardware/antenna/antenna.mdx
@@ -1,7 +1,8 @@
 ---
 id: antenna
 title: Antennas
-sidebar_label: Overview
+sidebar_label: Antennas
+sidebar_position: 2
 slug: /hardware/antenna
 ---
 

--- a/docs/hardware/antenna/non-aerial.mdx
+++ b/docs/hardware/antenna/non-aerial.mdx
@@ -3,6 +3,7 @@ id: non-aerial
 title: Non-aerial factors affecting transmission
 sidebar_label: Non-aerial factors
 slug: /hardware/non-aerial
+sidebar_position: 2
 ---
 
 Unless you're using your devices in a vacuum, with clear line of sight between aerials the following will have an effect:

--- a/docs/hardware/antenna/resources.mdx
+++ b/docs/hardware/antenna/resources.mdx
@@ -3,6 +3,7 @@ id: resources
 title: Antenna resources
 sidebar_label: Resources
 slug: /hardware/resources
+sidebar_position: 4
 ---
 
 ### More antenna information
@@ -10,31 +11,34 @@ slug: /hardware/resources
 - [Hackaday's Introduction to Antenna Basics](https://www.youtube.com/playlist?list=PL_tws4AXg7authztKFg5ZN5qWGtq3N_nI)
   - An excellent series of presentations on the basics of antenna design and function, presented by spacecraft radio engineer Karen Rucker.
 
+
 ### Coverage prediction
 
 - [Tower Coverage.com](https://www.towercoverage.com)
-
   - Commercial, but has free options
 
-- [HeyWhat'sThat](http://www.heywhatsthat.com)
 
+- [HeyWhat'sThat](http://www.heywhatsthat.com)
   - Free with path profiling options
+
 
 - [Radio Mobile Online](https://www.ve2dbe.com/rmonline_s.asp)
   - Radio Mobile Online is a radio wave propagation prediction tool dedicated to amateur radio
 
+
 ### RF Tools
 
 - [Times Microwave Systems](https://www.timesmicrowave.com/calculator/?Product=RG-6&RunLength=10&Frequency=868)
-
   - Coaxial Cable Attenuation & Power Handling Calculator
 
-- [Solwise Link Budget Calculator](https://www.solwise.co.uk/link-budget.htm)
 
+- [Solwise Link Budget Calculator](https://www.solwise.co.uk/link-budget.htm)
   - Predict the received signal strength
+
 
 - [Amateur Radio Toolkit](https://play.google.com/store/apps/details?id=com.daveyhollenberg.amateurradiotoolkit)
   - Android app with lots of antenna information
+
 
 ### Antenna designs
 

--- a/docs/hardware/antenna/testing.mdx
+++ b/docs/hardware/antenna/testing.mdx
@@ -2,6 +2,7 @@
 id: antenna-testing
 title: Antenna testing
 sidebar_label: Testing
+sidebar_position: 3
 ---
 
 Testing of antennas can be both simple and complex. At its simplest, testing involves sending messages from different locations and seeing which ones are received, and then comparing the results against other antennas. At the complex end, this can be using expensive test chambers and equipment to measure the signal strength, gain, and radiation patterns. However, it seems that a reasonable job can be done with cheaper methods.

--- a/docs/hardware/battery.mdx
+++ b/docs/hardware/battery.mdx
@@ -2,6 +2,7 @@
 id: battery
 title: Adding and sizing batteries
 sidebar_label: Batteries
+sidebar_position: 5
 ---
 
 import { BatteryCalculator } from '../../src/components/BatteryCalculator';

--- a/docs/hardware/buttons.mdx
+++ b/docs/hardware/buttons.mdx
@@ -2,6 +2,7 @@
 id: buttons
 title: Modifying devices to add buttons
 sidebar_label: Buttons
+sidebar_position: 4
 ---
 
 Many of the TTGO Lora32 devices do not have a program button to navigate the displayed pages. It is possible to add a button to the following device:

--- a/docs/hardware/gpsmodule.md
+++ b/docs/hardware/gpsmodule.md
@@ -2,6 +2,7 @@
 id: gpsmodule
 title: External GPS Module
 sidebar_label: GPS Module
+sidebar_position: 3
 ---
 
 :::warning

--- a/docs/hardware/supported/heltec.mdx
+++ b/docs/hardware/supported/heltec.mdx
@@ -2,6 +2,7 @@
 id: heltec
 title: Heltec device
 sidebar_label: Heltec
+sidebar_position: 5
 ---
 
 ## WiFi LoRa 32 (V2)
@@ -18,14 +19,16 @@ sidebar_label: Heltec
 - Reset and Program switches
 - No GPS
 
+
 - Firmware file: `firmware-heltec-1.x.x.bin`
 - [Purchase link](https://heltec.org/project/wifi-lora-32)
+
 
 [<img src="Heltec WiFi LoRa 32 (V2)" src="/img/hardware/heltec-v2.png" style={{zoom:'25%'}} />](/img/hardware/heltec-v2.png)
 
 [<img src="Heltec WiFi LoRa 32 (V2) Pinouts" src="/img/hardware/heltec_v2_pinmap.png" style={{zoom:'25%'}} />](/img/hardware/heltec_v2_pinmap.png)
 
-- There are two versions of the Heltec (V2). Below is a picture highlighting the visual differences:
+There are two versions of the Heltec (V2). Below is a picture highlighting the visual differences:
 
 [<img src="Heltec WiFi LoRa 32 (V2)" src="/img/hardware/heltec_v2_vs_v21.png" style={{zoom:'25%'}} />](/img/hardware/heltec_v2_vs_v21.png)
 

--- a/docs/hardware/supported/linux.mdx
+++ b/docs/hardware/supported/linux.mdx
@@ -2,6 +2,7 @@
 id: linux
 title: Linux Compatible Hardware
 sidebar_label: Linux
+sidebar_position: 6
 ---
 
 This page is a place holder.

--- a/docs/hardware/supported/lora.mdx
+++ b/docs/hardware/supported/lora.mdx
@@ -2,9 +2,23 @@
 id: lora
 title: LILYGO® TTGO Lora devices
 sidebar_label: LILYGO® Lora
+sidebar_position: 2
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-## Lora V1
+There are several versions of the LILYGO® Lora
+
+<Tabs
+groupId="t-lora"
+defaultValue="v1"
+values={[
+{label: 'Lora V1', value: 'v1'},
+{label: 'Lora V1.3', value: 'v1.3'},
+{label: 'Lora V2.0', value: 'v2.0'},
+{label: 'Lora V2.1-1.6', value:'v2.1'}
+]}>
+<TabItem value="v1">
 
 - ESP32 - Wifi & Bluetooth
 - SX1276 - LoRa Transceiver
@@ -16,12 +30,15 @@ sidebar_label: LILYGO® Lora
 - Reset and Program switches
 - No GPS
 
+
 - Firmware file: `firmware-tlora-v1-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/32840238513.html)
 
+
 [<img alt="LILYGO® TTGO Lora V1" src="/img/hardware/lora-v1.png" style={{zoom:'25%'}} />](/img/hardware/lora-v1.png)
 
-## Lora V1.3
+</TabItem>
+<TabItem value="v1.3">
 
 - ESP32 - Wifi & Bluetooth
 - SX127x - LoRa Transceiver
@@ -33,13 +50,16 @@ sidebar_label: LILYGO® Lora
 - Reset and Program switches
 - No GPS
 
+
 - Firmware file: `firmware-tlora_v1_3-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/4000628100802.html)
+
 
 [<img alt="LILYGO® TTGO Lora V1.3" src="/img/hardware/lora-v1.3.png" style={{zoom:'25%'}} />](/img/hardware/lora-v1.3.png)
 [<img alt="LILYGO® TTGO Lora V1.3 pin map" src="/img/hardware/lora-v1.3_pinmap.webp" style={{zoom:'25%'}} />](/img/hardware/lora-v1.3_pinmap.webp)
 
-## Lora V2.0
+</TabItem>
+<TabItem value="v2.0">
 
 - ESP32 - Wifi & Bluetooth
 - SX127x - LoRa Transceiver
@@ -53,12 +73,15 @@ sidebar_label: LILYGO® Lora
 - microSD connector
 - No GPS
 
+
 - Firmware file: `firmware-tlora-v2-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/32846302183.html)
 
+
 [<img alt="LILYGO® TTGO Lora V2" src="/img/hardware/lora-v2.0.png" style={{zoom:'25%'}} />](/img/hardware/lora-v2.0.png)
 
-## Lora V2.1-1.6
+</TabItem>
+<TabItem value="v2.1">
 
 - ESP32 - Wifi & Bluetooth
 - SX127x - LoRa Transceiver
@@ -72,11 +95,17 @@ sidebar_label: LILYGO® Lora
 - microSD connector
 - No GPS
 
+
 - Firmware file: `firmware-tlora-v2-1-1.6-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/32915894264.html)
+
 
 :::warning
 Some of these boards contained the wrong component in the LiPo battery charging circuit allowing the battery to be overcharged. While this does appear to have been fixed recently, please see the [warning](https://www.thethingsnetwork.org/community/berlin/post/warning-attention-users-of-ttgo21-v16-boards-labeled-t3_v16-on-pcb-battery-exploded-and-got-on-fire) on The Things Network for more information.
 :::
 
 [<img src="/img/hardware/lora-v2.1-1.6.png" alt="LILYGO® TTGO Lora V2.1-1.6" style={{zoom:'25%'}} />](/img/hardware/lora-v2.1-1.6.png)
+
+
+</TabItem>
+</Tabs>

--- a/docs/hardware/supported/rak4631.mdx
+++ b/docs/hardware/supported/rak4631.mdx
@@ -2,6 +2,7 @@
 id: wisBlock
 title: RAK WisBlock 4631
 sidebar_label: RAK WisBlock
+sidebar_position: 3
 ---
 
 The RAK WisBlock is a low power modular hardware system that can be used to build Meshtastic devices. Soldering is only required for the optional OLED screen.
@@ -37,6 +38,7 @@ There is currently no pin required to pair RAK devices via BLE.
 - U.FL antenna connector
 - Optional switches
 - Optional screen
+
 
 - Firmware for 5005 base board: [`firmware-rak4631_5005-1.x.x.uf2`](/downloads)
 

--- a/docs/hardware/supported/tbeam.mdx
+++ b/docs/hardware/supported/tbeam.mdx
@@ -2,9 +2,24 @@
 id: tbeam
 title: LILYGO® TTGO T-Beam devices
 sidebar_label: LILYGO® T-Beam
+sidebar_position: 1
 ---
 
-## T-Beam - Meshtastic - v1.1
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+There are several versions of the T-Beam
+
+<Tabs
+groupId="t-beam"
+defaultValue="1.1"
+values={[
+{label: 'T-Beam v1.1', value: '1.1'},
+{label: 'T-Beam with M8N', value: 'm8n'},
+{label: 'T-Beam with M8N & SX1262', value: 'sx1262'},
+{label: 'T-Beam v0.7', value:'0.7'}
+]}>
+<TabItem value="1.1">
 
 - Meshtastic pre-installed
 - ESP32 - Wifi & Bluetooth
@@ -19,14 +34,17 @@ sidebar_label: LILYGO® T-Beam
 - Power, Program and Reset switches
 - **Comes with 0.96 inch OLED display (some soldering required to assemble)**
 
+
 - Firmware file: `firmware-tbeam-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/4001178678568.html)
 
 [<img alt="LILYGO® TTGO T-Beam Meshtastic" src="/img/hardware/t-beam-meshtastic.png" style={{zoom:'25%'}} />](/img/hardware/t-beam-meshtastic.png)
-[<img alt="LILYGO® TTGO T-Beam v1.1" src="/img/hardware/t-beam-v1.1.png" style={{zoom:'35%'}} />](/img/hardware/t-beam-v1.1.png)
+<!--[<img alt="LILYGO® TTGO T-Beam v1.1" src="/img/hardware/t-beam-v1.1.png" style={{zoom:'35%'}} />](/img/hardware/t-beam-v1.1.png)-->
 [<img alt="LILYGO® TTGO T-Beam v1.1 pinmap" src="/img/hardware/t-beam_v1.1_pinmap.webp" style={{zoom:'35%'}} />](/img/hardware/t-beam_v1.1_pinmap.webp)
 
-## T-Beam - M8N
+
+</TabItem>
+<TabItem value="m8n">
 
 - ESP32 - Wifi & Bluetooth
 - SX1276 - LoRa Transceiver
@@ -40,12 +58,15 @@ sidebar_label: LILYGO® T-Beam
 - Power, Program and Reset switches
 - Screen sold separately
 
+
 - Firmware file: `firmware-tbeam-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/33047631119.html)
 
 [<img alt="LILYGO® TTGO T-Beam M8N" src="/img/hardware/t-beam-m8n.png" style={{zoom:'25%'}} />](/img/hardware/t-beam-m8n.png)
 
-## T-Beam - M8N & SX1262
+
+</TabItem>
+<TabItem value="sx1262">
 
 - ESP32 - Wifi & Bluetooth
 - **SX1262 - LoRa Transceiver - improved performance**
@@ -59,12 +80,15 @@ sidebar_label: LILYGO® T-Beam
 - Power, Program and Reset switches
 - Screen sold separately
 
+
 - Firmware file: `firmware-tbeam-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/4001287221970.html)
 
 [<img alt="LILYGO® TTGO T-Beam M8N & SX1262" src="/img/hardware/t-beam-sx1262.png" style={{zoom:'25%'}} />](/img/hardware/t-beam-sx1262.png)
 
-## T-Beam - v0.7
+
+</TabItem>
+<TabItem value="0.7">
 
 :::note
 This is an earlier version of the T-Beam board, and due to changes in the design in subsequent iterations this board uses a specific firmware file different from the other T-Beam boards.
@@ -84,15 +108,20 @@ This is an earlier version of the T-Beam board, and due to changes in the design
 - No GPS
 - Screen sold separately
 
+
 - Firmware file: `firmware-tbeam0.7-1.x.x.bin`
 - [Purchase link](https://www.aliexpress.com/item/4000469332610.html)
 
 [<img alt="LILYGO TTGO T-Beam v0.7" src="/img/hardware/t-beam-v0.7.png" style={{zoom:'25%'}} />](/img/hardware/t-beam-v0.7.png)
 [<img alt="LILYGO TTGO T-Beam v0.7 pinmap" src="/img/hardware/t-beam_v0.7_pinmap.jpeg" style={{zoom:'25%'}} />](/img/hardware/t-beam_v0.7_pinmap.jpeg)
 
+</TabItem>
+</Tabs>
+
 ## Screen
 
 - 0.96 inch OLED i<sup>2</sup>c display
 - [Purchase link](https://www.aliexpress.com/item/32922106384.html)
+
 
 [<img alt="0.96 inch OLED display" src="/img/hardware/screen.png" style={{zoom:'25%'}} />](/img/hardware/screen.png)

--- a/docs/hardware/supported/techo.mdx
+++ b/docs/hardware/supported/techo.mdx
@@ -2,9 +2,10 @@
 id: techo
 title: LILYGO® TTGO T-Echo devices
 sidebar_label: LILYGO® T-Echo
+sidebar_position: 4
 ---
 
-The T-Echo has been in development by LILYGO® over the past few months and has now been released.
+The T-Echo is the latest device to be release by LILYGO® supporting a low power consumption microcontroller.
 
 ### See [Getting Started](/docs/getting-started/flashing-nrf52)
 
@@ -20,8 +21,8 @@ The T-Echo has been in development by LILYGO® over the past few months and has 
 - L76K - GNSS receiver - Supporting GPS, BeiDou, GLONASS & QZSS
 - Reset, Program and capacitive touch buttons
 - U.FL antenna connector
-<!-- * BME280 - Humidity and Pressure Sensor -->
-- Optional case and battery
+- Optional BME280 - Humidity and Pressure Sensor
+- Comes with a case and battery
 
 <img
   alt="LILYGO T-Echo"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -11,6 +11,7 @@
   --ifm-color-primary-light: rgb(70, 203, 174);
   --ifm-color-primary-lighter: rgb(102, 212, 189);
   --ifm-color-primary-lightest: rgb(146, 224, 208);
+  --ifm-list-item-margin: 0;
   --ifm-code-font-size: 95%;
   --ifm-z-index-fixed: 1;
   --accent: #67ea94;
@@ -153,4 +154,14 @@ a + .navbar__link > svg {
   .hideDark {
     @apply block
   }
+}
+
+.markdown :where(li):not(:where([class~=not-prose] *)){
+  margin-bottom:0;
+  margin-top:0;
+}
+
+.markdown :where(ul ul,ul ol,ol ul,ol ol):not(:where([class~=not-prose] *)){
+  margin-bottom:0;
+  margin-top: 0;
 }


### PR DESCRIPTION
A tidy up of the hardware section, rearranged the sidebar positions, sorted out the lists (were missing an extra empty CR to terminate the list), Lora and T-beam pages condensed into tabs

The custom.css changes have changed the behaviour of list items, removing the top & bottom margins, so hopefully looking more like a list and less like a group of items spread across the page. This effect is site wide.

View at https://meshtastic-qtci4vwnk-apt105.vercel.app/