### PR TITLE
Device Config to Radio Config and other corrections

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -252,7 +252,7 @@ Navigate to Channels > Primary: Turn on the sliders for **Uplink Enabled** and *
 
 <h3>3. Configure Network Settings</h3>
 
-Navigate to Config > Device Config > Network: Turn on the slider for **Enabled** - Enter your **SSID** and **PSK** for your network - Click the **Save** icon.
+Navigate to Radio Config > Device > Network: Turn on the slider for **Enabled** - Enter your **SSID** and **PSK** for your network - Click the **Save** icon.
 
 [![Network Settings](/img/modules/mqtt/web_network_sm.png)](/img/modules/mqtt/web_network.png)
 

--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -70,7 +70,7 @@ This option is used to configure the interval (in seconds) that should be used t
 
 Default is `900` seconds (15 minutes).
 
-## Device Config Client Availability
+## Telemetry Config Client Availability
 
 <Tabs
 groupId="settings"

--- a/docs/configuration/radio/bluetooth.mdx
+++ b/docs/configuration/radio/bluetooth.mdx
@@ -115,7 +115,7 @@ meshtastic --set bluetooth.fixed_pin 111111
 All Bluetooth module config options are available for the Web UI.
 
 1. Open the Meshtastic Web UI.
-2. Navigate to: **Device Config > Bluetooth**
+2. Navigate to: **Radio Config > Bluetooth**
 
 :::
 

--- a/docs/configuration/radio/display.mdx
+++ b/docs/configuration/radio/display.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 The display config options are: Screen On Duration, Auto Carousel Interval, Always Point North, GPS Format, Preferred Display Units, OLED Definition, Display Mode, Heading Bold, and Wake on Tap or Motion. Display config uses an admin message sending a `Config.Display` protobuf.
 
-## Device Config Values
+## Display Config Values
 
 ### Screen On Duration
 
@@ -71,7 +71,7 @@ The heading can be hard to read when 'INVERTED' or 'TWOCOLOR' display mode is us
 
 This option enables the ability to wake the device screen when motion, such as a tap on the device, is detected via an attached accelerometer.
 
-## Device Config Client Availability
+## Display Config Client Availability
 
 <Tabs
 groupId="settings"

--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -39,13 +39,13 @@ Meshtastic nodes will rebroadcast all packets if they share [LoRa modem settings
 
 Meshtastic uses the word "channels" to define two different configuration properties: [Messaging Channels](/docs/configuration/radio/channels) & [LoRa Modem Channels](/docs/configuration/radio/lora#channel-number)
 
-### Device Config: Channels
+### Radio Config: Channels
 
 These configure "message groups" and include your PRIMARY and SECONDARY channels.  All SECONDARY channels use the same LoRa modem config as your PRIMARY channel (including LoRa channel number).
 
 There are 8 total chat channels.  Channel 0 is your PRIMARY channel, with channels 1-7 available for private group messaging and/or special channels such as [`admin`](/docs/configuration/remote-admin).
 
-### Device Config: LoRa: Channel Number
+### Radio Config: LoRa: Channel Number
 
 This configures the frequency the radio is set to.  Check out the [frequency calculator](/docs/overview/radio-settings#channel-frequency-calculator) to view the relationship between "channel number" and radio frequency.
 

--- a/docs/software/android/usage.mdx
+++ b/docs/software/android/usage.mdx
@@ -163,7 +163,7 @@ The debug panel allows you to see all packets sent between the application and t
 [![Meshtastic configuration options](/img/android/android-radio-configuration-c.png)](/img/android/android-radio-configuration.png)
 
 Radio Configuration opens a list of all radio and module configuration settings.
-- See [Device Config](/docs/configuration/radio) for radio settings.
+- See [Radio Config](/docs/configuration/radio) for radio settings.
 - See [Module Config](/docs/configuration/module) for module settings.
 - At the end of this list are buttons for Reboot, Shutdown, Factory reset, and NodeDB reset.
 

--- a/docs/software/mqtt/nodered.mdx
+++ b/docs/software/mqtt/nodered.mdx
@@ -20,7 +20,7 @@ Below is a valid JSON envelope for information sent by MQTT to a device for broa
 Node-RED is a free cross-platform programming tool for wiring together hardware, APIs, and online services developed originally by IBM for IOT. It is widely used for home automation by many non-professional programmers and runs well on Pi's. Node-RED has many plug-in modules written by the community. I will use this platform as a practical example on how to interface with the MQTT features of Meshtastic. Everything can be done from GUI's without using command line.
 
 Step one: use http://client.meshtastic.org/ , the python CLI, or an Apple or Android app to connect to your device and adjust these settings.
-Enable and enter network SSID/PSK. Settings--> Device Config--> Network; Save.
+Enable and enter network SSID/PSK. Settings--> Radio Config--> Network; Save.
 Set MQTT server address. Settings--> Module Config--> MQTT config; Verify Encryption Enabled is OFF. Turn JSON Output Enabled ON. Save.
 Go to Channel Editor and set Uplink and Downlink enabled to True. Save. 
 


### PR DESCRIPTION
This PR:
1. Aligns documentation wording with clients by changing Device Config to Radio Config. 
2. Fixes some other things too.

[preview link](https://sandbox-git-radio-config-pdxlocations.vercel.app/docs/introduction)