### PR TITLE
param value is case sensitive

### DIFF
--- a/docs/settings/config/bluetooth.mdx
+++ b/docs/settings/config/bluetooth.mdx
@@ -26,7 +26,7 @@ If your pairing mode is set to fixed PIN this is the value of that fixed 6 digit
 |          Setting          |  Acceptable Values  | Default |
 | :-----------------------: | :-----------------: | :-----: |
 | bluetooth.enabled |   `true`, `false`   | `true` |
-|  bluetooth.mode  |   `randomPin`, `fixedPin`, `noPin`   | `randomPin` |
+|  bluetooth.mode  |   `RandomPin`, `FixedPin`, `NoPin`   | `RandomPin` |
 | bluetooth.fixedPin  | `integer` 6 Digits |   `123456`   |
 
 


### PR DESCRIPTION
Using Python CLI v1.3.29:
```
>meshtastic --set bluetooth.mode randomPin
Connected to radio
bluetooth.mode does not have an enum called randomPin, so you can not set it.
Choices in sorted order are:
    FixedPin
    NoPin
    RandomPin
LocalConfig and LocalModuleConfig do not have attribute bluetooth.mode.
```