### PR TITLE
Update Mac System Report path and replace Windows 'fixme'

### DIFF
--- a/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
+++ b/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
@@ -59,6 +59,7 @@ values={[
 
 - `Silicon Labs CP210X USB to UART Bridge (COM5)`
 - `Silicon Labs CH9102 USB to UART Bridge (COM5)`
+- `USB-Enhanced-SERIAL CH9102 (COM5)`
 - `USB Serial Device (COM5)`
 
 </TabItem>

--- a/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
+++ b/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
@@ -43,7 +43,7 @@ values={[
 </TabItem>
 <TabItem value="macos">
 
-1. Navigate to `Apple Menu  > About This Mac > System Report... > Hardware > USB`.
+1. Navigate to `Apple Menu  > About This Mac > More Info > System Report... > Hardware > USB`.
 2. You should see similar to one of the following entries:
 
 - `CP210X USB to UART Bridge Controller`
@@ -58,7 +58,7 @@ values={[
 
 - `Silicon Labs CP210X USB to UART Bridge (COM5)`
 - `Silicon Labs CH9102 USB to UART Bridge (COM5)`
-- `FIXME (WISBLOCK OUTPUT)`
+- `USB Serial Device (COM5)`
 
 </TabItem>
 </Tabs>

--- a/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
+++ b/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
@@ -49,6 +49,7 @@ values={[
 - `CP210X USB to UART Bridge Controller`
 - `CH9102 USB to UART Bridge Controller`
 - `WisCore RAK4631 Board`
+- `USB Single Serial`
 
 </TabItem>
 <TabItem value="windows">


### PR DESCRIPTION
This PR:
1. fixes the navigation path to the MacOS System Report
2. fills in the info for Windows Device Manager
3. Add USB Single Serial as display option in mac USB devices

[preview link](https://sandbox-git-test-serial-01-pdxlocations.vercel.app/docs/getting-started/serial-drivers/test-serial-driver-installation)