### PR TITLE
nRF52 Flashing Methods Documentation Update

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/index.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/index.mdx
@@ -10,7 +10,7 @@ sidebar_position: 2
 The nRF52 based devices have the easiest firmware upgrade process. No driver or software install is required on any platform.
 
 ### Drag & Drop
-The [Drag & Drop](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop) firmware installation method is considered the "manual process" and recommended as the easiest solution.
+nRF52 devices use the [Drag & Drop](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop) installation method to install firmware releases.
 
 ### Factory Erase
 You may wish to perform a [Factory Erase](/docs/getting-started/flashing-firmware/nrf52/nrf52-erase) prior to installing firmware to clear data that may change format and location between releases.

--- a/docs/getting-started/flashing-firmware/nrf52/index.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/index.mdx
@@ -16,4 +16,4 @@ The [Drag & Drop](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop) fir
 You may wish to perform a [Factory Erase](/docs/getting-started/flashing-firmware/nrf52/nrf52-erase) prior to installing firmware to clear data that may change format and location between releases.
 
 ### Convert RAK4631-R to RAK4631
-If your device did not come with the Arduino bootloader you will need to [perform the conversion](/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r)
+If your device did not come with the Arduino bootloader you will need to [perform the conversion](/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r).

--- a/docs/getting-started/flashing-firmware/nrf52/index.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/index.mdx
@@ -9,4 +9,11 @@ sidebar_position: 2
 
 The nRF52 based devices have the easiest firmware upgrade process. No driver or software install is required on any platform.
 
-1. The [Drag & Drop](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop) firmware installation method is considered the "manual process" and recommended as the easiest solution.
+### Drag & Drop
+The [Drag & Drop](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop) firmware installation method is considered the "manual process" and recommended as the easiest solution.
+
+### Factory Erase
+You may wish to perform a [Factory Erase](/docs/getting-started/flashing-firmware/nrf52/nrf52-erase) prior to installing firmware to clear data that may change format and location between releases.
+
+### Convert RAK4631-R to RAK4631
+If your device did not come with the Arduino bootloader you will need to [perform the conversion](/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r)


### PR DESCRIPTION
This PR Addresses:

1. Index file only links to one of the sub-topics
2. Ordered list has only one option
3. nRF really only has one supported flashing method (drag & drop)

I like linking to the Factory Erase page here since it is good practice and might be missed otherwise.  Might as well add the RAK4631-R conversion here.  Most index pages link to all sub-topics.  I left out the now unsupported gui flasher method as that page would be entirely removed with #692 

[preview link](https://sandbox-git-nrf52-erase-pdxlocations.vercel.app/docs/getting-started/flashing-firmware/nrf52/)