### PR TITLE
Update Configs to add Chaining Tip

### DIFF
--- a/docs/configuration/device-config/bluetooth.mdx
+++ b/docs/configuration/device-config/bluetooth.mdx
@@ -88,6 +88,16 @@ All Bluetooth module config options are available in the python CLI. Example com
 | `bluetooth.mode`          | `RANDOM_PIN`, `FIXED_PIN`, `NO_PIN` | `RANDOM_PIN` |
 | `bluetooth.fixedPin`      | `integer` (6 digits) | `123456` |
 
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set bluetooth.enabled true  --set bluetooth.fixed_pin 111111
+```
+
+:::
+
 ```shell title="Enable/Disable Bluetooth Module"
 meshtastic --set bluetooth.enabled true
 meshtastic --set bluetooth.enabled false

--- a/docs/configuration/device-config/channels.mdx
+++ b/docs/configuration/device-config/channels.mdx
@@ -130,6 +130,16 @@ Channel settings are only available on Apple platforms by scanning QR codes.
 All Channel config options are available in the python CLI. Example commands are below:
 :::
 
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --ch-set name "My Channel" --ch-set psk random --ch-set uplink_enabled true --ch-index 4
+```
+
+:::
+
 **Id**
 
 ```shell title="Set the PRIMARY channel ID"

--- a/docs/configuration/device-config/device.mdx
+++ b/docs/configuration/device-config/device.mdx
@@ -28,12 +28,12 @@ Acceptable values:
 ### Serial Console 
 Acceptable values: `true` or `false`
 
-Disabling this will disable the SerialConsole by not initializing the StreamAPI
+Disabling this will disable the SerialConsole by not initializing the StreamAPI.
 
 ### Debug Log
 Acceptable values: `true` or `false`
 
-By default we turn off logging as soon as an API client connects Set this to true to leave the debug log outputting even when API is active.
+By default we turn off logging as soon as an API client connects. Set this to true to leave the debug log outputting even when API is active.
 
 ## Device Config Client Availability
 
@@ -44,7 +44,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -68,7 +67,27 @@ All device config options other than NTP Server are available on iOS, iPadOS and
 </TabItem>
 <TabItem value="cli">
 
+:::info
+
 All device config options are available in the python CLI. Example commands are below:
+
+:::
+
+| Setting                  | Acceptable Values                                  | Default  |
+|--------------------------|----------------------------------------------------|----------|
+| device.debug_log_enabled | `true`, `false`                                    | `false`  |
+| device.role              | `CLIENT`, `CLIENT_MUTE`, `ROUTER`, `ROUTER_CLIENT` | `CLIENT` |
+| device.serial_enabled    | `true`, `false`                                    | `true`   |
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set device.role CLIENT --set device.debug_log_enabled true
+```
+
+:::
 
 ```shell title="Set the role to client"
 meshtastic --set device.role CLIENT
@@ -83,14 +102,7 @@ meshtastic --set device.debug_log_enabled true
 ```
 
 </TabItem>
-<TabItem value="flasher">
-
-:::danger
-No device config options are available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All device config options are available in the Web UI.

--- a/docs/configuration/device-config/display.mdx
+++ b/docs/configuration/device-config/display.mdx
@@ -61,7 +61,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -85,7 +84,31 @@ All display config options are available on iOS, iPadOS and macOS at Settings > 
 </TabItem>
 <TabItem value="cli">
 
+:::info
+
 All display config options are available in the python CLI. Example commands are below:
+
+:::
+
+| Setting                           | Acceptable Values                          | Default                      |
+|-----------------------------------|--------------------------------------------|------------------------------|
+| display.auto_screen_carousel_secs | `integer`                                  | Default of `0` is 10 minutes |
+| display.compass_north_top         | `false`, `true`                            | `false`                      |
+| display.flip_screen               | `fasle`, `true`                            | `false`                      |
+| display.gps_format                | `DEC`, `DMS`, `UTM`, `MGRS`, `OLC`, `OSGR` | `DEC`                        |
+| display.oled                      | `OLED_AUTO`, `OLED_SSD1306`, `OLED_SH1106` | `OLED_AUTO`                  |
+| display.screen_on_secs            | `integer`                                  | Default of `0` is off.       |
+| display.units                     | `METRIC`, `IMPERIAL`                       | `METRIC`                     |
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set display.screen_on_secs 120 --set display.gps_format UTM
+```
+
+:::
 
 ```shell title="Set Screen On Duration (Default of 0 is 10 minutes)"
 meshtastic --set display.screen_on_secs 0
@@ -103,14 +126,7 @@ meshtastic --set display.gps_format UTM
 ```
 
 </TabItem>
