### PR TITLE
add iPad and mac to BLE

### DIFF
--- a/docs/getting-started/initial-config.mdx
+++ b/docs/getting-started/initial-config.mdx
@@ -34,7 +34,7 @@ values={[
 
 - [Android App](/docs/category/android-app)
 - [Web Client](https://client.meshtastic.org)
-- [iOS App](/docs/category/apple-apps)
+- [iOS/iPadOS/macOS App](/docs/category/apple-apps)
 
 </TabItem>
 <TabItem value="network">


### PR DESCRIPTION
This PR adds iPadOS and macOS to BLE Connection options (with iOS)