### PR TITLE
Removed standalone mac executable instructions

### DIFF
--- a/docs/software/python-cli/installation.mdx
+++ b/docs/software/python-cli/installation.mdx
@@ -206,7 +206,7 @@ You may need to close and re-open the CLI. The path variables may or may not upd
 
 ## Standalone
 
-There are standalone executable files for Mac, Windows and Ubuntu. A single file is all you need to run the command line interface (CLI) Meshtastic tool. There is a zip file per operating system. To use, see the operating system specific notes below:
+There are standalone executable files for Windows and Ubuntu. A single file is all you need to run the command line interface (CLI) Meshtastic tool. There is a zip file per operating system. To use, see the operating system specific notes below:
 
 They can be found on the [Releases](https://github.com/meshtastic/Meshtastic-python/releases) page.
 
@@ -215,7 +215,6 @@ groupId="operating-system"
 defaultValue="windows"
 values={[
 {label: 'Ubuntu', value: 'ubuntu'},
-{label: 'macOS', value: 'macos'},
 {label: 'Windows', value: 'windows'},
 ]}>
 <TabItem value="ubuntu">
@@ -229,52 +228,6 @@ chmod +x meshtastic_ubuntu && mv meshtastic_ubuntu meshtastic
 ```
 
 - To run the cli:
-
-```shell
-./meshtastic
-```
-
-:::tip
-Copy (or move) this binary somewhere in your path.
-:::
-
-</TabItem>
-<TabItem value="macos">
-
-- Download meshtastic_mac
-
-- Run the following command to make the file executable and to rename it 'meshtastic':
-
-```shell
-chmod +x meshtastic_mac && mv meshtastic_mac meshtastic
-```
-
-- Try to run it:
-
-```shell
-./meshtastic
-```
-
-:::note
-You may get a dialog that says:
-"meshtastic" can't be opened because Apple cannot check it for malicious software.
-:::
-
-- To fix, go into "System Preferences", "Security & Privacy", "General" tab, and click on the "Allow Anyway" button.
-
-- Try to run it again:
-
-```shell
-./meshtastic
-```
-
-:::note
-You may get a dialog that says:
-"meshtastic" can't be opened because Apple cannot check it for malicious software.
-Click "Open".
-:::
-
-- Now when you want to run it, you can simply run:
 
 ```shell
 ./meshtastic


### PR DESCRIPTION
Based on discussions on discourse, it's unlikely the mac standalone executable will reappear anytime soon so I've removed the instructions from the documentation to avoid confusion.  I've previewed this in a local development environment as suggested and it seems to look and function properly.  Thank you for your patience and mentoring as I learn the github workflow!