-<TabItem value="flasher">
-
-:::info
-No display config options are available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All display config options are available in the Web UI.

--- a/docs/configuration/device-config/lora.mdx
+++ b/docs/configuration/device-config/lora.mdx
@@ -104,7 +104,11 @@ Configuration of Region, Modem Preset and Hop Limit is available on iOS, iPadOS 
 </TabItem>
 <TabItem value="cli">
 
+:::info
+
 LoRa config commands are available in the python CLI. Example commands are below:
+
+:::
 
 |   Setting    |                               Acceptable Values                               |      Default      |
 | :----------: | :---------------------------------------------------------------------------: | :---------------: |
@@ -112,15 +116,49 @@ LoRa config commands are available in the python CLI. Example commands are below
 |    lora.region    |     `UNSET`, `US`, `EU_433`, `EU_868`, `CN`, `JP`, `ANZ`, `KR`, `TW`, `RU` ,`IN`, `NZ_865`, `TH`, `LORA_24` |      `UNSET`      |
 | lora.hop_limit    |     `1`,`2`,`3`,`4`,`5`,`6`,`7`   |   `3` |
 | lora.override_duty_cycle    |     `false`, `true`    |   `false` |
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+
+```shell title="Example:"
+meshtastic --set lora.region US --set lora.modem_preset LONG_FAST
+```
+
+:::
+
+```shell title="Set Modem Preset"
+meshtastic --set lora.modem_preset LONG_FAST
+meshtastic --set lora.modem_preset MEDIUM_FAST
+```
+
+```shell title="Set Region"
+meshtastic --set lora.region US
+meshtastic --set lora.region EU_433
+```
+
+```shell title="Set Hop Limit"
+
+meshtastic --set lora.hop_limit 2
+```
+
+```shell title="Override Duty Cycle"
+meshtastic --set lora.override_duty_cycle true
+meshtastic --set lora.override_duty_cycle false
+```
+
 </TabItem>
 <TabItem value="flasher">
 
 :::info
-No LoRa config options are available in the Flasher.
+
+Only `lora.region` can be set via the GUI flasher. Refer to other clients for any other config.
+
 :::
 
-  </TabItem>
-  <TabItem value="web">
+</TabItem>
+<TabItem value="web">
 
 :::info
 All LoRa config options are available in the Web UI.

--- a/docs/configuration/device-config/network.mdx
+++ b/docs/configuration/device-config/network.mdx
@@ -65,12 +65,11 @@ The first time your device restarts after enabling WiFi or Ethernet, it will tak
 
 <Tabs
 groupId="settings"
-defaultValue="flasher"
+defaultValue="cli"
 values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 
@@ -98,7 +97,11 @@ Network config is not available on Apple OS's.
 
 <TabItem value="cli">
 
+:::info
+
 All Network config options are available in the python CLI.
+
+:::
 
 |    Setting    | Acceptable Values | Default |
 | :-----------: | :---------------: | :-----: |
@@ -106,6 +109,16 @@ All Network config options are available in the python CLI.
 | network.wifi_enabled  |  `true`, `false`  | `false`          |
 | network.wifi_psk      |      string       |  `""`            |
 | network.wifi_ssid     |      string       |  `""`            |
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set network.wifi_enabled true --set network.wifi_ssid "my network" --set network.wifi_psk mypassword
+```
+
+:::
 
 ```shell title="Set NTP Server"
 meshtastic --set network.ntp_server "0.pool.ntp.org"
