### PR TITLE
iOS app doesn't share channel link yet

### DIFF
--- a/docs/faq/channel.mdx
+++ b/docs/faq/channel.mdx
@@ -16,7 +16,7 @@ This is the LoRa frequency within the frequency band your device is configured t
 
 ### How do I share my Meshtastic Channel with other people?
 
-Your Meshtastic client (Android, iOS, Web or Python) will provide you a URL or QR code. You can email, text or print this URL or QR code and share it with people you want to join your Meshtastic Channel.
+Your Meshtastic client (Android, Web, or Python) will provide you a URL or QR code. You can email, text or print this URL or QR code and share it with people you want to join your Meshtastic Channel. Note: This feature is not yet available on the iOS app.
 
 ### What is a Primary Channel?
 


### PR DESCRIPTION
Edited to note that the iOS app doesn't have a share function yet.