### PR TITLE
Add missing option from power documentation summary

### DIFF
--- a/docs/configuration/device-config/power.mdx
+++ b/docs/configuration/device-config/power.mdx
@@ -13,7 +13,7 @@ import calculateADC from "/src/utils/calculateADC";
 Power settings are advanced configuration, most users should choose a role under [Device Config](/docs/settings/config/device) to manage power for their device and shouldn't ever need to adjust these settings.
 :::
 
-The power config options are: Power Saving, Shutdown after losing power, ADC Multiplier Override, Wait Bluetooth Interval, Mesh Super Deep Sleep Timeout, Super Deep Sleep Interval, Light Sleep Interval, and Minimum Wake Interval. Power config uses an admin message sending a `Config.Power` protobuf.
+The power config options are: Power Saving, Shutdown after losing power, ADC Multiplier Override, Wait Bluetooth Interval, Mesh Super Deep Sleep Timeout, Super Deep Sleep Interval, Light Sleep Interval, Minimum Wake Interval, and Device Battery INA2xx Address. Power config uses an admin message sending a `Config.Power` protobuf.
 
 :::info
 ADC Multiplier, Super Deep Sleep, and Light Sleep settings only apply to ESP32-based boards.  These settings will have no effect on nRF52 modules.


### PR DESCRIPTION
This PR adds missing option "Device Battery INA-2xx Address" from page summary.

[preview link](https://sandbox-git-power-config-pdxlocations.vercel.app/docs/settings/config/power)