### PR TITLE
Add ESP32 Only for ADC Multiplier

### DIFF
--- a/docs/configuration/device-config/power.mdx
+++ b/docs/configuration/device-config/power.mdx
@@ -9,9 +9,11 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import calculateADC from "/src/utils/calculateADC";
 
-The power config options are: Power Saving, Shutdown after losing power, ADC Multiplier Override Wait Bluetooth Interval, Mesh Super Deep Sleep Timeout, Super Deep Sleep Interval, Light Sleep Interval and Minimum Wake Interval. Power config uses an admin message sending a `Config.Power` protobuf.
+:::info
+Power settings are advanced configuration, most users should choose a role under [Device Config](/docs/settings/config/device) to manage power for their device and shouldn't ever need to adjust these settings.
+:::
 
-Power settings are advanced configuration, most users should choose a role under Device Config to manage power for their device and should never need to touch any of these settings.
+The power config options are: Power Saving, Shutdown after losing power, ADC Multiplier Override, Wait Bluetooth Interval, Mesh Super Deep Sleep Timeout, Super Deep Sleep Interval, Light Sleep Interval, and Minimum Wake Interval. Power config uses an admin message sending a `Config.Power` protobuf.
 
 ## Power Config Values
 
@@ -23,13 +25,17 @@ If set, Bluetooth, Wifi, and screen (if applicable) are turned off. When using t
 
 Automatically shut down a device after a defined time period if power is lost.
 
-### ADC Multiplier Override `Fixes issues on Heltec v2`
+### ADC Multiplier Override
 
 Ratio of voltage divider for battery pin e.g. 3.20 (R1=100k, R2=220k)
 
 Overrides the ADC_MULTIPLIER defined in the firmware device variant file for battery voltage calculation.
 
 Should be set to floating point value between 2 and 6
+
+:::info
+ADC Multiplier only applies to ESP32-based boards.  This setting will have no effect on nRF52 modules.
+:::
 
 #### Calibration Process ([Attribution](https://wiki.uniteng.com/en/meshtastic/nano-g1-explorer#calibration-process))
 
@@ -85,7 +91,7 @@ It's important to note that this calibration method only maps 4.2V to Battery Ch
 
 ### Wait Bluetooth Interval
 
-How long wait before turning off BLE in no Bluetooth states
+How long to wait before turning off BLE in no Bluetooth states
 
 `0` for default of 1 minute
 
@@ -103,11 +109,17 @@ While in Light Sleep if Mesh Super Deep Sleep Timeout Seconds is exceeded we wil
 
 `0` for default of one year
 
-### Light Sleep Interval `ESP32 Only Setting`
 
-In light sleep the CPU is suspended, LoRa radio is on, BLE is off an GPS is on
+
+### Light Sleep Interval
+
+In light sleep the CPU is suspended, LoRa radio is on, BLE is off and GPS is on
 
 `0` for default of five minutes
+
+:::info
+Light Sleep Interval only applies to ESP32-based boards.  This setting will have no effect on nRF52 modules.
+:::
 
 ### Minimum Wake Interval
 


### PR DESCRIPTION
This PR addresses:

1. Adds a note that the ADC Multiplier setting only applies to ESP32 Devices
2. Moves blurb about power settings being advanced config to prominent position and 'note' format
3. Removes code backticks from table of contents navigation
4. Corrects typos

[Preview Link](https://sandbox-git-power-config-01-pdxlocations.vercel.app/docs/settings/config/power)