### PR TITLE
param value is case sensitive

### DIFF
--- a/docs/settings/config/lora.mdx
+++ b/docs/settings/config/lora.mdx
@@ -108,7 +108,7 @@ LoRa config conmmands are available in the python CLI. Example commands are belo
 |   Setting    |                               Acceptable Values                               |      Default      |
 | :----------: | :---------------------------------------------------------------------------: | :---------------: |
 | lora.modem_preset |   `longFast`, `longSlow`, `vlongSlow`, `medSlow`, `medFast`, `shortSlow`, `shortFast`       | `longFast` |
-|    lora.region    |     `Unset`, `US`, `EU433`, `EU868`, `CN`, `JP`, `ANZ`, `KR`, `TW`, `RU` ,`IN`, `NZ865`, `TH`       |      `Unset`      |
+|    lora.region    |     `UNSET`, `US`, `EU_433`, `EU_868`, `CN`, `JP`, `ANZ`, `KR`, `TW`, `RU` ,`IN`, `NZ_865`, `TH`       |      `UNSET`      |
 | lora.hop_limit    |     `1`,`2`,`3`,`4`,`5`,`6`,`7`   |   `3`
 
 </TabItem>

--- a/docs/settings/config/lora.mdx
+++ b/docs/settings/config/lora.mdx
@@ -108,7 +108,7 @@ LoRa config conmmands are available in the python CLI. Example commands are belo
 |   Setting    |                               Acceptable Values                               |      Default      |
 | :----------: | :---------------------------------------------------------------------------: | :---------------: |
 | lora.modem_preset |   `longFast`, `longSlow`, `vlongSlow`, `medSlow`, `medFast`, `shortSlow`, `shortFast`       | `longFast` |
-|    lora.region    |     `Unset`, `us`, `eu433`, `eu868`, `cn`, `jp`, `anz`, `kr`, `tw`, `ru` ,`in`, ` nz865`, `th`       |      `Unset`      |
+|    lora.region    |     `Unset`, `US`, `EU433`, `EU868`, `CN`, `JP`, `ANZ`, `KR`, `TW`, `RU` ,`IN`, `NZ865`, `TH`       |      `Unset`      |
 | lora.hop_limit    |     `1`,`2`,`3`,`4`,`5`,`6`,`7`   |   `3`
 
 </TabItem>


### PR DESCRIPTION
Using Python CLI v1.3.29:
```
>meshtastic --set lora.region eu433
Connected to radio
lora.region does not have an enum called ru, so you can not set it.
Choices in sorted order are:
    ANZ
    CN
    EU433
    EU868
    IN
    JP
    KR
    NZ865
    RU
    TH
    TW
    US
    Unset
LocalConfig and LocalModuleConfig do not have attribute lora.region.
```