### PR TITLE
Add two padding bytes to Packet Header

### DIFF
--- a/docs/about/overview/mesh-alg.mdx
+++ b/docs/about/overview/mesh-alg.mdx
@@ -36,7 +36,8 @@ This layer is conventional non-reliable LoRa packet transmission. A packet gener
 |  0x08  |                 4 bytes                  | Integer | Packet Header: The sending node's unique packet ID for this packet.                      |
 |  0x0C  |                  1 byte                  |  Bits   | Packet Header: Flags. See the [header flags](#packet-header-flags) for usage.            |
 |  0x0D  |                  1 byte                  |  Bits   | Packet Header: Channel hash. Used as hint for decryption for the receiver.               |
-|  0x0E  | Max. 237 bytes (excl. protobuf overhead) |  Bytes  | Actual packet data. Unused bytes are not transmitted.                                    |
+|  0x0E  |                 2 bytes                  |  Bytes  | Packet Header: Padding for memory alignment.                                             |
+|  0x10  | Max. 237 bytes (excl. protobuf overhead) |  Bytes  | Actual packet data. Unused bytes are not transmitted.                                    |
 
 #### Packet Header Flags
 


### PR DESCRIPTION
Although the Packet Header contains only 14 bytes of useful data, `sizeof(PacketHeader)` gives 16, meaning there are 2 padding bytes at the end.