### PR TITLE
Replace note about DMs on primary channel by periodic broadcasts

### DIFF
--- a/docs/configuration/device-config/channels.mdx
+++ b/docs/configuration/device-config/channels.mdx
@@ -48,7 +48,7 @@ Each channel is assigned one of 3 roles:
 1. `PRIMARY` or `1`
    - This is the first channel that is created for you on initial setup.
    - Only one primary channel can exist and can not be disabled.
-   - Direct messages are only available on this channel.
+   - Periodic broadcasts like position and telemetry are only sent over this channel.
 2. `SECONDARY` or `2`
    - Can modify the encryption key (PSK).
 3. `DISABLED` or `0`


### PR DESCRIPTION
DMs can now also be sent over secondary channels, while I could not find where it was noted that periodic broadcasts are only sent out over the primary channel.