### PR TITLE
Position Config updates and corrections

### DIFF
--- a/docs/configuration/device-config/position.mdx
+++ b/docs/configuration/device-config/position.mdx
@@ -8,31 +8,31 @@ sidebar_label: Position
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-The position config options are: GPS Enabled, GPS Update Interval, GPS Attempt Time, Fixed Position, Smart Broadcast, Broadcast Interval and Position Packet Flags. Position config uses an admin message sending a `Config.Position` protobuf.
+The position config options are: GPS Enabled, GPS Update Interval, GPS Attempt Time, Fixed Position, Smart Broadcast, Smart Broadcast Minimum Distance, Smart Broadcast Minimum Interval, Broadcast Interval, Position Packet Flags, and GPS RX/TX Pins. Position config uses an admin message sending a `Config.Position` protobuf.
 
 Position data from GPS is provided by either the radio or your paired phone. Position data is not required to use Meshtastic but time calculations require at least one device on the mesh have either a GPS or internet connection for time.
 
 ## Position Config Values
 
-### GPS Disabled
+### GPS Enabled
 
 Acceptable values: `true` or `false`
 
-Defaults to false. Should the device GPS be disabled for this node?
+Defaults to true. Enables GPS on the node.
 
 ### GPS Update Interval
 
-How often should we try to get GPS position (in seconds), or zero for the default of once every 30 seconds, or a very large value (maxint) to update only once at boot.
+How often we should try to get GPS position (in seconds), or zero for the default of once every 2 minutes, or a very large value (maxint) to update only once at boot.
 
 ### GPS Attempt Time
 
-How long should we try to get our position during each GPS update interval attempt? (in seconds) Or if zero, use the default of 30 seconds.
+How long should we try to get our position during each GPS update interval attempt? (in seconds) Or if zero, use the default of 15 minutes.
 
 ### Fixed Position
 
 Acceptable values: `true` or `false`
 
-Off by default
+True by default
 
 If set, this node is at a fixed position. The device will generate GPS updates at the regular GPS update interval, but use whatever the last lat/lon/alt it saved for the node. The lat/lon/alt can be set by an internal GPS or with the help of the mobile device's GPS.
 
@@ -40,7 +40,7 @@ If set, this node is at a fixed position. The device will generate GPS updates a
 
 Acceptable values: `true` or `false`
 
-On by default
+True by default
 
 Smart broadcast will send out your position at an increased frequency only if your location has changed enough for a position update to be useful.
 
@@ -48,17 +48,29 @@ Smart broadcast complements broadcast interval (doesn't override that setting) b
 
 Smart broadcast will calculate an ideal position update interval based on the data rate of your selected channel configuration.
 
+### Smart Broadcast Minimum Distance
+
+Default of `0` is 100 meters
+
+The minimum distance in meters traveled (since the last send) before we can send a position to the mesh if smart broadcast is enabled.
+
+### Smart Broadcast Minimum Interval
+
+Default of `0` is 30 seconds
+
+The minimum number of seconds (since the last send) before we can send a position to the mesh if smart broadcast is enabled.
+
 ### Broadcast Interval
 
 Default of `0` is 15 minutes
 
-If smart broadcast is of we should send our position this often (but only if it has changed significantly)
+If smart broadcast is off we should send our position this often (but only if it has changed significantly)
 
-The GPS updates will be sent out every Broadcast Interval, with either the actual GPS location, or an empty location if no GPS fix was achieved. This defaults to broadcast every 15 minutes.
+The GPS updates will be sent out every Broadcast Interval, with either the actual GPS location, or an empty location if no GPS fix was achieved.
 
 ### Position Flags
 
-Bit field of boolean configuration options for POSITION messages (bitwise OR of PositionFlags)
+Defines which options are sent in POSITION messages. Values are stored as a bit field of boolean configuration options (bitwise OR of PositionFlags).
 
 |       Value        |                           Description                            |
 | :----------------: | :--------------------------------------------------------------: |
@@ -116,17 +128,19 @@ All Position config commands are available in the python CLI. Example commands a
 
 :::
 
-|                  Setting                  |                                                             Acceptable Values                                                             |           Default            |
-| :---------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------: |
-|           position.gps_enabled            |                                                              `true`, `false`                                                              |            `true`            |
-|       position.gps_update_interval        |                                                            `integer` (seconds)                                                            |  Default `0` is 30 Seconds   |
-|         position.gps_attempt_time         |                                                            `integer` (seconds)                                                            | Default of `0` is 30 Seconds |
-|          position.fixed_position          |                                                              `true`, `false`                                                              |           `false`            |
-| position.position_broadcast_smart_enabled |                                                              `true`, `false`                                                              |            `true`            |
-|     position.position_broadcast_secs      |                                                            `integer` (seconds)                                                            | Default of `0` is 15 Minutes |
-|              position.flags               | `UNSET`, `ALTITUDE`, `ALTITUDE_MSL`, `GEOIDAL_SEPARATION`, `DOP`, `HVDOP`, `PDOP`, `SATINVIEW`, `SEQ_NO`, `TIMESTAMP`, `HEADING`, `SPEED` |           `UNSET`            |
-|             position.rx_gpio              |                                                             `integer` (0-39)                                                              |           `UNSET`            |
-|             position.tx_gpio              |                                                             `integer` (0-34)                                                              |           `UNSET`            |
+|                  Setting                     |                                                             Acceptable Values                                                             |           Default            |
+| :------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------: |
+|             position.gps_enabled             |                                                              `true`, `false`                                                              |            `true`            |
+|         position.gps_update_interval         |                                                            `integer` (seconds)                                                            |  Default `0` is 2 Minutes    |
+|           position.gps_attempt_time          |                                                            `integer` (seconds)                                                            | Default of `0` is 15 Minutes |
+|            position.fixed_position           |                                                              `true`, `false`                                                              |           `false`            |
+|  position.position_broadcast_smart_enabled   |                                                              `true`, `false`                                                              |            `true`            |
+|  position.broadcast_smart_minimum_distance   |                                                             `integer` (meters)                                                            | Default of `0` is 100 Meters |
+|position.broadcast_smart_minimum_interval_secs|                                                            `integer` (seconds)                                                            | Default of `0` is 15 Minutes |
+|       position.position_broadcast_secs       |                                                            `integer` (seconds)                                                            | Default of `0` is 30 Seconds |
+|                position.flags                | `UNSET`, `ALTITUDE`, `ALTITUDE_MSL`, `GEOIDAL_SEPARATION`, `DOP`, `HVDOP`, `PDOP`, `SATINVIEW`, `SEQ_NO`, `TIMESTAMP`, `HEADING`, `SPEED` |           `UNSET`            |
+|               position.rx_gpio               |                                                             `integer` (0-39)                                                              |           `UNSET`            |
+|               position.tx_gpio               |                                                             `integer` (0-34)                                                              |           `UNSET`            |
 
 :::tip
 


### PR DESCRIPTION
This PR:

1. Adds `broadcast_smart_minimum_distance` & `broadcast_smart_minimum_interval_secs` to descriptions and cli
2. Updates default values for `gps_attempt_time` & `gps_update_interval`
3. Corrects setting `GPS disabled` to `GPS enabled`
4. Fix grammar and typos
5. Clarify Position Flags

[preview link](https://sandbox-git-position-config-pdxlocations.vercel.app/docs/settings/config/position)