### PR TITLE
doco: help users identify 2.1-1.6 boards

### DIFF
--- a/docs/hardware/devices/lora/index.mdx
+++ b/docs/hardware/devices/lora/index.mdx
@@ -145,6 +145,12 @@ Early versions of some of these boards contained the wrong component in the LiPo
   - Micro USB
   - Antenna: SMA antenna connector
 
+## Variations of identifying marks
+  - FCC ID: 2ASYE-T3-V1-6-1
+    - "LILYGO 868/915 Modle: LORA32" sticker on the chip
+    - "T3_v1.6.1 20210104" on the board
+    - "Model T3 V1.6.1" on the FCC sticker
+  
 ## Features
 
 - Built in 0.96 inch OLED display

--- a/docs/hardware/devices/lora/index.mdx
+++ b/docs/hardware/devices/lora/index.mdx
@@ -146,10 +146,11 @@ Early versions of some of these boards contained the wrong component in the LiPo
   - Antenna: SMA antenna connector
 
 ## Variations of identifying marks
-  - FCC ID: 2ASYE-T3-V1-6-1
-  - "T3_v1.6.1 20210104" on the board
-  - "Model T3 V1.6.1" on the FCC sticker
-  
+
+- FCC ID: 2ASYE-T3-V1-6-1
+- "T3_v1.6.1 20210104" on the board
+- "Model T3 V1.6.1" on the FCC sticker
+
 ## Features
 
 - Built in 0.96 inch OLED display

--- a/docs/hardware/devices/lora/index.mdx
+++ b/docs/hardware/devices/lora/index.mdx
@@ -147,9 +147,8 @@ Early versions of some of these boards contained the wrong component in the LiPo
 
 ## Variations of identifying marks
   - FCC ID: 2ASYE-T3-V1-6-1
-    - "LILYGO 868/915 Modle: LORA32" sticker on the chip
-    - "T3_v1.6.1 20210104" on the board
-    - "Model T3 V1.6.1" on the FCC sticker
+  - "T3_v1.6.1 20210104" on the board
+  - "Model T3 V1.6.1" on the FCC sticker
   
 ## Features
 


### PR DESCRIPTION
Add section for 2.1-1.6 boards that have alternate markings. As far as I can tell this information doesn't exist anywhere else.