### PR TITLE
Add USB DFU to RAK4631 Bootloader update

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
@@ -9,6 +9,25 @@ The only difference between the _RAK4631-R_ (RUI3) and the _RAK4631_ (Arduino) i
 
 Meshtastic requires the Arduino bootloader on RAK WisBlock nRF52-based boards. The process of converting the bootloader only needs to be performed once.
 
+Here are two ways to flash the bootloader:
+
+## USB Device Firmware Upgrade (DFU)
+
+1. Install [Python](https://www.python.org/downloads/)
+2. Install [adafruit-nrfutil](https://github.com/adafruit/Adafruit_nRF52_nrfutil)
+   ```shell
+   pip3 install adafruit-nrfutil
+   ```
+3. Download the required bootloader: [WisCore_RAK4631_Board_Bootloader.zip](https://github.com/RAKWireless/WisBlock/releases/download/0.4.2/WisCore_RAK4631_Board_Bootloader.zip)
+4. Connect your RAK device by USB.
+5. Flash the bootloader
+   ```shell
+   adafruit-nrfutil --verbose dfu serial --package ./WisCore_RAK4631_Board_Bootloader.zip  -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+   ```
+6. Continue with the normal [flashing instructions](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop)
+
+## Debugger
+
 This conversion requires the use of either a [DAPLink](https://daplink.io/) or [J-Link](https://www.segger.com/products/debug-probes/j-link/). The most reasonably priced and available is the [RAKDAP1](https://store.rakwireless.com/products/daplink-tool).
 
 1. Install [Python](https://www.python.org/downloads/)


### PR DESCRIPTION
No J-Link cable is needed unless your bootloader is corrupted. Added documention to emphasize using USB DFU as the main bootloader update for RAK4631.

References:
- https://discord.com/channels/867578229534359593/871540140382761020/968759729667051550
- https://forum.rakwireless.com/t/bootloader-fails-to-upgrade-via-ble/4193/4