### PR TITLE
Make opening shared links troubleshooting more prominent

### DIFF
--- a/docs/software/android/usage.mdx
+++ b/docs/software/android/usage.mdx
@@ -82,7 +82,7 @@ The app will generate a new QR code on the screen.  This encodes the channel det
 
 2. If the channel is shared from a file or link using the `Share` button, you can click on the file or link and you need to choose "Open with Meshtastic".
 
-:::info If a QR or URL opens a webpage instead of the APP.
+:::info If a QR or URL opens a webpage instead of the APP or "Open with Meshtastic" is not an option:
 1. Go to Android Settings > Apps > Default apps > Meshtastic > Opening links
 2. Make sure you have in "links/web address": www.meshtastic.org
 3. If you see the option "Open the supported links", make sure it is enabled.

--- a/docs/software/android/usage.mdx
+++ b/docs/software/android/usage.mdx
@@ -82,23 +82,11 @@ The app will generate a new QR code on the screen.  This encodes the channel det
 
 2. If the channel is shared from a file or link using the `Share` button, you can click on the file or link and you need to choose "Open with Meshtastic".
 
-<details>
-  <summary>Troubleshooting shared links: Can't "open with Meshtastic".</summary>
-  <div>
-    <div>
-      If you don't see "Meshtastic" as an option to open the file or link with:
-      <br />
-      1. Go to Android Settings > Apps > Default apps > Meshtastic > Opening
-      links
-      <br />
-      2. Make sure you have in "links/web address": www.meshtastic.org
-      <br />
-      3. If you see the option "Open the supported links", make sure it is
-      enabled.
-      <br />
-    </div>
-  </div>
-</details>
+:::info If a QR or URL opens a webpage instead of the APP.
+1. Go to Android Settings > Apps > Default apps > Meshtastic > Opening links
+2. Make sure you have in "links/web address": www.meshtastic.org
+3. If you see the option "Open the supported links", make sure it is enabled.
+:::
 
 [![Accept new channel](/img/android/android-accept-channel-c.png)](/img/android/android-accept-channel.png)
 


### PR DESCRIPTION
This PR proposes to make the fix more obvious for Android users who scan a QR or use a Meshtastic URL to setup channels but are brought to a webpage instead of the app.  In the current implementation it is easy to miss.
[preview link](https://sandbox-git-android-shared-links-pdxlocations.vercel.app/docs/software/android/usage#join-a-channel)