### PR TITLE
Add Official ATAK Plugin

### DIFF
--- a/docs/software/integrations/atak-plugin.mdx
+++ b/docs/software/integrations/atak-plugin.mdx
@@ -1,0 +1,28 @@
+---
+id: integrations-atak-plugin
+title: ATAK Plugin
+sidebar_label: ATAK Plugin
+sidebar_position: 2
+---
+
+## Official Meshtastic ATAK Plugin
+
+Meshtastic can integrate with ATAK on Android using the [Official ATAK Plugin.](https://github.com/meshtastic/ATAK-Plugin)
+
+### Introduction
+
+The ATAK plugin does not permit any Meshtastic configuration. The plugin does three things:
+
+1. Bind to the IMeshService provided by the Meshtastic Android App in order to send.
+2. Intercept all outgoing ATAK CoT via the ATAK "PreSendProcessor" Interface and send them to the IMeshService.
+3. Listen for broadcasts from the Meshtastic Android App regarding ATAK_FORWARDER portnum packets.
+
+The current iteration works very well for ATAK CoT that fit within the 200ish byte range (after we shrink via libcotshirnk) because they fit into a single DataPacket.
+
+### Instructions
+
+1. Use the Meshtastic Android App on all party's devices, and ensure they can talk to their local LoRa radio. Confirm they are able to achieve basic text messaging using the App.
+
+2. With the Meshtastic Android App running in the background (to ensure the IMeshService is alive), launch ATAK (with the Meshtastic ATAK-Plugin installed or install it once ATAK is running) and you should observe a green Meshtastic icon in the bottom right. If the icon is red, then the plugin was not able to bind to the IMeshService provided by the Meshtastic Android App. If this is the case, check to ensure the Meshtastic Android App is functioning. The plugin will reconnect after a failed bind without restarting ATAK.
+
+3. ATAK PLI and simple map markers will fit within the "small send" DataPackets. Sending larger CoT such as freestyle map drawings or GeoChats will fragment and take longer to send.  Don't try to send a bunch without waiting for the previous one to complete.

--- a/docs/software/integrations/index.mdx
+++ b/docs/software/integrations/index.mdx
@@ -11,4 +11,6 @@ Current Meshtastic integrations:
 
 - [CalTopo / SARTopo](/docs/software/integrations/integrations-caltopo) - Track Meshtastic nodes in CalTopo and SARTopo.
 
+- [ATAK Plugin](/docs/software/integrations/integrations-atak-plugin) - Official Meshtastic ATAK Plugin for sending CoT to IMeshService in the Meshtastic Android app.
+
 Support for the integrated products should be sought from their respective authors or vendors.


### PR DESCRIPTION
This PR adds a page for the Official ATAK Plugin and a link from the Integrations Index
[preview link](https://sandbox-git-atak-plugin-pdxlocations.vercel.app/docs/software/integrations)