### PR TITLE
Channel Calculator Fix

### DIFF
--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -263,21 +263,24 @@ export const FrequencyCalculator = (): JSX.Element => {
 	useEffect(() => {
 		const selectedRegion = RegionData.get(region);
 		const selectedModemPreset = modemPresets.get(modemPreset);
-		setNumChannels(
-			Math.floor(
-				(selectedRegion.freq_end - selectedRegion.freq_start) /
-					(selectedRegion.spacing + selectedModemPreset.bw / 1000),
-			),
+		const calculatedNumChannels = Math.floor(
+			(selectedRegion.freq_end - selectedRegion.freq_start) /
+				(selectedRegion.spacing + selectedModemPreset.bw / 1000),
 		);
 
-		if (channel >= numChannels) {
-			setChannel(numChannels - 1);
+		setNumChannels(calculatedNumChannels);
+
+		let updatedChannel = channel;
+		if (updatedChannel >= calculatedNumChannels) {
+			updatedChannel = 0;
 		}
+
+		setChannel(updatedChannel);
 
 		setChannelFrequency(
 			selectedRegion.freq_start +
 				selectedModemPreset.bw / 2000 +
-				channel * (selectedModemPreset.bw / 1000),
+				updatedChannel * (selectedModemPreset.bw / 1000),
 		);
 	}, [modemPreset, region, channel]);
 


### PR DESCRIPTION
This will fix the issue with the channel calculator displaying the incorrect frequency for channel 1 on first load. As well as fix the issue with a frequency outside the possible range for the selected options being displayed when switching from a combo with higher possible channels/frequency. It'll update to channel 1 info upon change. 

Screen record below shows the current setup first as shown on the live site. Then it switches to my preview of this update where it shows it correctly displays/updates the info with an example of just changing the region as well as one changing the modem preset. 

https://github.com/meshtastic/meshtastic/assets/6912600/e2c84e71-780f-4cfb-ba10-c32178967c23

