### PR TITLE
Updated Configuration Pages due to Recent Android Change

### DIFF
--- a/docs/configuration/device-config/bluetooth.mdx
+++ b/docs/configuration/device-config/bluetooth.mdx
@@ -57,7 +57,7 @@ values={[
 All Bluetooth config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Advanced Settings > Bluetooth Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Bluetooth Config**
 
 :::
 

--- a/docs/configuration/device-config/channels.mdx
+++ b/docs/configuration/device-config/channels.mdx
@@ -111,7 +111,7 @@ values={[
 <TabItem value="android">
 
 :::info
-Limited Channel config options are available on android. QR code scanning is available.
+Limited Channel Config options are available on Android. QR code scanning is available.
 :::
 
 </TabItem>

--- a/docs/configuration/device-config/device.mdx
+++ b/docs/configuration/device-config/device.mdx
@@ -50,7 +50,11 @@ values={[
 <TabItem value="android">
 
 :::info
-Device config is not available for Android.
+Device Config is available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Device Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/device-config/device.mdx
+++ b/docs/configuration/device-config/device.mdx
@@ -50,6 +50,7 @@ values={[
 <TabItem value="android">
 
 :::info
+
 Device Config is available for Android.
 
 1. Open the Meshtastic App

--- a/docs/configuration/device-config/display.mdx
+++ b/docs/configuration/device-config/display.mdx
@@ -67,7 +67,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Display config is not available for Android.
+
+Display Config is available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Display Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/device-config/lora.mdx
+++ b/docs/configuration/device-config/lora.mdx
@@ -82,7 +82,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Region and Modem Preset can be configured on Android.
+
+LoRa Config options such as Region, Modem Preset, and Hop Limit can be configured on Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > LoRa Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/device-config/network.mdx
+++ b/docs/configuration/device-config/network.mdx
@@ -77,7 +77,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Network config is not available for Android.
+
+Network Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Network Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/device-config/position.mdx
+++ b/docs/configuration/device-config/position.mdx
@@ -89,7 +89,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Position config is not available for Android.
+
+Position Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Position Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/device-config/power.mdx
+++ b/docs/configuration/device-config/power.mdx
@@ -80,7 +80,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Light Sleep Interval and Wait Bluetooth Interval are available under advanced settings for Android.
+
+Power Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Power Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/device-config/user.mdx
+++ b/docs/configuration/device-config/user.mdx
@@ -51,7 +51,12 @@ values={[
 <TabItem value="android">
 
 :::info
-`LongName` can be edited on Android.
+
+User Config options are available for Android. 
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > User Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/module-config/audio.mdx
+++ b/docs/configuration/module-config/audio.mdx
@@ -59,7 +59,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Audio module config is not available for Android.
+
+Audio Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Audio Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/module-config/canned-message.mdx
+++ b/docs/configuration/module-config/canned-message.mdx
@@ -87,7 +87,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Canned Message module config is not available for Android.
+
+Canned Message Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Canned Message Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/module-config/external-notification.mdx
+++ b/docs/configuration/module-config/external-notification.mdx
@@ -57,7 +57,12 @@ values={[
 <TabItem value="android">
 
 :::info
-External notification module config is not available for Android.
+
+External Notification Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > External Notification Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/module-config/mqtt.mdx
+++ b/docs/configuration/module-config/mqtt.mdx
@@ -55,7 +55,12 @@ values={[
 <TabItem value="android">
 
 :::info
-MQTT module config is not available for Android.
+
+MQTT Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > MQTT Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/module-config/range-test.mdx
+++ b/docs/configuration/module-config/range-test.mdx
@@ -43,7 +43,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Range Test features are available for Android.
+
+Range Test Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Range Test Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/module-config/serial.mdx
+++ b/docs/configuration/module-config/serial.mdx
@@ -73,7 +73,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Serial module config is not available for Android.
+
+Serial Module Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Serial Config**
+
 :::
 
 </TabItem>

--- a/docs/configuration/module-config/telemetry.mdx
+++ b/docs/configuration/module-config/telemetry.mdx
@@ -74,7 +74,12 @@ values={[
 <TabItem value="android">
 
 :::info
-Telemetry Module config is not available for Android.
+
+Telemetry Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Telemetry Config**
+
 :::
 
 </TabItem>


### PR DESCRIPTION
The Android App recently updated and the "Advanced Settings" menu was split into two separate menus "Device Settings" and "Module Settings". 

<img src="https://user-images.githubusercontent.com/6912600/205517231-c176108e-32d9-481c-8ebe-e5c2e1c54bdd.jpg" width="175" height="400">


I've updated the Device Config pages client availability table to reflect this. I've also updated the Module config pages client availability table to reflect which module configs are available in the android app now. 