### PR TITLE
Reformat nRF52 drivers documentation

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -59,7 +59,7 @@ Some cables only provide _charging_, verify that your cable is also capable of _
 
 :::caution
 
-nRF52 devices typically do not require serial drivers. They use the UF2 bootloader which make the devices appear as flash drives.  Do _NOT_ download the USB device drivers unless required.  You may [test for installed serial drivers](/docs/getting-started/serial-drivers/test-serial-driver-installation) before continuing.
+nRF52 devices typically do not require serial drivers. They use the UF2 bootloader which makes the devices appear as flash drives.  Do _NOT_ download the USB device drivers unless required to install UF2 support.
 
 :::
 

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -59,7 +59,7 @@ Some cables only provide _charging_, verify that your cable is also capable of _
 
 :::caution
 
-With the latest versions of MacOS, USB Serial drivers are built-in. Do _NOT_ download the USB device drivers unless required.  You may [test for installed serial drivers](/docs/getting-started/serial-drivers/test-serial-driver-installation) before continuing.
+nRF52 devices typically do not require serial drivers. They use the UF2 bootloader which make the devices appear as flash drives.  Do _NOT_ download the USB device drivers unless required.  You may [test for installed serial drivers](/docs/getting-started/serial-drivers/test-serial-driver-installation) before continuing.
 
 :::
 

--- a/docs/getting-started/serial-drivers/serial-drivers-nrf52.mdx
+++ b/docs/getting-started/serial-drivers/serial-drivers-nrf52.mdx
@@ -13,7 +13,7 @@ import Link from "@docusaurus/Link";
 
 :::caution
 
-nRF52 devices typically do not require serial drivers. They use the UF2 bootloader which make the devices appear as flash drives.  Do _NOT_ download the USB device drivers unless required.
+nRF52 devices typically do not require serial drivers. They use the UF2 bootloader which makes the devices appear as flash drives.  Do _NOT_ download the USB device drivers unless required to install UF2 support.
 
 :::
 

--- a/docs/getting-started/serial-drivers/serial-drivers-nrf52.mdx
+++ b/docs/getting-started/serial-drivers/serial-drivers-nrf52.mdx
@@ -11,6 +11,12 @@ import Link from "@docusaurus/Link";
 
 ## Install nRF52 USB to Serial Drivers
 
+:::caution
+
+nRF52 devices typically do not require serial drivers. They use the UF2 bootloader which make the devices appear as flash drives.  Do _NOT_ download the USB device drivers unless required.
+
+:::
+
 <Tabs
 groupId="operating-system"
 defaultValue="windows"
@@ -22,17 +28,16 @@ values={[
 
 <TabItem value="linux">
 
-- [CH9102 Driver - Linux Download](http://www.wch-ic.com/downloads/CH341SER_LINUX_ZIP.html)
+- [CH34x Driver - Linux Download](http://www.wch-ic.com/downloads/CH341SER_LINUX_ZIP.html)
 
 </TabItem>
 
 <TabItem value="macos">
 
-- [CH9102 Driver - macOS Download](https://github.com/WCHSoftGroup/ch34xser_macos)
 
-:::caution
+:::info
 
-With the latest versions of MacOS, the USB Serial driver is built-in. Do _NOT_ download the USB device drivers unless required. If you downloaded/installed any already, please remove them.
+With the latest versions of MacOS, the USB Serial driver is built-in. If you downloaded/installed any already, please remove them.
 
 :::
 
@@ -47,11 +52,18 @@ Uninstall the kernel extension:
 3. `sudo rm -rf /Library/Extensions/usbserial.kext`
 4. Reboot
 
+
+### Install the CH34x Driver
+
+- [CH34x Driver- macOS Download](https://github.com/WCHSoftGroup/ch34xser_macos)
+
+
+
 </TabItem>
 
 <TabItem value="windows">
 
-- [CH9102 Driver - Windows Download](http://www.wch-ic.com/downloads/CH341SER_EXE.html)
+- [CH34x Driver - Windows Download](http://www.wch-ic.com/downloads/CH341SER_EXE.html)
 
 </TabItem>
 


### PR DESCRIPTION
This PR fixes #696 

1. Specifically warn against any installation of nRF drivers on all platforms but leave options available for edge cases such as installing UF2 support.
2. Changes CH9102 driver to CH34x driver (i believe the driver name is CH34x for the CH9102 Chip?)
3. Moves Mac install instructions after the uninstall instructions so the "After Installing" Info box comes after installing.

These technologies are not in my wheelhouse so comments/edits are welcome.

[preview link](https://sandbox-git-nrf52-driver-pdxlocations.vercel.app/docs/getting-started)