### PR TITLE
add --request-telemetry

### DIFF
--- a/docs/software/python-cli/index.mdx
+++ b/docs/software/python-cli/index.mdx
@@ -306,7 +306,16 @@ meshtastic --sendping
 Traceroute from connected node to a destination. You need pass the destination ID as an argument. Only nodes that have the encryption key can be traced.
 
 ```shell title="Usage"
-meshtastic --traceroute 'ba4bf9d0'
+meshtastic --traceroute '!ba4bf9d0'
+```
+
+### --request-telemetry
+
+Request telemetry from a node. You need to pass the destination ID as an argument with '--dest'. For repeaters, the nodeNum is required.
+
+```shell title="Usage"
+meshtastic --request-telemetry --dest '!ba4bf9d0'
+meshtastic --request-telemetry --dest 1828779180
 ```
 
 ### --ack


### PR DESCRIPTION
This PR adds --request-telemetry to the CLI docs
It also adds a missing exclamation mark in the --traceroute example
[preview link](https://sandbox-git-add-request-telemetry-to-cli-pdxlocations.vercel.app/docs/software/python/cli#--traceroute-traceroute)