### PR TITLE
Erase/Reinstall to update web client

### DIFF
--- a/docs/getting-started/flashing-firmware/esp32/index.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/index.mdx
@@ -14,3 +14,9 @@ The recommended method for firmware flashing is the [Web-Based Installer.](https
 1. The [Web-Based Installer](/docs/getting-started/flashing-firmware/esp32/web-flasher.mdx) requires either Chrome or Edge browsers but is an excellent choice for quickly flashing devices. **This method is highly recommended for firmware flashing, especially for new users of the project, as it is easy to use.**
 2. The [CLI Script](/docs/getting-started/flashing-firmware/esp32/cli-script) is considered the "manual process" for flashing firmware.
 3. Flashing your device using an [external serial adapter](/docs/getting-started/flashing-firmware/esp32/external-serial-adapter) should only be attempted as a last resort if no other method has been successful.
+
+:::info note
+
+The [web client](http://localhost:3000/docs/software/web-client) at meshtastic.local is only updated with an erase/reinstall, not with just an update. If you choose a reinstall, you will get the latest (bundled) web interface.
+
+:::


### PR DESCRIPTION
This PR adds the note: The [web client](http://localhost:3000/docs/software/web-client) at meshtastic.local is only updated with an erase/reinstall, not with just an update. If you choose a reinstall, you will get the latest (bundled) web interface.

[preview link](https://sandbox-git-flash-web-pdxlocations.vercel.app/docs/getting-started/flashing-firmware/esp32/)

from: https://discord.com/channels/867578229534359593/871553714782081024/1156643980168151050