### PR TITLE
Add offline maps heading to Android usage

### DIFF
--- a/docs/software/android/usage.mdx
+++ b/docs/software/android/usage.mdx
@@ -152,6 +152,8 @@ The Map tab will show a local map with an icon for each active mesh node that ha
 
 - Clicking the layers icon in the top-right will allow you to select the map type.
 
+### Offline maps
+
 [![Download offline maps](/img/android/android-map-download-c.png)](/img/android/android-map-download.png)
 
 - Some map types allow downloading for offline use.  If offline maps are available for your selected map type, a download icon will appear in the bottom-right corner of the map.  Tap this icon and choose the option to Download Region, then select the area you wish to download.


### PR DESCRIPTION
Just a quick header for the offline maps section of the Android usage page so folks can locate it easier.
Helps with #687 