### PR TITLE
Embed YouTube Videos

### DIFF
--- a/docs/about/overview/mesh-alg.mdx
+++ b/docs/about/overview/mesh-alg.mdx
@@ -10,7 +10,7 @@ sidebar_position: 2
 
 The routing protocol for Meshtastic is really quite simple (and sub-optimal). If you want to test its theoretical performance, you can have a look at the [simulator](https://github.com/GUVWAF/Meshtasticator). The protocol is heavily influenced by the mesh routing algorithm used in [RadioHead](https://www.airspayce.com/mikem/arduino/RadioHead) (which was used in very early versions of this project). It has four conceptual layers.
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/7v6UbC5blJU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<object data="https://www.youtube.com/embed/7v6UbC5blJU?autohide=1&autoplay=0" width="100%" height="400"></object>
 
 ### A Note About Protocol Buffers
 

--- a/docs/about/overview/mesh-alg.mdx
+++ b/docs/about/overview/mesh-alg.mdx
@@ -10,6 +10,8 @@ sidebar_position: 2
 
 The routing protocol for Meshtastic is really quite simple (and sub-optimal). If you want to test its theoretical performance, you can have a look at the [simulator](https://github.com/GUVWAF/Meshtasticator). The protocol is heavily influenced by the mesh routing algorithm used in [RadioHead](https://www.airspayce.com/mikem/arduino/RadioHead) (which was used in very early versions of this project). It has four conceptual layers.
 
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/7v6UbC5blJU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ### A Note About Protocol Buffers
 
 Because we want our devices to work across various vendors and implementations, we use [Protocol Buffers](https://github.com/meshtastic/protobufs) pervasively. For purposes of this document you mostly only

--- a/docs/configuration/module-config/serial.mdx
+++ b/docs/configuration/module-config/serial.mdx
@@ -14,7 +14,7 @@ This is a simple interface to send messages over the mesh network by sending str
 
 ![image](https://user-images.githubusercontent.com/9000580/205529843-962c3187-8411-452c-b729-42c58b1571f5.png)
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/HdOiGKBtapw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<object data="https://www.youtube.com/embed/HdOiGKBtapw?autohide=1&autoplay=0" width="100%" height="400"></object>
 
 ## Serial Module Config Values
 

--- a/docs/configuration/module-config/serial.mdx
+++ b/docs/configuration/module-config/serial.mdx
@@ -14,6 +14,8 @@ This is a simple interface to send messages over the mesh network by sending str
 
 ![image](https://user-images.githubusercontent.com/9000580/205529843-962c3187-8411-452c-b729-42c58b1571f5.png)
 
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/HdOiGKBtapw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ## Serial Module Config Values
 
 ### Enabled

--- a/docs/configuration/module-config/telemetry.mdx
+++ b/docs/configuration/module-config/telemetry.mdx
@@ -12,7 +12,7 @@ The Telemetry Module provides three types of data over the mesh: Device metrics 
 
 Supported sensors connected to the I2C bus of the device will be automatically detected at startup. Environment Telemetry and Air Quality must be enabled for them to be instrumented and their readings sent over the mesh.
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/6jj1s-fsPlc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<object data="https://www.youtube.com/embed/6jj1s-fsPlc?autohide=1&autoplay=0" width="100%" height="400"></object>
 
 ### Currently Supported Sensor Types
 

--- a/docs/configuration/module-config/telemetry.mdx
+++ b/docs/configuration/module-config/telemetry.mdx
@@ -12,6 +12,8 @@ The Telemetry Module provides three types of data over the mesh: Device metrics 
 
 Supported sensors connected to the I2C bus of the device will be automatically detected at startup. Environment Telemetry and Air Quality must be enabled for them to be instrumented and their readings sent over the mesh.
 
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/6jj1s-fsPlc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ### Currently Supported Sensor Types
 
 | Sensor  | I<sup>2</sup>C Address |                          Data Points                          |

--- a/docs/configuration/module-config/traceroute.mdx
+++ b/docs/configuration/module-config/traceroute.mdx
@@ -14,6 +14,10 @@ Only nodes that know the encryption key of the channel you use can be tracked. A
 
 In order to use it, make sure your devices use firmware version 2.0.8 or higher.
 
+
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/PKUmaELKaUo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+
 ## Traceroute Module Client Availability
 
 <Tabs

--- a/docs/configuration/module-config/traceroute.mdx
+++ b/docs/configuration/module-config/traceroute.mdx
@@ -14,9 +14,7 @@ Only nodes that know the encryption key of the channel you use can be tracked. A
 
 In order to use it, make sure your devices use firmware version 2.0.8 or higher.
 
-
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/PKUmaELKaUo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
+<object data="https://www.youtube.com/embed/PKUmaELKaUo?autohide=1&autoplay=0" width="100%" height="400"></object>
 
 ## Traceroute Module Client Availability
 

--- a/docs/hardware/antennas/lora-antennas.mdx
+++ b/docs/hardware/antennas/lora-antennas.mdx
@@ -20,7 +20,7 @@ The antenna's design will affect:
 While the LoRa devices we use for Meshtastic are relatively low power radios, care should be taken _not_ to operate any radio transmission device without an antenna or with a poorly matched antenna. Un-transmitted radio signal reflected back to the transmitter can damage the device.
 :::
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/V3f-Y3EfsBU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<object data="https://www.youtube.com/embed/V3f-Y3EfsBU?autohide=1&autoplay=0" width="100%" height="400"></object>
 
 ## Important considerations
 

--- a/docs/hardware/antennas/lora-antennas.mdx
+++ b/docs/hardware/antennas/lora-antennas.mdx
@@ -20,6 +20,8 @@ The antenna's design will affect:
 While the LoRa devices we use for Meshtastic are relatively low power radios, care should be taken _not_ to operate any radio transmission device without an antenna or with a poorly matched antenna. Un-transmitted radio signal reflected back to the transmitter can damage the device.
 :::
 
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/V3f-Y3EfsBU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ## Important considerations
 
 ### What transmission frequency are you using?


### PR DESCRIPTION
In response to https://github.com/meshtastic/meshtastic/issues/670

Videos are currently placed after the introduction on each page.  Month of Modules videos are placed on their respective pages.  I popped Range Issues on the Lora Antennas page for lack of a better location.  Flood Routing is dropped in the Mesh Algorithm page.  Thoughts on these placements/inclusions?

Demo Deployments:
MOM#1 - Serial Module [Serial Module](https://sandbox-git-embed-youtube-videos-pdxlocations.vercel.app/docs/settings/moduleconfig/serial)
MOM#2 - Telemetry [Telemetry Module](https://sandbox-git-embed-youtube-videos-pdxlocations.vercel.app/docs/settings/moduleconfig/telemetry)
MOM#3 - Traceroute [Traceroute Module](https://sandbox-git-embed-youtube-videos-pdxlocations.vercel.app/docs/settings/moduleconfig/traceroute)
Range Issues [Lora Antennas](https://sandbox-git-embed-youtube-videos-pdxlocations.vercel.app/docs/hardware/antennas/lora-antenna)
Flood Routing [Mesh Algorithm](https://sandbox-git-embed-youtube-videos-pdxlocations.vercel.app/docs/overview/mesh-algo)