### PR TITLE
Web API missing from community apps index page

### DIFF
--- a/docs/software/community/index.mdx
+++ b/docs/software/community/index.mdx
@@ -11,5 +11,6 @@ Current community projects:
 
 - [ATAK (Android Team Awareness Kit) Forwarder](/docs/software/community/community-atak) - An ATAK plugin for forwarding CoT messages via a hardware layer which supports Meshtastic devices.
 - [Meshtasticator (Simulator)](/docs/software/community/community-meshtasticator) - Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software.
+- [Meshtastic Web API](/docs/software/community/meshtastic-web-api) - Meshtastic Web API provides a RESTful interface to interact with a Meshtastic node via a serial connection.
 
 Support for these projects should be sought from their respective authors.


### PR DESCRIPTION
This PR adds Web API to the Community Apps index page.
[preview link](https://sandbox-git-add-web-api-to-index-pdxlocations.vercel.app/docs/software/community)