### PR TITLE
Corrected String lengths for SSID and NTP server name

### DIFF
--- a/docs/configuration/radio/network.mdx
+++ b/docs/configuration/radio/network.mdx
@@ -21,7 +21,7 @@ ESP32 devices have the ability to connect to WiFi as a client. SoftAP mode is no
 
 The NTP server used if IP networking is available.
 
-Set to `0.pool.ntp.org` by default. (Max Length: 33)
+Set to `0.pool.ntp.org` by default. (Max Length: 32)
 
 ### WiFi Enabled
 
@@ -33,7 +33,7 @@ Set to `false` (Disabled) by default.
 
 This is your WiFi Network's SSID.
 
-Empty `""` by default. (Case Sensitive, Max Length: 33)
+Empty `""` by default. (Case Sensitive, Max Length: 32)
 
 ### WiFi PSK
 


### PR DESCRIPTION
According to the source in in /firmware/src/mesh/generated/meshtastic/config.pb.h  the declarations are
char wifi_ssid[33];
char ntp_server[33];
so these variables can hold 32 characters and the terminator \0