@@ -128,14 +141,6 @@ meshtastic --set network.wifi_psk mypassword
 // With spaces
 meshtastic --set network.wifi_psk "my password"
 ```
-
-</TabItem>
-
-<TabItem value="flasher">
-
-:::info
-All Network config options are available in the Flasher.
-:::
 
 </TabItem>
 

--- a/docs/configuration/device-config/position.mdx
+++ b/docs/configuration/device-config/position.mdx
@@ -83,7 +83,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -107,7 +106,11 @@ All position config values are available on iOS, iPadOS and macOS at Settings > 
 </TabItem>
 <TabItem value="cli">
 
+:::info 
+
 All Position config commands are available in the python CLI. Example commands are below:
+
+:::
 
 |         Setting                |                                                                       Acceptable Values                                                                       |     Default     |
 | :----------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------: |
@@ -119,6 +122,15 @@ All Position config commands are available in the python CLI. Example commands a
 | position.position_broadcast_secs        |                                                                      `integer` (seconds)                                                                      | Default of `0` is 15 Minutes  |
 |      position.flags            | `UNSET`, `ALTITUDE`, `ALTITUDE_MSL`, `GEOIDAL_SEPARATION`, `DOP`, `HVDOP`, `PDOP`, `SATINVIEW`, `SEQ_NO`, `TIMESTAMP`, `HEADING`, `SPEED` | `UNSET` |
 
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one. **This is especially important for position values to ensure they are set at the same time and avoid being overwritten by subsequent commands.**
+
+```shell title="Example:"
+meshtastic --set position.fixed_position true --setlat 37.8651 --setlon -119.5383
+```
+
+:::
 
 ```shell title="Set GPS update interval (Default of 0 is 30 seconds)"
 meshtastic --set position.gps_update_interval 0
@@ -160,30 +172,19 @@ meshtastic --set position.broadcast_secs 60
 It may take some time to see that the change has taken effect. The GPS location is updated according to the value specified on `gps_update_interval` and the mesh will be notified of the new position in relation to the `position_broadcast_secs` value.
 :::
 
-:::tip
-Include each flag desired separated by a single space.
-:::
-
 ```shell title="Set / Unset Position Flags"
 meshtastic --pos-fields ALTITUDE ALTITUDE_MSL
 meshtastic --pos-fields UNSET
 ```
 
 </TabItem>
-<TabItem value="flasher">
-
-:::info
-No position config options are available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All position config options are available in the Web UI.
 :::
     
-  </TabItem>
+</TabItem>
 </Tabs>
 
 :::caution

--- a/docs/configuration/device-config/power.mdx
+++ b/docs/configuration/device-config/power.mdx
@@ -74,7 +74,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -99,7 +98,11 @@ Power config is not available on Apple OS's.
 </TabItem>
 <TabItem value="cli">
 
+:::info 
+
 All Power config options are available in the python CLI.
+
+:::
 
 |            Setting                   |                                                                        Acceptable Values                                                                        |  Default  |
 | :----------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------: |
@@ -112,6 +115,15 @@ All Power config options are available in the python CLI.
 |            power.ls_secs             |                                                                       `integer` (seconds)                                                                       |   Default of `0` is 1 hour   |
 |         power.min_wake_secs          |                                                                       `integer` (seconds)                                                                       |   Default of `0` is 10 seconds   |
 
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set power.is_power_saving true --set power.on_battery_shutdown_after_secs 120
+```
+
+:::
 
 ```shell title="Enable / Disable Power Saving"
 meshtastic --set power.is_power_saving true
