### PR TITLE
Remove Outdated Info

### DIFF
--- a/docs/hardware/devices/rak/index.mdx
+++ b/docs/hardware/devices/rak/index.mdx
@@ -18,7 +18,7 @@ If you wish to purchase parts separately, you will need a [WisBlock Base Board](
 
 You can optionally purchase peripherals such as a GPS module, Screen, Sensor, or other various modules.
 
-Please see the RAK documentation for the correct way to connect your hardware to ensure that you do not damage the device. There is currently no pin required to pair RAK devices via BLE.
+Please see the RAK documentation for the correct way to connect your hardware to the baseboard to ensure that you do not damage the device.
 
 ## Resources
 


### PR DESCRIPTION
Removes reference to no BLE pin being required. 