### PR TITLE
Correct RAK19003 Port Type

### DIFF
--- a/docs/hardware/devices/rak/base-boards.mdx
+++ b/docs/hardware/devices/rak/base-boards.mdx
@@ -92,7 +92,7 @@ Further information on the RAK19007 can be found on the [RAK Documentation Cente
     - Connector for 3.7v LiPo battery (with charge controller)
     - Connector for 5v solar panel (max 5.5v)
     - I<sup>2</sup>C, UART and BOOT headers accessible with solder contacts
-    - Micro USB port for debugging and power
+    - USB Type-C port for debugging and power
   - **Screen Support**
     - OLED screen support (OLED screen sold separately)
 


### PR DESCRIPTION
Per the product images on rakwireless.com and the product datasheet the RAK19003 has a Type-C port, not a Micro USB.