### PR TITLE
Update faq.mdx

### DIFF
--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -133,10 +133,6 @@ Push the left PWR button for about 10 seconds.
 
 There was a bug where Meshtastic Starter kits were sent out with the same MAC address. With a single MAC address the devices all report as being the same device. Without the battery connected, flash the starter kit device(s) to 1.2.59 and then do a factory reset, disconnect and reconnect the board and run `meshtastic --info`.
 
-### Why does only one RAK Meshtastic Starter kit show up in my node list?
-
-There was a bug where Meshtastic Starter kits were sent out with the same MAC address. With a single MAC address the devices all report as being the same device. Without the battery connected, flash the starter kit device(s) to 1.2.59 and then do a factory reset, disconnect and reconnect the board and run `meshtastic --info`.
-
 <!-- HAM -->
 
 ## Amateur Radio (HAM)

--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -131,7 +131,7 @@ Push the left PWR button for about 10 seconds.
 
 ### Why does only one RAK Meshtastic Starter kit show up in my node list?
 
-There was a bug where Meshtastic Starter kits were sent out with the same MAC address. With a single MAC address the devices all report as being the same device. Without the battery connected, flash the starter kit device(s) to 1.2.59 and then do a factory reset, disconnect and reconnect the board and run `meshtastic --info`.
+There was a bug where Meshtastic Starter kits were sent out with the same MAC address. With a single MAC address the devices all report as being the same device. Without the battery connected, flash the starter kit device(s) to any firmware > 1.2.59 and then do a factory reset, disconnect and reconnect the board and run `meshtastic --info`.
 
 <!-- HAM -->
 


### PR DESCRIPTION
This part was doubled :

Why does only one RAK Meshtastic Starter kit show up in my node list? There was a bug where Meshtastic Starter kits were sent out with the same MAC address. With a single MAC address the devices all report as being the same device. Without the battery connected, flash the starter kit device(s) to 1.2.59 and then do a factory reset, disconnect and reconnect the board and run meshtastic --info.

https://meshtastic.org/docs/faq#why-does-only-one-rak-meshtastic-starter-kit-show-up-in-my-node-list https://meshtastic.org/docs/faq#why-does-only-one-rak-meshtastic-starter-kit-show-up-in-my-node-list-1