### PR TITLE
Link to Tips page from LoRa Channel Config

### DIFF
--- a/docs/configuration/device-config/lora.mdx
+++ b/docs/configuration/device-config/lora.mdx
@@ -103,6 +103,10 @@ Defaults to true
 
 This is controlling the actual hardware frequency the radio is transmitting on. A channel number between 1 and NUM_CHANNELS (whatever the max is in the current region). If this is ZERO/UNSET then the rule is "use the old channel name hash based algorithm to derive the channel number".
 
+:::info
+LoRa Channel Configuration should not to be confused with messaging [Channel Configuration](/docs/settings/config/channels). See [Chat Channels VS Lora Modem Channels](/docs/configuration/tips#chat-channels-vs-lora-modem-channels) for further clarification.
+:::
+
 ### Ignore Incoming Array
 
 For testing it is useful sometimes to force a node to never listen to particular other nodes (simulating radio out of range). All nodenums listed in the ignore_incoming array will have packets they send dropped on receive (by router.cpp)


### PR DESCRIPTION
This PR adds an info box with a link to the Tips page to help clarify Channels vs Channels.
[preview link](https://sandbox-git-link-to-info-01-pdxlocations.vercel.app/docs/settings/config/lora#channel-number)