### PR TITLE
Getting Started - Don't send user to drivers page if nRF52

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -57,7 +57,13 @@ Some cables only provide _charging_, verify that your cable is also capable of _
 
 ### Install Serial Drivers
 
-If you don't have serial drivers installed on your computer, please choose one of the options below and install it before continuing.
+:::caution
+
+With the latest versions of MacOS, USB Serial drivers are built-in. Do _NOT_ download the USB device drivers unless required.  You may [test for installed serial drivers](/docs/getting-started/serial-drivers/test-serial-driver-installation) before continuing.
+
+:::
+
+If you require serial drivers installed on your computer, please choose one of the options below and install it before continuing.
 
 <div className="indexCtasBody">
   <div className="split-container">


### PR DESCRIPTION
The PR addresses:

The Getting Started documentation says to install drivers before continuing to flashing firmware.  However if you choose the nRF drivers link, there is a warning NOT to install drivers.  This PR add the warning to the index page to potentially avoid unnecessary navigation.

[preview link](https://sandbox-git-getting-started-01-pdxlocations.vercel.app/docs/getting-started#install-serial-drivers)