### PR TITLE
Removed mention of /static/

### DIFF
--- a/docs/software/modules/range-test.mdx
+++ b/docs/software/modules/range-test.mdx
@@ -28,7 +28,7 @@ These are the settings that can be configured.
         1 = Enabled
 
     range_test_module_save
-        If enabled, we will save a log of all received messages to /static/rangetest.csv which you can access from the webserver. We will abort
+        If enabled, we will save a log of all received messages to the device. The log can be accessed via the Web interface (meshtastic.local when connected via Wi-Fi only) by navigating to Extensions > File Browser. We will abort
         writing if there is less than 50k of space on the filesystem to prevent filling up the storage.
 
         0 = Disabled (Default)


### PR DESCRIPTION
Removed mention of /static/ as the Range Test output is no longer located in this directory.