### PR TITLE
Add android availability to S&F config documentation

### DIFF
--- a/docs/configuration/module-config/store-and-forward-module.mdx
+++ b/docs/configuration/module-config/store-and-forward-module.mdx
@@ -34,9 +34,6 @@ Because of the increased network traffic for this overhead, it's not advised to 
 | store_forward.history_return_window |     `integer`     |   `0`   |
 |        store_forward.records        |     `integer`     |   `0`   |
 
-### Enabled
-
-Enables the module.
 
 <Tabs
 groupId="settings"
@@ -48,6 +45,10 @@ values={[
 {label: 'Web', value: 'web'},
 ]}>
 <TabItem value="cli">
+
+### Enabled
+
+Enables the module.
 
 ```shell title="Enable the module"
 meshtastic --set store_forward.enabled true
@@ -57,213 +58,95 @@ meshtastic --set store_forward.enabled true
 meshtastic --set store_forward.enabled false
 ```
 
-  </TabItem>
-  <TabItem value="android">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="iOS">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="web">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-</Tabs>
-
 ### Heartbeat
 
 The Store & Forward Router sends a periodic message onto the network. This allows connected devices to know that a router is in range and listening to received messages. A client like Android, iOS, or Web can (if supported) indicate to the user whether a store and forward router is available.
-
-<Tabs
-groupId="settings"
-defaultValue="cli"
-values={[
-{label: 'CLI', value: 'cli'},
-{label: 'Android', value: 'android'},
-{label: 'iOS', value: 'iOS'},
-{label: 'Web', value: 'web'},
-]}>
-<TabItem value="cli">
 
 ```shell title="Set store_forward.heartbeat to default"
 meshtastic --set store_forward.heartbeat 0
 ```
 
-  </TabItem>
-  <TabItem value="android">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="iOS">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="web">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-</Tabs>
-
 ### History Return Max
 
 Sets the maximum number of messages to return to a client device.
 
-<Tabs
-groupId="settings"
-defaultValue="cli"
-values={[
-{label: 'CLI', value: 'cli'},
-{label: 'Android', value: 'android'},
-{label: 'iOS', value: 'iOS'},
-{label: 'Web', value: 'web'},
-]}>
-<TabItem value="cli">
-
 ```shell title="Set store_forward.history_return_max to default"
 meshtastic --set store_forward.history_return_max 0
 ```
-
 ```shell title="Set store_forward.history_return_max to 100 messages"
 meshtastic --set store_forward.history_return_max 100
 ```
-
-  </TabItem>
-  <TabItem value="android">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="iOS">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="web">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-</Tabs>
 
 ### History Return Window
 
 Limits the time period (in minutes) a client device can request.
 
-<Tabs
-groupId="settings"
-defaultValue="cli"
-values={[
-{label: 'CLI', value: 'cli'},
-{label: 'Android', value: 'android'},
-{label: 'iOS', value: 'iOS'},
-{label: 'Web', value: 'web'},
-]}>
-<TabItem value="cli">
-
 ```shell title="Set store_forward.history_return_window to default"
 meshtastic --set store_forward.history_return_window 0
 ```
-
 ```shell title="Set store_forward.history_return_window to 1 day (1440 minutes)"
 meshtastic --set store_forward.history_return_window 1440
 ```
-
-  </TabItem>
-  <TabItem value="android">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="iOS">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-  <TabItem value="web">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
-</Tabs>
 
 ### Records
 
 Set this to the maximum number of records to save. Best to leave this at the default (`0`) where the module will use 2/3 of your device's available PSRAM. This is about 11,000 records.
 
-<Tabs
-groupId="settings"
-defaultValue="cli"
-values={[
-{label: 'CLI', value: 'cli'},
-{label: 'Android', value: 'android'},
-{label: 'iOS', value: 'iOS'},
-{label: 'Web', value: 'web'},
-]}>
-<TabItem value="cli">
-
 ```shell title="Set store_forward.records to default (≈11,000 records)"
 meshtastic --set store_forward.records 0
 ```
-
 ```shell title="Set store_forward.records to 100 records"
 meshtastic --set store_forward.records 100
 ```
+</TabItem>
 
-  </TabItem>
-  <TabItem value="android">
+<TabItem value="android">
+
+:::info
+Store and Forward Config options are available for Android.
+
+1. Open the Meshtastic App
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio configuration > Module configuration > Store & Forward**
+:::
+
+### Enabled
+
+Enables the module.
+
+### Heartbeat
+
+The Store & Forward Router sends a periodic message onto the network. This allows connected devices to know that a router is in range and listening to received messages. A client like Android, iOS, or Web can (if supported) indicate to the user whether a store and forward router is available.
+
+### History Return Max
+
+Sets the maximum number of messages to return to a client device.
+
+### History Return Window
+
+Limits the time period (in minutes) a client device can request.
+### Records
+
+Set this to the maximum number of records to save. Best to leave this at the default (`0`) where the module will use 2/3 of your device's available PSRAM. This is about 11,000 records.
+
+</TabItem>
+
+<TabItem value="iOS">
 
 :::info
 Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
 :::
 
-  </TabItem>
-  <TabItem value="iOS">
+</TabItem>
+
+<TabItem value="web">
 
 :::info
 Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
 :::
 
-  </TabItem>
-  <TabItem value="web">
-
-:::info
-Configuring this setting is not yet available for the selected platform. If this is incorrect please update the documentation for this page.
-:::
-
-  </TabItem>
+</TabItem>
 </Tabs>
+
 
 ## Details
 


### PR DESCRIPTION
The PR addresses:

1. Adds the availability of S&F settings in the Android App.
2. Removes redundant platform tabs

[preview link](https://sandbox-git-store-and-forward-pdxlocations.vercel.app/docs/settings/moduleconfig/store-and-forward-module#settings)