### PR TITLE
Remote Hardware Module needs Python CLI

### DIFF
--- a/docs/configuration/gpio-peripherals.mdx
+++ b/docs/configuration/gpio-peripherals.mdx
@@ -14,6 +14,8 @@ GPIO access is fundamentally dangerous because invalid options can physically da
 
 ### Supported Operations
 
+Using the [Python CLI](/docs/software/python/cli) it is possible to:
+
 - Set any GPIO
 - Read any GPIO
 - Receive notification of changes in any GPIO


### PR DESCRIPTION
A note to make it clear that this module works through the Python CLI