### PR TITLE
Update rak4631.mdx

### DIFF
--- a/docs/hardware/supported/rak4631.mdx
+++ b/docs/hardware/supported/rak4631.mdx
@@ -44,7 +44,7 @@ Further information on the RAK5005-O can be found on the [RAK Documentation Cent
 It may be possible to add a user button using the [13002 IO module](https://store.rakwireless.com/collections/wisblock-interface/products/adapter-module-rak13002).
 
 - [Update the bootloader](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Quickstart/#updating-the-bootloader) on first use! This can be done easily with [Meshtastic-flasher](https://github.com/meshtastic/Meshtastic-gui-installer).
-- Firmware for 5005 base board: [`firmware-rak4631_5005-1.x.x.uf2`](/downloads) 
+- Firmware for 5005 base board: [`firmware-rak4631-1.x.x.uf2`](/downloads) 
 
 
   <img
@@ -73,7 +73,7 @@ Further information on the RAK19003 can be found on the [RAK Documentation Cente
 It is currently not possible to add a user button to this board.
 
 - [Update the bootloader](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Quickstart/#updating-the-bootloader) on first use! This can be done easily with [Meshtastic-flasher](https://github.com/meshtastic/Meshtastic-gui-installer).
-- Firmware for 19003 base board: [`firmware-rak4631_19003-1.x.x.uf2`](/downloads)
+- Firmware for 19003 base board: [`firmware-rak4631-1.x.x.uf2`](/downloads)
 
 
   <img
@@ -252,7 +252,7 @@ The [RAK1400 EPD module](https://store.rakwireless.com/products/wisblock-epd-mod
 - Occupies the IO Port of a Wisblock Base
 
 
-- Firmware for 5005 with RAK14000 epaper: [`firmware-rak4631_19003-epaper-1.3.x.uf2`](/downloads)
+- Firmware for 5005 with RAK14000 epaper: [`firmware-rak4631_eink-1.3.x.uf2`](/downloads)
 
   <img
     alt="RAK4631 5005 14000"


### PR DESCRIPTION
Removed baseboard model 5005/19003 from firmware filename and changed epaper firmware filename to eink.