### PR TITLE
Smallerize images in MQTT walkthrough

### DIFF
--- a/docs/configuration/module-config/mqtt.mdx
+++ b/docs/configuration/module-config/mqtt.mdx
@@ -130,8 +130,6 @@ All MQTT module config options are available for the Web UI.
   </TabItem>
 </Tabs>
 
-
-
 ## Connect to the Default Public Server
 
 <Tabs
@@ -149,11 +147,11 @@ values={[
 
 Navigate to: Vertical Ellipsis (3 dots top right) > Radio configuration > MQTT: Turn on the slider for **MQTT enabled** and tap **Send**.
 
-[![MQTT Settings](/img/modules/mqtt/android_mqtt_sm.png)](/img/modules/mqtt/android_mqtt.png)
+[<img src="/img/modules/mqtt/android_mqtt_sm.png" style={{zoom:'40%'}} />](/img/modules/mqtt/android_mqtt.png)
 
 *Optional:* To use your phone's internet connection to send and receive packets over the web, also enable the slider for **MQTT Client Proxy** and skip the Configure Network Settings step below.
 
-[![Client Proxy](/img/modules/mqtt/android_mqtt_proxy_sm.png)](/img/modules/mqtt/android_mqtt_proxy.png)
+[<img src="/img/modules/mqtt/android_mqtt_proxy_sm.png" style={{zoom:'40%'}} />](/img/modules/mqtt/android_mqtt_proxy.png)
 
 :::caution
 
@@ -165,13 +163,13 @@ Though this option may be visible in your UI, Client Proxy is not yet functional
 
 Navigate to: Vertical Ellipsis (3 dots top right) > Radio configuration > Channels > LongFast: Turn on the sliders for **Uplink enabled** and **Downlink enabled**, then tap **Save** and tap **Send**.
 
-[![Channel Settings](/img/modules/mqtt/android_channel_sm.png)](/img/modules/mqtt/android_channel.png)
+[<img src="/img/modules/mqtt/android_channel_sm.png" style={{zoom:'40%'}} />](/img/modules/mqtt/android_channel.png)
 
 <h3>3. Configure Network Settings</h3>
 
 Navigate to: Vertical Ellipsis (3 dots top right) > Radio configuration > Network: Turn on the slider for **WiFi enabled**, Enter the **SSID** and **PSK** for your network, then tap **Send**.
 
-[![Network Settings](/img/modules/mqtt/android_network_sm.png)](/img/modules/mqtt/android_network.png)
+[<img src="/img/modules/mqtt/android_network_sm.png" style={{zoom:'40%'}} />](/img/modules/mqtt/android_network.png)
 
 </TabItem>
 <TabItem value="apple">
@@ -180,24 +178,26 @@ Navigate to: Vertical Ellipsis (3 dots top right) > Radio configuration > Networ
 
 Navigate to Settings > MQTT: Turn on the slider for MQTT enabled and tap **Save**
 
-[![MQTT Settings 1](/img/modules/mqtt/apple_mqtt_1_sm.png)](/img/modules/mqtt/apple_mqtt_1.png)
-[![MQTT Settings 2](/img/modules/mqtt/apple_mqtt_2_sm.png)](/img/modules/mqtt/apple_mqtt_2.png)
+[<img src="/img/modules/mqtt/apple_mqtt_1_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/apple_mqtt_1.png)
+[<img src="/img/modules/mqtt/apple_mqtt_2_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/apple_mqtt_2.png)
+
+
 
 *Optional:* To use your phone's internet connection to send and receive packets over the web, also enable the slider for **MQTT Client Proxy** and skip the Configure Network Settings step below.
 
-[![Client Proxy](/img/modules/mqtt/apple_mqtt_1_proxy_sm.png)](/img/modules/mqtt/apple_mqtt_1_proxy.png)
+[<img src="/img/modules/mqtt/apple_mqtt_1_proxy_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/apple_mqtt_1_proxy.png)
 
 <h3>2. Enable Channel Uplink & Downlink</h3>
 
 Navigate to Settings > Channels > Primary Channel: Turn on the sliders for **Uplink enabled** and **Downlink enabled** - Tap **Save**
 
-[![Channel Settings](/img/modules/mqtt/apple_channel_sm.png)](/img/modules/mqtt/apple_channel.png)
+[<img src="/img/modules/mqtt/apple_channel_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/apple_channel.png)
 
 <h3>3. Configure Network Settings</h3>
 
 Navigate to Settings > Network: Turn on the slider for **WiFi enabled** - Enter your **SSID** and **PSK** for your network - Tap **Save**
 
-[![Network Settings](/img/modules/mqtt/apple_network_sm.png)](/img/modules/mqtt/apple_network.png)
+[<img src="/img/modules/mqtt/apple_mqtt_1_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/apple_mqtt_1_sm.png)
 
 </TabItem>
 <TabItem value="cli">
@@ -240,11 +240,11 @@ meshtastic --set network.wifi_enabled true --set network.wifi_ssid "your network
 
 Navigate to Config > Module Config > MQTT - Turn on the slider for MQTT enabled - Click the **Save** icon.
 
-[![MQTT Settings](/img/modules/mqtt/web_mqtt_sm.png)](/img/modules/mqtt/web_mqtt.png)
+[<img src="/img/modules/mqtt/web_mqtt_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/web_mqtt.png)
 
 *Optional:* To use your client's internet connection to send and receive packets over the web, also enable the slider for **Proxy to Client Enabled** and skip the Configure Network Settings step below.
 
-[![Client Proxy](/img/modules/mqtt/web_mqtt_proxy_sm.png)](/img/modules/mqtt/web_mqtt_proxy.png)
+[<img src="/img/modules/mqtt/web_mqtt_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/web_mqtt.png)
 
 :::caution
 
@@ -257,13 +257,13 @@ Though this option may be visible in your UI, Client Proxy is not yet functional
 
 Navigate to Channels > Primary: Turn on the sliders for **Uplink Enabled** and **Downlink Enabled** - Click the **Save** icon.
 
-[![Channel Settings](/img/modules/mqtt/web_channel_sm.png)](/img/modules/mqtt/web_channel.png)
+[<img src="/img/modules/mqtt/web_channel_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/web_channel.png)
 
 <h3>3. Configure Network Settings</h3>
 
 Navigate to Config > Device Config > Network: Turn on the slider for **Enabled** - Enter your **SSID** and **PSK** for your network - Click the **Save** icon.
 
-[![Network Settings](/img/modules/mqtt/web_network_sm.png)](/img/modules/mqtt/web_network.png)
+[<img src="/img/modules/mqtt/web_network_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/web_network.png)
 
 </TabItem>
 </Tabs>

--- a/docs/configuration/module-config/mqtt.mdx
+++ b/docs/configuration/module-config/mqtt.mdx
@@ -197,7 +197,7 @@ Navigate to Settings > Channels > Primary Channel: Turn on the sliders for **Upl
 
 Navigate to Settings > Network: Turn on the slider for **WiFi enabled** - Enter your **SSID** and **PSK** for your network - Tap **Save**
 
-[<img src="/img/modules/mqtt/apple_mqtt_1_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/apple_mqtt_1_sm.png)
+[<img src="/img/modules/mqtt/apple_network_sm.png" style={{zoom:'50%'}} />](/img/modules/mqtt/apple_network.png)
 
 </TabItem>
 <TabItem value="cli">


### PR DESCRIPTION
The images are just a bit too big.  
Here's a [preview](https://sandbox-git-mqtt-smaller-images-pdxlocations.vercel.app/docs/settings/moduleconfig/mqtt#connect-to-the-default-public-server) of smaller ones