@@ -150,14 +162,7 @@ meshtastic --set power.min_wake_secs 0
 meshtastic --set power.min_wake_secs 120
 ```
 </TabItem>
-<TabItem value="flasher">
-
-:::info
-Power config is not available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All power config options are available in the Web UI.

--- a/docs/configuration/device-config/user.mdx
+++ b/docs/configuration/device-config/user.mdx
@@ -44,7 +44,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 
@@ -71,9 +70,23 @@ User Config options are available for Android.
 
 <TabItem value="cli">
 
+:::info
+
 All User config options are available in the python CLI. Example commands are below:
 
+:::
+
 Please see instructions for [Enabling HAM License](/docs/software/python/cli/usage#ham-radio-support)
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set-owner 'your node name' --set-owner-short  'NODE'
+```
+
+:::
 
 ```shell title="Set the LongName Value"
 meshtastic --set-owner 'your node name'
@@ -86,14 +99,6 @@ meshtastic --set-owner-short  'NODE'
 ```shell title="Enable Ham Mode, set name to license, disable encryption"
 meshtastic  --set-ham 'CALLSIGN'
 ```
-
-</TabItem>
-
-<TabItem value="flasher">
-
-:::info
-No User config options are available in the Flasher.
-:::
 
 </TabItem>
 

--- a/docs/configuration/module-config/audio.mdx
+++ b/docs/configuration/module-config/audio.mdx
@@ -65,7 +65,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -89,7 +88,11 @@ Audio module config is not available on iOS, iPadOS and macOS.
 </TabItem>
 <TabItem value="cli">
 
+:::info 
+
 All audio module config options are available in the python CLI. Example commands are below:
+
+:::
 
 |        Setting        |  Acceptable Values  | Default |
 | :-------------------: | :-----------------: | :-----: |
@@ -101,6 +104,15 @@ All audio module config options are available in the python CLI. Example command
 | audio.i2s_din |  GPIO Pin Number 1-34   | no Default   |
 | audio.i2s_sck |  GPIO Pin Number 1-34   | no Default  |
 
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set audio.enabled true --set audio.bitrate CODEC2_1400
+```
+
+:::
 
 ```shell title="Enable / Disable Module"
 meshtastic --set audio.enabled true
@@ -125,14 +137,7 @@ meshtastic --set audio.bitrate CODEC2_1400
 ```
 
 </TabItem>
-<TabItem value="flasher">
-
-:::info
-No audio module config options are available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All audio module config options are available in the Web UI.
@@ -142,7 +147,9 @@ All audio module config options are available in the Web UI.
 </Tabs>
 
 :::warning
+
 GPIO access is fundamentally dangerous because invalid options can physically damage or destroy your hardware. Ensure that you fully understand the schematic for your particular device before trying this as we do not offer a warranty. Use at your own risk.
 
 This module requires attaching a peripheral accessory to your device. It will not work without one.
+
 :::

--- a/docs/configuration/module-config/canned-message.mdx
+++ b/docs/configuration/module-config/canned-message.mdx
@@ -81,7 +81,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -106,7 +105,9 @@ All canned message module config options are available on iOS, iPadOS and macOS 
 <TabItem value="cli">
 
 :::info
+
 All canned message module config options are available in the python CLI. 
+
 :::
 
 Example commands are below:
@@ -124,6 +125,16 @@ Example commands are below:
 |    canned_message.inputbroker_pin_a      |     `integer`     | (not defined) |
 |    canned_message.inputbroker_pin_b      |     `integer`     | (not defined) |
 |  canned_message.inputbroker_pin_press    |     `integer`     | (not defined) |
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set canned_message.enabled true --set canned_message.send_bell true
+```
+
+:::
 
 ```shell title="Enable/Disable the Canned Message Module"
 meshtastic --set canned_message.enabled true
@@ -178,14 +189,7 @@ meshtastic --set canned_message.inputbroker_event_press KEY_SELECT
 meshtastic --set canned_message.inputbroker_event_press ""
 ```
 </TabItem>
-<TabItem value="flasher">
-
-:::info
-No canned message test module config options are available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All canned message module config options are available in the Web UI.

--- a/docs/configuration/module-config/external-notification.mdx
+++ b/docs/configuration/module-config/external-notification.mdx
@@ -51,7 +51,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -75,7 +74,11 @@ All external notification module config options are available on iOS, iPadOS and
 </TabItem>
 <TabItem value="cli">
 
+:::info
+
 All external notification module config options are available in the python CLI. Example commands are below:
+
+:::
 
 |         Setting                |    Acceptable Values     | Default |
 | :----------------------------: | :----------------------: | :-----: |
@@ -85,6 +88,16 @@ All external notification module config options are available in the python CLI.
 | external_notification.alert_message |     `true`, `false`      | `false` |
 |    external_notification.output     |        `integer`         |   `0`   |
 |   external_notification.output_ms   | `integer` (milliseconds) |   `0`   |
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set external_notification.enabled true --set external_notification.alert_bell true
+```
+
+:::
 
 ```shell title="Enable/Disable External Notification Module"
 meshtastic --set external_notification.enabled true
@@ -115,20 +128,13 @@ meshtastic --set external_notification.output_ms 0
 meshtastic --set external_notification.output_ms 1500
 ```
 </TabItem>
