### PR TITLE
fix/remove-inaccurate-note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .vercel
 .DS_Store
 .env
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ build
 .vercel
 .DS_Store
 .env
-yarn.lock

--- a/docs/software/device/remote-admin.mdx
+++ b/docs/software/device/remote-admin.mdx
@@ -89,18 +89,11 @@ Connected to radio
 Using the node ID from that list, send a message through the mesh telling that node to change its owner name.
 
 ```shell title="Expected output"
-$ meshtastic --dest \!28979058 --set-owner "Im Remote"
+$ meshtastic --dest '!28979058' --set-owner "Im Remote"
 Connected to radio
 Setting device owner to Im Remote
 INFO:root:Requesting configuration from remote node (this could take a while)
 ```
-
-:::note
-You will need to escape the `!` using `\!` otherwise the command will fail.
-:::
-:::note
-The above note needs clarification. Currently, you refer to other nodes with `!########`. No backslashes are used.
-:::
 
 And you can now confirm via the local node that the remote node has changed:
 


### PR DESCRIPTION
- removed note stating that exclamation point preceding node ID must be escaped