### PR TITLE
Update router.mdx

### DIFF
--- a/docs/settings/router.mdx
+++ b/docs/settings/router.mdx
@@ -73,7 +73,7 @@ Toggling `is_router` changes your device settings in the following ways.
 | `position_broadcast_secs` |      12 hours       |   15 minutes   |
 |   `wait_bluetooth_secs`   |          1          |       60       |
 |  `mesh_sds_timeout_secs`  | NODE_DELAY_FOREVER  |    2 hours     |
-|         `ls_secs`         |        1 day        |   5 minutes    |
+|         `ls_secs`         |        1 day        |   5 minutes or 1 hour? |
 
 ### Altered Behaviors
 

--- a/docs/settings/router.mdx
+++ b/docs/settings/router.mdx
@@ -73,7 +73,7 @@ Toggling `is_router` changes your device settings in the following ways.
 | `position_broadcast_secs` |      12 hours       |   15 minutes   |
 |   `wait_bluetooth_secs`   |          1          |       60       |
 |  `mesh_sds_timeout_secs`  | NODE_DELAY_FOREVER  |    2 hours     |
-|         `ls_secs`         |        1 day        |   5 minutes or 1 hour? |
+|         `ls_secs`         |        1 day        |     1 hour     |
 
 ### Altered Behaviors
 


### PR DESCRIPTION
Ls_secs default setting is listed as 5 minutes on this page, and 1 hour on power page in docs, so one must be wrong.

Here on router page, Under Details headiing, table line ls_secs, is this the correct “normal default” - 5 minutes?
On power page, The ls_secs default  power page isays the normal default is 1 hour