-<TabItem value="flasher">
-
-:::info
-External Notification module config is not available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All External Notification module config is available for the Web UI.
 :::
     
-  </TabItem>
+</TabItem>
 </Tabs>
 
 :::warning

--- a/docs/configuration/module-config/mqtt.mdx
+++ b/docs/configuration/module-config/mqtt.mdx
@@ -49,7 +49,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -73,7 +72,11 @@ MQTT module config is not available for Apple.
 </TabItem>
 <TabItem value="cli">
 
+:::info
+
 All MQTT module config options are available in the python CLI. Example commands are below:
+
+:::
 
 |     Setting                  |    Acceptable Values     | Default |
 | :--------------------------: | :----------------------: | :-----: |
@@ -84,9 +87,24 @@ All MQTT module config options are available in the python CLI. Example commands
 |    mqtt.encryption_enabled   |     `string`             |         |
 |    mqtt.json_enabled         |     `true`, `false`      | `false` |
 
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set mqtt.enabled true --set mqtt.json_enabled true
+```
+
+:::
+
 ```shell title="Enable/Disable MQTT Module"
 meshtastic --set mqtt.enabled true
 meshtastic --set mqtt.enabled false
+```
+
+```shell title="Enable/Disable MQTT JSON"
+meshtastic --set mqtt.json_enabled true
+meshtastic --set mqtt.json_enabled false
 ```
 
   </TabItem>

--- a/docs/configuration/module-config/range-test.mdx
+++ b/docs/configuration/module-config/range-test.mdx
@@ -37,7 +37,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -61,13 +60,27 @@ All range test module config options are available on iOS, iPadOS and macOS at S
 </TabItem>
 <TabItem value="cli">
 
+:::info
+
 Range Test module config options are available in the python CLI. Example commands are below:
+
+:::
 
 |          Setting          |  Acceptable Values  | Default |
 | :-----------------------: | :-----------------: | :-----: |
 | range_test.enabled |   `true`, `false`   | `false` |
 |  range_test.save   |   `true`, `false`   | `false` |
 | range_test.sender  | `integer` (Seconds) |   `0`   |
+
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set range_test.enabled true --set range_test.save false
+```
+
+:::
 
 ```shell title="Enable / Disable the range test"
 meshtastic --set range_test.enabled true
@@ -88,20 +101,15 @@ meshtastic --set range_test.sender 0
 ```
 
 </TabItem>
-<TabItem value="flasher">
+<TabItem value="web">
 
 :::info
-No range test module config options are available in the Flasher.
-:::
 
-  </TabItem>
-  <TabItem value="web">
-
-:::info
 No range test module config options are available in the Web UI.
+
 :::
-    
-  </TabItem>
+
+</TabItem>
 </Tabs>
 
 ## Examples

