### PR TITLE
Updated documentation for pairing BLE devices on Android

### DIFF
--- a/docs/software/android/usage.mdx
+++ b/docs/software/android/usage.mdx
@@ -20,6 +20,10 @@ You will need a device with Meshtastic installed to go any further. See the [get
 
 To find devices to connect via Bluetooth click the button on the bottom right corner.
 
+:::note
+Scanning for BLE devices requires both location permission and for location services to be turned on during a scan. This is a [known issue](https://issuetracker.google.com/issues/37065090?pli=1).
+:::
+
 [![Device available to select](/img/android/android-settings-connect-sm.png)](/img/android/android-settings-connect.png)
 
 1. Select the device name, `Meshtastic_bebc` in this example. (You will see devices within range, so make sure to get the right one.)


### PR DESCRIPTION
Updated the Android application documentation for how to connect to a device via bluetooth. Connecting a BLE device requires location services to be turned on at the time of any scan. This is a [known issue](https://issuetracker.google.com/issues/37065090?pli=1).