### PR TITLE
param value is case sensitive

### DIFF
--- a/docs/settings/config/lora.mdx
+++ b/docs/settings/config/lora.mdx
@@ -107,7 +107,7 @@ LoRa config conmmands are available in the python CLI. Example commands are belo
 
 |   Setting    |                               Acceptable Values                               |      Default      |
 | :----------: | :---------------------------------------------------------------------------: | :---------------: |
-| lora.modem_preset |   `longFast`, `longSlow`, `vlongSlow`, `medSlow`, `medFast`, `shortSlow`, `shortFast`       | `longFast` |
+| lora.modem_preset |   `LongFast`, `LongSlow`, `VLongSlow`, `MedSlow`, `MedFast`, `ShortSlow`, `ShortFast`       | `LongFast` |
 |    lora.region    |     `Unset`, `us`, `eu433`, `eu868`, `cn`, `jp`, `anz`, `kr`, `tw`, `ru` ,`in`, ` nz865`, `th`       |      `Unset`      |
 | lora.hop_limit    |     `1`,`2`,`3`,`4`,`5`,`6`,`7`   |   `3`
 

--- a/docs/settings/config/lora.mdx
+++ b/docs/settings/config/lora.mdx
@@ -107,7 +107,7 @@ LoRa config conmmands are available in the python CLI. Example commands are belo
 
 |   Setting    |                               Acceptable Values                               |      Default      |
 | :----------: | :---------------------------------------------------------------------------: | :---------------: |
-| lora.modem_preset |   `LongFast`, `LongSlow`, `VeryLongSlow`, `MediumSlow`, `MediumFast`, `ShortSlow`, `ShortFast`       | `LongFast` |
+| lora.modem_preset |   `LONG_FAST`, `LONG_SLOW`, `VERY_LONG_SLOW`, `MEDIUM_SLOW`, `MEDIUM_FAST`, `SHORT_SLOW`, `SHORT_FAST`       | `LONG_FAST` |
 |    lora.region    |     `Unset`, `us`, `eu433`, `eu868`, `cn`, `jp`, `anz`, `kr`, `tw`, `ru` ,`in`, ` nz865`, `th`       |      `Unset`      |
 | lora.hop_limit    |     `1`,`2`,`3`,`4`,`5`,`6`,`7`   |   `3`
 

--- a/docs/settings/config/lora.mdx
+++ b/docs/settings/config/lora.mdx
@@ -107,7 +107,7 @@ LoRa config conmmands are available in the python CLI. Example commands are belo
 
 |   Setting    |                               Acceptable Values                               |      Default      |
 | :----------: | :---------------------------------------------------------------------------: | :---------------: |
-| lora.modem_preset |   `LongFast`, `LongSlow`, `VLongSlow`, `MedSlow`, `MedFast`, `ShortSlow`, `ShortFast`       | `LongFast` |
+| lora.modem_preset |   `LongFast`, `LongSlow`, `VeryLongSlow`, `MediumSlow`, `MediumFast`, `ShortSlow`, `ShortFast`       | `LongFast` |
 |    lora.region    |     `Unset`, `us`, `eu433`, `eu868`, `cn`, `jp`, `anz`, `kr`, `tw`, `ru` ,`in`, ` nz865`, `th`       |      `Unset`      |
 | lora.hop_limit    |     `1`,`2`,`3`,`4`,`5`,`6`,`7`   |   `3`
 


### PR DESCRIPTION
Using Python CLI v1.3.29:
```
>meshtastic --set lora.modem_preset longSlow
Connected to radio
lora.modem_preset does not have an enum called longSlow, so you can not set it.
Choices in sorted order are:
    LongFast
    LongSlow
    MedFast
    MedSlow
    ShortFast
    ShortSlow
    VLongSlow
LocalConfig and LocalModuleConfig do not have attribute lora.modem_preset.
```