### PR TITLE
Add External Notification YouTube to Module Documentaion

### DIFF
--- a/docs/configuration/module-config/external-notification.mdx
+++ b/docs/configuration/module-config/external-notification.mdx
@@ -10,6 +10,8 @@ import TabItem from "@theme/TabItem";
 
 The External Notification Module will allow you to connect a buzzer, speaker, LED, or other device to notify you when a message has been received from the mesh network. You can enable up to 3 pins independently from each other.
 
+<object data="https://www.youtube.com/embed/MWt3RHMpifo?autohide=1&autoplay=0" width="100%" height="400"></object>
+
 ## External Notification Module Config Values
 
 ### Enabled


### PR DESCRIPTION
This PR embeds the Month of Modules Week 4: External Notifications to the External Notifications Module documentation page.

[preview link](https://sandbox-git-external-notification-youtube-pdxlocations.vercel.app/docs/settings/moduleconfig/external-notification)