### PR TITLE
fix typo in tx_enabled values

### DIFF
--- a/docs/configuration/device-config/lora.mdx
+++ b/docs/configuration/device-config/lora.mdx
@@ -169,7 +169,7 @@ LoRa config commands are available in the python CLI. Example commands are below
 |    lora.frequency_offset    |                                                      `0` to `1000000`                                                       |     `0`     |
 |       lora.hop_limit        |                                                 `1`,`2`,`3`,`4`,`5`,`6`,`7`                                                 |     `3`     |
 |        lora.tx_power        |                                                         `0` to `30`                                                         |     `0`     |
-|       lora.tx_enabled       |                                                      `false`, `false`                                                       |   `true`    |
+|       lora.tx_enabled       |                                                      `false`, `true`                                                       |   `true`    |
 |      lora.channel_num       |                                                 `0`, `1` to `NUM_CHANNELS`                                                  |     `0`     |
 |  lora.override_duty_cycle   |                                                       `false`, `true`                                                       |   `false`   |
 | lora.sx126x_rx_boosted_gain |                                                       `false`, `true`                                                       |   `false`   |


### PR DESCRIPTION
tx_enabled acceptable values are listed as 'false', 'false'