### PR TITLE
fix Android broken links

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,14 @@
     {
       "source": "/docs/settings/config/:path*",
       "destination": "/docs/configuration/radio/:path*"
+    },
+    {
+      "source": "/software/android-too-old",
+      "destination": "/docs/software/android/installation"
+    },
+    {
+      "source": "/docs/software/android/android-installation",
+      "destination": "/docs/software/android/installation"
     }
   ]
 }


### PR DESCRIPTION
redirects old broken links to `android/installation`