### PR TITLE
./ is not used in Windows shell

### DIFF
--- a/docs/getting-started/flashing-firmware/flashing-esp32.mdx
+++ b/docs/getting-started/flashing-firmware/flashing-esp32.mdx
@@ -246,13 +246,13 @@ values={[
 #### Install
 
 ```shell title="Command"
-./device-install.bat -f firmware-BOARD-VERSION.bin
+device-install.bat -f firmware-BOARD-VERSION.bin
 ```
 
 #### Update
 
 ```shell title="Command"
-./device-update.bat -f firmware-BOARD-VERSION.bin
+device-update.bat -f firmware-BOARD-VERSION.bin
 ```
 
   </TabItem>


### PR DESCRIPTION
Using ./ at the start of the shell command in Windows 10 will result in an error, so I've removed this part of the instruction.