### PR TITLE
Redirect links with trailing slash

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,14 @@
       "destination": "/docs/configuration/module"
     },
     {
+      "source": "/docs/settings/",
+      "destination": "/docs/configuration/"
+    },
+    {
+      "source": "/docs/settings/moduleconfig/",
+      "destination": "/docs/configuration/module/"
+    },
+    {
       "source": "/docs/settings/moduleconfig/:path*",
       "destination": "/docs/configuration/module/:path*"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -5,12 +5,24 @@
       "destination": "/docs/configuration"
     },
     {
-      "source": "/docs/settings/moduleconfig",
-      "destination": "/docs/configuration/module"
-    },
-    {
       "source": "/docs/settings/",
       "destination": "/docs/configuration/"
+    },
+    {
+      "source": "/docs/settings/config",
+      "destination": "/docs/configuration/radio"
+    },
+    {
+      "source": "/docs/settings/config/",
+      "destination": "/docs/configuration/radio/"
+    },
+    {
+      "source": "/docs/settings/config/:path*",
+      "destination": "/docs/configuration/radio/:path*"
+    },
+    {
+      "source": "/docs/settings/moduleconfig",
+      "destination": "/docs/configuration/module"
     },
     {
       "source": "/docs/settings/moduleconfig/",
@@ -19,14 +31,6 @@
     {
       "source": "/docs/settings/moduleconfig/:path*",
       "destination": "/docs/configuration/module/:path*"
-    },
-    {
-      "source": "/docs/settings/config",
-      "destination": "/docs/configuration/radio"
-    },
-    {
-      "source": "/docs/settings/config/:path*",
-      "destination": "/docs/configuration/radio/:path*"
     },
     {
       "source": "/docs/hardware/peripheral/",


### PR DESCRIPTION
The PR adds redirects for links with a trailing slash:
https://meshtastic.org/docs/settings/moduleconfig/
https://meshtastic.org/docs/settings/config/
https://meshtastic.org/docs/settings/