### PR TITLE
css fix for social icons on lg and smaller screens

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -204,7 +204,7 @@ function Home() {
           ))}
         </Carousel>
 
-        <div className="bg-primaryDark mx-auto flex w-full w-auto flex-col gap-4 p-4 shadow-inner">
+        <div className="bg-primaryDark mx-auto flex w-full lg:w-auto flex-col gap-4 p-4 shadow-inner">
           <h3 className="text-xl font-bold">Connect with us.</h3>
           <div className="flex w-full overflow-x-auto">
             {SocialCards.map((card, index) => (


### PR DESCRIPTION
Check this on iPad down to iPhone SE and the social icons are now scrolling instead of making the whole page scroll. Viewable [here](https://meshtastic-qbb8fmpd7-jfirwin.vercel.app).