--- a/docs/configuration/module-config/serial.mdx
+++ b/docs/configuration/module-config/serial.mdx
@@ -70,7 +70,6 @@ values={[
 {label: 'Android', value: 'android'},
 {label: 'Apple', value: 'apple'},
 {label: 'CLI', value: 'cli'},
-{label: 'Flasher', value: 'flasher'},
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="android">
@@ -94,7 +93,11 @@ All serial module config options are available on iOS, iPadOS and macOS at Setti
 </TabItem>
 <TabItem value="cli">
 
+:::info 
+
 All serial module config options are available in the python CLI. Example commands are below:
+
+:::
 
 |        Setting        |  Acceptable Values  | Default |
 | :-------------------: | :-----------------: | :-----: |
@@ -106,6 +109,15 @@ All serial module config options are available in the python CLI. Example comman
 | serial.baud    | `BAUD_DEFAULT` `BAUD_110` `BAUD_300` `BAUD_600` `BAUD_1200` `BAUD_2400` `BAUD_4800` `BAUD_9600` `BAUD_19200` `BAUD_38400` `BAUD_57600` `BAUD_115200` `BAUD_230400` `BAUD_460800` `BAUD_576000` `BAUD_921600` |  `BAUD_DEFAULT`  |
 | serial.timeout | `integer` (seconds) |   `0`   |
 
+:::tip
+
+Because the device will reboot after each command is sent via CLI, it is recommended when setting multiple values in a config section that commands be chained together as one.
+
+```shell title="Example:"
+meshtastic --set serial.enabled true --set serial.echo true
+```
+
+:::
 
 ```shell title="Enable / Disable Module"
 meshtastic --set serial.enabled true
@@ -140,20 +152,13 @@ meshtastic --set serial.timeout 15
 ```
 
 </TabItem>
-<TabItem value="flasher">
-
-:::info
-No serial module config options are available in the Flasher.
-:::
-
-  </TabItem>
-  <TabItem value="web">
+<TabItem value="web">
 
 :::info
 All serial module config options are available in the Web UI.
 :::
     
-  </TabItem>
+</TabItem>
 </Tabs>
 
 :::warning

--- a/docs/configuration/module-config/telemetry.mdx
+++ b/docs/configuration/module-config/telemetry.mdx
@@ -103,11 +103,11 @@ All telemetry module config options are available in the python CLI. Example com
 
 |                         Setting                         |  Acceptable Values  | Default |
 | :-----------------------------------------------------: | :-----------------: | :-----: |
-|         telemetry.device_update_interval         | `integer` (seconds) |   Default `0` is 15 minutes.   |
+|         telemetry.device_update_interval         | `integer` (seconds) |   Default `0` is 15 minutes(`900` seconds).   |
 |     telemetry.environment_display_fahrenheit     |   `true`, `false`   | `false` |
 |    telemetry.environment_measurement_enabled     |   `true`, `false`   | `false` |
 |       telemetry.environment_screen_enabled       |   `true`, `false`   |   `0`   |
-|      telemetry.environment_update_interval       | `integer` (seconds) |   Default `0` is 15 minutes.    |
+|      telemetry.environment_update_interval       | `integer` (seconds) |   Default `0` is 15 minutes(`900` seconds).    |
 
 :::tip
 

--- a/docs/configuration/module-config/telemetry.mdx
+++ b/docs/configuration/module-config/telemetry.mdx
@@ -103,11 +103,11 @@ All telemetry module config options are available in the python CLI. Example com
 
 |                         Setting                         |  Acceptable Values  | Default |
 | :-----------------------------------------------------: | :-----------------: | :-----: |
-|         telemetry.device_update_interval         | `integer` (seconds) |   `900`   |
+|         telemetry.device_update_interval         | `integer` (seconds) |   Default `0` is 15 minutes.   |
 |     telemetry.environment_display_fahrenheit     |   `true`, `false`   | `false` |
 |    telemetry.environment_measurement_enabled     |   `true`, `false`   | `false` |
 |       telemetry.environment_screen_enabled       |   `true`, `false`   |   `0`   |
-|      telemetry.environment_update_interval       | `integer` (seconds) |   `0`   |
+|      telemetry.environment_update_interval       | `integer` (seconds) |   Default `0` is 15 minutes.    |
 
 :::tip
 

--- a/docs/configuration/module-config/telemetry.mdx
+++ b/docs/configuration/module-config/telemetry.mdx
@@ -151,7 +151,7 @@ All telemetry module config options are available in the Web UI.
 
 :::
     
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ## Examples


### PR DESCRIPTION
- Added to each config page a tip about chaining commands w/ an example specific to that config. 
- Various formatting fixes.
- Removed flasher from tabs where applicable for consistency and to reflect status of setting configs in flasher being removed (except `lora.region`)
- Added missing tables for a few CLI tabs.