### PR TITLE
Point "Learn More" button to "Introduction" page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,7 @@ const config = {
       items: [
         {
           label: 'Docs',
-          to: 'docs/introduction',
+          to: 'docs/about',
         },
         {
           label: 'Downloads',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -176,7 +176,7 @@ function Home() {
           </h1>
           <p className="hero__subtitle">{siteConfig.tagline}</p>
           <div className="indexCtas">
-            <Link className="button button--lg" to="/docs/about">
+            <Link className="button button--lg" to="/docs/introduction">
               Learn More
             </Link>
             <Link className="button button--lg" to="/docs/getting-started">


### PR DESCRIPTION
This PR points the "Learn More" homepage button to the "Introduction" page instead of the "About" page. This PR implements #562.

Closes #562 