### PR TITLE
Update Android settings navigation path

### DIFF
--- a/docs/configuration/device-config/bluetooth.mdx
+++ b/docs/configuration/device-config/bluetooth.mdx
@@ -57,7 +57,7 @@ values={[
 All Bluetooth config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Bluetooth Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Bluetooth**
 
 :::
 

--- a/docs/configuration/device-config/device.mdx
+++ b/docs/configuration/device-config/device.mdx
@@ -88,7 +88,7 @@ values={[
 Device Config is available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Device Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Device**
 
 :::
 

--- a/docs/configuration/device-config/display.mdx
+++ b/docs/configuration/device-config/display.mdx
@@ -90,7 +90,7 @@ values={[
 Display Config is available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Display Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Display**
 
 :::
 

--- a/docs/configuration/device-config/lora.mdx
+++ b/docs/configuration/device-config/lora.mdx
@@ -138,7 +138,7 @@ values={[
 LoRa Config options such as Region, Modem Preset, and Hop Limit can be configured on Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > LoRa Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > LoRa**
 
 :::
 

--- a/docs/configuration/device-config/network.mdx
+++ b/docs/configuration/device-config/network.mdx
@@ -79,7 +79,7 @@ values={[
 Network Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Network Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Network**
 
 :::
 

--- a/docs/configuration/device-config/position.mdx
+++ b/docs/configuration/device-config/position.mdx
@@ -96,7 +96,7 @@ values={[
 Position Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Position Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Position**
 
 :::
 

--- a/docs/configuration/device-config/power.mdx
+++ b/docs/configuration/device-config/power.mdx
@@ -141,7 +141,7 @@ values={[
 Power Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > Power Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Power**
 
 :::
 

--- a/docs/configuration/device-config/user.mdx
+++ b/docs/configuration/device-config/user.mdx
@@ -54,7 +54,7 @@ values={[
 User Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Device Settings > User Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > User**
 
 :::
 

--- a/docs/configuration/module-config/audio.mdx
+++ b/docs/configuration/module-config/audio.mdx
@@ -74,7 +74,8 @@ values={[
 Audio Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Audio Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Audio**
+
 
 :::
 

--- a/docs/configuration/module-config/canned-message.mdx
+++ b/docs/configuration/module-config/canned-message.mdx
@@ -90,7 +90,7 @@ values={[
 Canned Message Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Canned Message Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Canned Message**
 
 :::
 

--- a/docs/configuration/module-config/external-notification.mdx
+++ b/docs/configuration/module-config/external-notification.mdx
@@ -65,7 +65,7 @@ values={[
 External Notification Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > External Notification Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > External Notification**
 
 :::
 

--- a/docs/configuration/module-config/mqtt.mdx
+++ b/docs/configuration/module-config/mqtt.mdx
@@ -58,7 +58,7 @@ values={[
 MQTT Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > MQTT Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > MQTT**
 
 :::
 

--- a/docs/configuration/module-config/range-test.mdx
+++ b/docs/configuration/module-config/range-test.mdx
@@ -44,7 +44,7 @@ values={[
 Range Test Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Range Test Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Range Test**
 
 :::
 

--- a/docs/configuration/module-config/serial.mdx
+++ b/docs/configuration/module-config/serial.mdx
@@ -83,7 +83,7 @@ values={[
 Serial Module Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Serial Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Serial**
 
 :::
 

--- a/docs/configuration/module-config/telemetry.mdx
+++ b/docs/configuration/module-config/telemetry.mdx
@@ -87,7 +87,7 @@ values={[
 Telemetry Config options are available for Android.
 
 1. Open the Meshtastic App
-2. Navigate to: **Vertical Ellipsis (3 dots top right) > Module Settings > Telemetry Config**
+2. Navigate to: **Vertical Ellipsis (3 dots top right) > Radio Configuration > Telemetry**
 
 :::
 


### PR DESCRIPTION
The PR fixes:

Android App settings navigation path eg:
OLD: Vertical Ellipsis (3 dots top right) > Module Settings > Serial Config
NEW: Vertical Ellipsis (3 dots top right) > Radio Configuration > Serial

[demo link](https://sandbox-git-android-module-menu-path-pdxlocations.vercel.app/docs/introduction)