### PR TITLE
Clarify Android OTA availability for Rak Devices 

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/ota.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/ota.mdx
@@ -21,10 +21,8 @@ values={[
 <TabItem value="android">
 
 :::info
-As of this writing, the current Android release of the nRF DFU app (v2.3.0) is not compatible with Meshtastic firmware updates.
+As of this writing, the current Android release of the nRF DFU app (v2.3.0) is not compatible with Meshtastic firmware updates. OTA firmware updates are available for Android using an older release of the more advanced nRF Connect App __version 4.24.3__ which is available for download from the [Nordic Semiconductor GitHub page](https://github.com/NordicSemiconductor/Android-nRF-Connect/releases/tag/v4.24.3).
 :::
-
-OTA firmware updates are available for Android using an older release of the more advanced nRF Connect App __version 4.24.3__ which is available for download from the [Nordic Semiconductor GitHub page](https://github.com/NordicSemiconductor/Android-nRF-Connect/releases/tag/v4.24.3).
 
 1. Download the firmware release you wish to install from the [Meshtastic Download Page](/downloads) or [Meshtastic GitHub](https://github.com/meshtastic/firmware/releases).
 2. Unzip the firmware folder


### PR DESCRIPTION
This PR moves text that OTA is available into the INFO box
[preview link](https://sandbox-git-rak-ota-pdxlocations.vercel.app/docs/getting-started/flashing-firmware/nrf52/ota)