### PR TITLE
Network config documentation updates

### DIFF
--- a/docs/configuration/device-config/network.mdx
+++ b/docs/configuration/device-config/network.mdx
@@ -8,7 +8,7 @@ sidebar_label: Network
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-The Network config options are: WiFi Enabled, WiFi SSID, WiFi PSK, Ethernet Enabled, IPv4 Networking Mode, Static Address and NTP Server. Network config uses an admin message sending a `Config.Network` protobuf.
+The Network config options are: NTP Server, WiFi Enabled, WiFi SSID, WiFi PSK, Ethernet Enabled, IPv4 Networking Mode, and Static Address. Network config uses an admin message sending a `Config.Network` protobuf.
 
 :::info
 Enabling WiFi will disable Bluetooth. Only one connection method will work at a time.

--- a/docs/configuration/device-config/network.mdx
+++ b/docs/configuration/device-config/network.mdx
@@ -32,13 +32,13 @@ Set to `false` (Disabled) by default.
 
 ### WiFi SSID
 
-This is your WiFi Networks SSID.
+This is your WiFi Network's SSID.
 
 Empty `""` by default. (Case Sensitive, Max Length: 33)
 
 ### WiFi PSK
 
-This is your WiFi Networks password.
+This is your WiFi Network's password.
 
 Empty `""` by default. (Case Sensitive, Max Length: 64)
 
@@ -106,8 +106,10 @@ All Network config options are available in the python CLI.
 | :------------------: | :---------------: | :--------------: |
 |  network.ntp_server  |      string       | `0.pool.ntp.org` |
 | network.wifi_enabled |  `true`, `false`  |     `false`      |
-|   network.wifi_psk   |      string       |       `""`       |
 |  network.wifi_ssid   |      string       |       `""`       |
+|   network.wifi_psk   |      string       |       `""`       |
+| network.eth_enabled  |  `true`, `false`  |     `false`      |
+| network.address_mode | `DHCP`, `STATIC`  |      `DHCP`      |
 
 :::tip
 

--- a/docs/configuration/device-config/network.mdx
+++ b/docs/configuration/device-config/network.mdx
@@ -89,7 +89,8 @@ Network Config options are available for Android.
 
 :::info
 
-Network config is not available on Apple OS's.
+Network config options are available on iOS, iPadOS and macOS.
+
 :::
 
 </TabItem>


### PR DESCRIPTION
This PR:
1. Reorders config options to match navigation
2. Adds missing apostrophes
3. Adds `network.eth_enabled` & `network.address_mode` to cli commands

- Omits cli commands `network.ipv4_config` & `network.rsyslog_server` - Do they work?

[preview link](https://sandbox-git-network-config-pdxlocations.vercel.app/docs/settings/config/network)