### PR TITLE
Update core-modules.mdx

### DIFF
--- a/docs/hardware/devices/rak/core-modules.mdx
+++ b/docs/hardware/devices/rak/core-modules.mdx
@@ -15,27 +15,26 @@ groupId="rakcore"
 defaultValue="RAK4631"
 values={[
 {label: 'RAK4631', value: 'RAK4631'},
-{label: 'RAK11200', value: 'RAK11200'}
+{label: 'RAK11200', value: 'RAK11200'},
+{label: 'RAK11310', value: 'RAK11310'}
 ]}>
 
 <TabItem value="RAK4631">
 
-### RAK4631
+## RAK4631 - nRF52
 
 :::info
 Please be aware of the difference between the RAK4631 (Arduino bootloader) and the RAK4631-R (RUI3 bootloader). Meshtastic requires the Arduino bootloader. If you have a RAK4631-R, please see the [instructions for converting the bootloader](/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r).
 :::
 
-- [RAK4631](https://store.rakwireless.com/products/rak4631-lpwan-node?variant=37505443856582)
+- [RAK4631]
   - **MCU**
     - nRF52840
       - Bluetooth BLE 5.0
       - Very low power consumption
-  - **Meshtastic Firmware**
-    - [`firmware-rak4631-2.X.X.xxxxxxx.uf2`](/downloads)
-  - **LoRa transceiver**
+  - **LoRa Transceiver:**
     - SX1262
-  - **Frequency Options**
+  - **Frequency Options:**
     - 433 MHz
     - 470 MHz
     - 799 MHz
@@ -44,12 +43,16 @@ Please be aware of the difference between the RAK4631 (Arduino bootloader) and t
     - 915 MHz
     - 920 MHz
     - 923 MHz
-  - **Connectors**
-    - U.FL antenna
+  - **Connectors:**
+    - U.FL/IPEX antenna connector for LoRa
 
-Further information on the RAK4631 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Overview/#product-description).
+### RAK4631 Resources
 
-US Distributor - Purchase link: [Rokland - US915 Mhz](https://store.rokland.com/products/rak-wireless-rak4631-nordic-nrf52840-ble-core-module-for-lorawan-with-lora-sx1262)
+- Firmware file: `firmware-rak4631-X.X.X.xxxxxxx.uf2`
+- Further information on the RAK4631 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Overview/#product-description).
+- US Distributor - Purchase link: [Rokland - US915 Mhz](https://store.rokland.com/products/rak-wireless-rak4631-nordic-nrf52840-ble-core-module-for-lorawan-with-lora-sx1262)
+- Purchase Link: [RAK Wireless Store](https://store.rakwireless.com/products/rak4631-lpwan-node?variant=37505443856582)
+- Purchase Link: [RAK Wireless Aliexpress](https://www.aliexpress.us/item/3256801470104151.html)
 
 <img
   alt="RAK4631 Core Module"
@@ -60,29 +63,53 @@ US Distributor - Purchase link: [Rokland - US915 Mhz](https://store.rokland.com/
 </TabItem>
 <TabItem value="RAK11200">
 
-### RAK11200 / RAK13300
+## RAK11200 - ESP32
 
-:::caution Note
-Only supported on the RAK5005-O / RAK19007 and the RAK19001 base board.
+:::info
+Only supported on the RAK5005-O / RAK19007 and the RAK19001 base boards.
 :::
 
 The RAK11200 does not contain a LoRa transceiver, and thus needs to be added separately in the form of the [RAK13300 LPWAN module](https://store.rakwireless.com/products/rak13300-wisblock-lpwan). This occupies the IO Port of the base board.
 
-- [RAK11200](https://store.rakwireless.com/products/wiscore-esp32-module-rak11200)
-  - **MCU**
+- RAK11200
+  - **MCU:**
     - ESP32-WROVER
       - Bluetooth 4.2
       - WiFi 802.11 b/g/n
       - High power consumption (relative to nRF52)
-  - **Meshtastic Firmware**
-    - [`firmware-rak11200-2.X.X.xxxxxx.bin`](/downloads)
 
-Further information on the RAK11200 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK11200/Overview/#product-description).
+### RAK11200 Resources
 
-- [RAK13300](https://store.rakwireless.com/products/rak13300-wisblock-lpwan)
-  - **LoRa transceiver**
+- Firmware file: `firmware-rak11200-X.X.X.xxxxxxx.bin`
+- Further information on the RAK11200 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK11200/Overview/#product-description).
+- Purchase Link: [RAK Wireless Store](https://store.rakwireless.com/products/wiscore-esp32-module-rak11200)
+- Purchase Link: [RAK Wireless Aliexpress](https://www.aliexpress.us/item/3256802312474717.html)
+
+<img
+  alt="RAK4631 5005 11200"
+  src="/img/hardware/rak11200.jpg"
+  style={{ zoom: "50%" }}
+/>
+
+</TabItem>
+
+<TabItem value="RAK11310">
+
+## RAK13310 - RP2040
+
+:::info
+
+**Please note, this core module does include BLE/WiFi.**
+
+:::
+
+  - **MCU:**
+    - Raspberry Pi RP2040
+      - Dual M0+ Core
+      - 133MHz CPU Clock
+  - **LoRa Transceiver:**
     - SX1262
-  - **Frequency Options**
+  - **Frequency Options:**
     - 433 MHz
     - 470 MHz
     - 864 MHz
@@ -91,16 +118,15 @@ Further information on the RAK11200 can be found on the [RAK Documentation Cente
     - 915 MHz
     - 920 MHz
     - 923 MHz
-  - **Connectors**
-    - U.FL antenna
+  - **Connectors:**
+    - U.FL/IPEX antenna connector for LoRa
 
-Further information on the RAK13300 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK13300/Overview/#product-description).
+### RAK11310 Resources
 
-<img
-  alt="RAK4631 5005 11200"
-  src="/img/hardware/rak11200.jpg"
-  style={{ zoom: "50%" }}
-/>
+- Firmware file: `firmware-rak11310-X.X.X.xxxxxxx.uf2`
+- Further information on the RAK13300 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK13300/Overview/#product-description).
+- Purchase Link: [RAK Wireless Store](https://store.rakwireless.com/products/rak11310-wisblock-lpwan-module)
+- Purchase Link: [RAK Wireless Aliexpress](https://www.aliexpress.us/item/3256803225175784.html)
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
What this PR does:
- Breaks out 11200/11300 (11310)
- Updates 11300 to 11310, adds information about device, includes a note for no BLE.
- Adds clarification of each device's MCU via header so it's more prominent. 
- Formatting updates.