### PR TITLE
HTTP API links

### DIFF
--- a/docs/development/device/http-api.mdx
+++ b/docs/development/device/http-api.mdx
@@ -90,7 +90,7 @@ A reference client written in JavaScript will provide a JavaScript API for using
 
 ### Protoman
 
-See: [https://github.com/spluxx/Protoman]
+See: https://github.com/spluxx/Protoman
 
 Protoman is able to interface with the Meshtastic REST API out of the box. This is useful for manual testing of the endpoints.
 
@@ -100,4 +100,4 @@ HTTP and HTTPS are both supported on the ESP32 using self signed certificates on
 
 ## Related documents
 
-- Interesting slide pack on the concept: [https://www.slideshare.net/mokeefe/javaone-2009-ts5276-restful-protocol-buffers]
+- Interesting slide pack on the concept: https://www.slideshare.net/mokeefe/javaone-2009-ts5276-restful-protocol-buffers


### PR DESCRIPTION
Fixin' a couple of missing links.
[preview](https://sandbox-git-http-api-pdxlocations.vercel.app/docs/development/device/http-api)