### PR TITLE
fix cli ls_secs default value

### DIFF
--- a/docs/configuration/device-config/power.mdx
+++ b/docs/configuration/device-config/power.mdx
@@ -176,7 +176,7 @@ All Power config options are available in the python CLI.
 |      power.wait_bluetooth_secs       |     `integer` (seconds)      |     Default of `0` is 1 minute      |
 |     power.mesh_sds_timeout_secs      |     `integer` (seconds)      |      Default of `0` is 2 hours      |
 |            power.sds_secs            |     `integer` (seconds)      |      Default of `0` is 1 year       |
-|            power.ls_secs             |     `integer` (seconds)      |      Default of `0` is 1 hour       |
+|            power.ls_secs             |     `integer` (seconds)      |      Default of `0` is 5 minutes    |
 |         power.min_wake_secs          |     `integer` (seconds)      |    Default of `0` is 10 seconds     |
 | power.device_battery_ina_address     | `integer` (I2C address as decimal)     |  Default of `0` is no address set   |
 


### PR DESCRIPTION
This PR fixes the default value of power.ls_secs in the cli table.
[preview link](https://sandbox-git-power-config-02-pdxlocations.vercel.app/docs/settings/config/power)