### PR TITLE
Updated Community Apps Pages

### DIFF
--- a/docs/1.2-End-of-life/index.mdx
+++ b/docs/1.2-End-of-life/index.mdx
@@ -7,8 +7,6 @@ sidebar_position: 20
 
 Meshtastic 1.2 was a beta version that has been superceded by 1.3. Version 1.2 is fundamentally incompatible with any 1.3 versions of device firmware, flashing utilities, or client applications.
 
-While 1.2 is end of life, it may continue to be useful for certain networks with Android only users, or users of ATAK until the forwarder is updated.
-
 - Last 1.2 Python api version install: pip install meshtastic==1.2.95
 - Final 1.2 Meshtastic Flasher install: pip install meshtastic-flasher==1.0.106 (Do not attempt to install 1.3.x firmware with this release)
 - [Final 1.2 Device Firmware](https://github.com/meshtastic/firmware/releases/tag/v1.2.65.0adc5ce)

--- a/docs/software/community/atak.mdx
+++ b/docs/software/community/atak.mdx
@@ -1,0 +1,33 @@
+---
+id: community-atak
+title: ATAK Forwarder
+sidebar_label: ATAK Forwarder
+sidebar_position: 1
+---
+
+:::note
+
+This is a community project maintained by @paulmandal.
+Development can be followed on [GitHub](https://github.com/paulmandal/atak-forwarder).
+Support should be sought from the respective authors.
+
+:::
+
+:::info
+
+The ATAK Forwarder plugin has recently been updated to support Meshtastic 2.0.6+ but is currently a pre-release version to allow for additional testing to be completed.
+- After installing you need to open the Meshtastic app and click the add device "+" so it will ask for Bluetooth permissions.
+
+:::
+
+The ATAK Forwarder plugin requires the Meshtastic Android app to be installed.
+
+This is a plugin for ATAK (Android Team Awareness Kit) that uses Meshtastic to provide off-grid communications. This includes plotting the position of others on the map, transmission of markers and routes, and chat messages. It has been signed by the TAK Product Center for use with the Play Store version of ATAK. He is currently distributing development builds via [Google Drive](https://drive.google.com/drive/folders/1xeKJnn9tmzkkmuDbMp0LCLOV9OzHU-Ex), aiming to publish it to the Play Store in the future.
+
+![ATAK Module](/img/atak-animation.gif)
+
+The builds of the module on the Google Drive are now signed for the Play Store version of ATAK, as of 6/3/2021.
+
+- A walk-through on how to [set up ATAK](https://paul-mandal.medium.com/atak-for-hikers-d96d5246193e).
+- The module source is available on [GitHub](https://github.com/paulmandal/atak-forwarder), along with instructions for setting it up.
+- Development builds are available on [Google Drive](https://drive.google.com/drive/folders/1xeKJnn9tmzkkmuDbMp0LCLOV9OzHU-Ex).

--- a/docs/software/community/index.mdx
+++ b/docs/software/community/index.mdx
@@ -1,10 +1,15 @@
 ---
-title: Community
+title: Community Apps
 slug: /software/community
-sidebar_label: Community
+sidebar_label: Community Apps
 sidebar_position: 10
 ---
 
-## Simulator
+The Meshtastic ecosystem is highly extensible, and a number of community projects have been made to fit different people's needs. If you wish to create your own application or module, please read the information in the developers section, and tell us about your project on the forum.
 
-- https://github.com/GUVWAF/Meshtasticator
+Current community projects:
+
+- [ATAK (Android Team Awareness Kit) Forwarder](/docs/software/community/community-atak) - An ATAK plugin for forwarding CoT messages via a hardware layer which supports Meshtastic devices.
+- [Meshtasticator (Simulator)](/docs/software/community/community-meshtasticator) - Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software.
+
+Support for these projects should be sought from their respective authors.

--- a/docs/software/community/meshtasticator.mdx
+++ b/docs/software/community/meshtasticator.mdx
@@ -1,0 +1,16 @@
+---
+id: community-meshtasticator
+title: Meshtasticator
+sidebar_label: Meshtasticator (Simulator)
+sidebar_position: 2
+---
+
+:::note
+
+This is a community project maintained by @GUVWAF.
+Development can be followed on [GitHub](https://github.com/GUVWAF/Meshtasticator).
+Support should be sought from the respective authors.
+
+:::
+
+Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software and can be used to assess the performance of your scenario, or the scalability of the protocol. Meshtasticator was created and is maintained by GUVWAF and more information on its use and setup can be found on the [Meshtasticator Github page](https://github.com/GUVWAF/Meshtasticator)


### PR DESCRIPTION
Updated Community Apps to include ATAK Forwarder 2.0 upgrade, broke each community out into their own page, removed section from 1.2 EOL index page stating still useful for ATAK users (since ATAK Forwarder has been updated). 