### PR TITLE
Style Guide example template table formatting

### DIFF
--- a/docs/development/documentation/style-guides/settings.mdx
+++ b/docs/development/documentation/style-guides/settings.mdx
@@ -59,7 +59,7 @@ import TabItem from '@theme/TabItem';
 <!--- Table of settings in alphabetical order --->
 
 |         Setting         |      Acceptable Values      | Default |
-| :---------------------: | :-------------------------: | :-----: |
+| :---------------------: | :-------------------------: | :-----: |  
 | my_setting_with_options | `apple`, `banana`, `orange` | `apple` |
 
 <!--- H3 for each setting above (alphabetized) --->
@@ -71,7 +71,7 @@ import TabItem from '@theme/TabItem';
 <!--- if the setting has many options, insert a table describing what those variables do --->
 
 |  Value   |          Description           |
-| :------: | :----------------------------: |
+| :------: | :----------------------------: |  
 | `apple`  | Description of apple (default) |
 | `banana` |     Description of banana      |
 | `orange` |     Description of orange      |


### PR DESCRIPTION
This PR fixes:

The tables in the code block of the Config Pages Style Guide do not display properly.

[preview link](https://sandbox-git-style-guide-config-page-tables-pdxlocations.vercel.app/docs/development/documentation/style-guides/config-pages)

[current site for comparison](https://meshtastic.org/docs/development/documentation/style-guides/config-pages)