### PR TITLE
Remove speculation in http-api

### DIFF
--- a/docs/development/device/http-api.mdx
+++ b/docs/development/device/http-api.mdx
@@ -42,7 +42,7 @@ A `PUT` request to this endpoint will be expected to contain a series of ToRadio
 
 The protobufs will be sent in binary as the body for the request.
 
-For the initial implementation, only one ToRadio message per request is supported, but future optimizations to improve throughput might add support for multiple ToRadios in a single request.
+Only one ToRadio message per request is supported.
 
 #### OPTIONS
 
@@ -76,9 +76,7 @@ The protobufs will be sent in binary as the body for the request.
 
 ## Authentication
 
-The initial release will not have **any** user authentication. We assume access to the HTTP server is enough to establish trust.
-
-Since authentication is also eventually needed for our other transports (TCP and eventually open BLE), we will be adding authentication **in-band**. When added in the second release there will be a new payload supported inside ToRadio for `SignIn <userid> <usersecret>`. The server will respond with a FromRadio `SignInResponse okay|fail`. Also, in the case of the REST API, that SignIn status will then be associated with the current session key. Most (all?) ToRadio packets will be ignored if the client is not signed in. Most (all?) FromRadio packets will be sent to clients that are not signed in.
+There isn't **any** user authentication. We assume access to the HTTP server is enough to establish trust.
 
 ## Client
 


### PR DESCRIPTION
This PR removes references to future enhancements in the http-api development documentaion
[preview link](https://sandbox-git-web-api-speculation-pdxlocations.vercel.app/docs/development/device/http-api)