### PR TITLE
Update store-and-forward-module.mdx

### DIFF
--- a/docs/settings/modules/store-and-forward-module.mdx
+++ b/docs/settings/modules/store-and-forward-module.mdx
@@ -301,7 +301,7 @@ Either use a custom channel configuration with at an at least 1kbit data rate or
 Recommended channel setting is for 1.343kbps:
 
 ```shell title="Recommended channel setting for S&F module"
-meshtastic --setchan spread_factor 11 --setchan coding_rate 4 --setchan bandwidth 500
+meshtastic --setchan spread_factor 11 --setchan coding_rate 5 --setchan bandwidth 500
 ```
 
 With an aftermarket coaxial antenna or moxon antenna, that will give you roughly the same range as "Long Range / Slow" and 5x the bitrate.


### PR DESCRIPTION
Using the recommended channel settings  "coding_Rate 4" causes critical error 7. When I looked at the coding_rate documentation on channels page it listed 5 as the lowest allowable setting.