### PR TITLE
Update meshtastic-flasher.mdx

### DIFF
--- a/docs/getting-started/flashing-firmware/meshtastic-flasher.mdx
+++ b/docs/getting-started/flashing-firmware/meshtastic-flasher.mdx
@@ -99,74 +99,11 @@ sudo apt install -y python3 python3-pip python3-venv
 
 ### Install App
 
-This is the preferred installation method for `meshtastic-flasher`.
 
-<Tabs
-groupId="operating-system"
-defaultValue="linux"
-values={[
-{label: 'Linux', value: 'linux'},
-{label: 'macOS', value: 'macos'},
-{label: 'Windows', value: 'windows'},
-]}>
-<TabItem value="linux">
-
-```shell title="Install Meshtastic Flasher"
-python3 --version
-# ensure you are using at least python v3.6
-# change to a directory where you want to create a python virtual environment
-mkdir some_dir
-cd some_dir
-# if the following command fails, it might tell you what package to install
-python3 -m venv venv
-# activate the python virtual environment
-source venv/bin/activate
-# your prompt should change - it should include "(venv) in the front
-# upgrade pip
-pip install --upgrade pip
-pip install meshtastic-flasher
-```
-
-```shell title="Running Meshtastic Flasher"
-meshtastic-flasher
-```
-
-</TabItem>
-<TabItem value="macos">
-
-<div className="indexCtasBody">
-  <Link
-    className={'button button--outline  button--lg cta--button'}
-    to={'https://github.com/meshtastic/Meshtastic-gui-installer/releases/tag/macapp1.0.0'}
-  >
-    Download macOS application
-  </Link>
-</div>
-
-Once downloaded, unzip the file and drag it to `~/Applications`. It may take a moment to load as it downloads dependencies required to interact with your device, so be patient. The first time running it can take a few minutes.
-
-</TabItem>
-<TabItem value="windows">
-
-<div className="indexCtasBody">
-  <Link
-    className={'button button--outline  button--lg cta--button'}
-    to={'https://github.com/meshtastic/Meshtastic-gui-installer/releases/tag/winapp1.0.3'}
-  >
-    Download Windows application
-  </Link>
-</div>
-
-Once downloaded, unzip the file and run it. It may take a moment to load as it downloads dependencies required to interact with your device, so be patient. The first time running it can take a few minutes.
-
-</TabItem>
-</Tabs>
-
-<details>
 <summary>
 Install using `pip`
 </summary>
-This option is typically for developers.
+Note: The previous "single executable" installation option has been deprecated as of March 10, 2022.
 
 <Tabs
 groupId="operating-system"
@@ -244,7 +181,7 @@ meshtastic-flasher
   </TabItem>
 </Tabs>
 
-</details>
+
 
 ## Flashing the Device
 


### PR DESCRIPTION
Updated to reflect the information inside https://github.com/meshtastic/Meshtastic-gui-installer which states that the single install executables were deprecated in March 2022. This page was previously linking to versions of the Flasher from March 2022 (approx 84 commits behind).