### PR TITLE
Firmware Download Mode for S3 Devices 

### DIFF
--- a/docs/hardware/devices/heltec/index.mdx
+++ b/docs/hardware/devices/heltec/index.mdx
@@ -77,9 +77,9 @@ This device may have issues charging a connected battery if utilizing a USB-C to
 
 ### Pin Map
 
-![HTIT-WSL_V3_PIN_MAP](/img/hardware/HTIT-WB32LA(F)_V3.png)
+![HTIT-WSL_V3_PIN_MAP](</img/hardware/HTIT-WB32LA(F)_V3.png>)
 
-Image Source: [Heltec](https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-WB32LA(F)_V3.png)
+Image Source: [Heltec](<https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-WB32LA(F)_V3.png>)
 
 ## Resources
 
@@ -117,6 +117,7 @@ This device may have issues charging a connected battery if utilizing a USB-C to
 - No GPS
 
 ### Meshtastic I2C Definitions
+
 - SCL: GPIO47
 - SDA: GPIO48
 
@@ -157,6 +158,25 @@ This device may have issues charging a connected battery if utilizing a USB-C to
 
 - Onboard 0.96-inch LCD display
 - User and Reset Buttons
+
+## Flashing the Wireless Tracker
+
+If you are having issues flashing the wireless tracker, especially if it's your first attempt, you may need to manually place the device into Espressif's Firmware Download mode. Please follow the process below to do so.
+
+:::warning
+
+Do not proceed unless an antenna is connected to avoid possible damage to the device's radio.
+
+:::
+
+The following process will manually place the device into the Espressif Firmware Download mode:
+
+1. Unplug the device.
+2. Press and hold the USER button.
+3. Plug device in.
+4. After 2-3 seconds, release the USER button.
+
+With the device now in the Espressif Firmware Download mode, you can proceed with flashing using one of the supported flashing methods. It's generally recommended to use the [Web Flasher](https://flasher.meshtastic.org/). You can select "Heltec Wireless Tracker" from the device drop-down.
 
 ## Pin Map
 

--- a/docs/hardware/devices/tbeam/index.mdx
+++ b/docs/hardware/devices/tbeam/index.mdx
@@ -160,8 +160,8 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 </TabItem>
 <TabItem value = "s3core">
 
-  - **MCU**
-  - ESP32-S3 (WiFi & Bluetooth 5LE)
+- **MCU**
+- ESP32-S3 (WiFi & Bluetooth 5LE)
 - **LoRa Transceiver**
   - **Semtech SX1262** (improved performance)
 - **Frequency options**
@@ -174,25 +174,25 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 - **Connectors**
   - USB-C
   - Antenna: U.FL antenna connector
-  
+
 ## Features
-  
+
 - SoftRF preinstalled (flashing to Meshtastic required)
 - Boot and Reset switches
 - Can be used standalone without 'Supreme' daughterboard in a headless configuration
-  
+
 ## Resources
 
-  - Firmware file: `firmware-tbeam-s3-core-X.X.X.xxxxxxx.bin`
-  - Purchase Link: [AliExpress](https://www.aliexpress.com/item/1005005418286231.html)
+- Firmware file: `firmware-tbeam-s3-core-X.X.X.xxxxxxx.bin`
+- Purchase Link: [AliExpress](https://www.aliexpress.com/item/1005005418286231.html)
 
 ![T-Beam S3-Core](/img/hardware/T-BEAM-S3Core.jpg)
 
 </TabItem>
 <TabItem value = "supreme">
 
-  - **MCU**
-  - ESP32-S3 (WiFi & Bluetooth 5LE)
+- **MCU**
+- ESP32-S3 (WiFi & Bluetooth 5LE)
 - **LoRa Transceiver**
   - **Semtech SX1262** (improved performance)
 - **Frequency options**
@@ -205,9 +205,9 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 - **Connectors**
   - USB-C
   - Antenna: U.FL antenna connector
-  
+
 ## Features
-  
+
 - Includes T-Beam S3-Core Module
 - SoftRF preinstalled (flashing to Meshtastic required)
 - Power, Boot and Reset switches
@@ -217,7 +217,26 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 - QMC6310 Magnetometer
 - PCF8563 RTC
 - Micro-SD reader (not implemented in Meshtastic)
-  
+
+## Flashing the T-Beam Supreme
+
+If you are having issues flashing the T-Beam Supreme, especially if it's your first attempt, you may need to manually place the device into Espressif's Firmware Download mode. Please follow the process below to do so.
+
+:::warning
+
+Do not proceed unless an antenna is connected to avoid possible damage to the device's radio.
+
+:::
+
+The following process will manually place the device into the Espressif Firmware Download mode:
+
+1. Unplug the device.
+2. Press and hold the BOOT button.
+3. Plug device in.
+4. After 2-3 seconds, release the BOOT button.
+
+With the device now in the Espressif Firmware Download mode, you can proceed with flashing using one of the supported flashing methods. It's generally recommended to use the [Web Flasher](https://flasher.meshtastic.org/). You can select "Tbeam S3 Core from the device drop-down.
+
 ## Resources
 
 - Firmware file: `firmware-tbeam-s3-core-X.X.X.xxxxxxx.bin`
@@ -225,7 +244,6 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
   - LilyGO Store: [Meshtastic T-Beam 433/868/915/923Mhz](https://www.lilygo.cc/products/t-beam-v1-1-esp32-lora-module)
   - AliExpress: [Meshtastic T-Beam 868/915MHz](https://www.aliexpress.com/item/1005005418286231.html)
   - US Distributor - Purchase link: Rokland [NEO-M10S](https://store.rokland.com/products/lilygo-t-beam-supreme-esp32-s3-lora-development-board-sx1262-915mhz-gps-l76k-or-u-blox?variant=41051191378003), [Quectel L76K](https://store.rokland.com/products/lilygo-t-beam-supreme-esp32-s3-lora-development-board-sx1262-915mhz-gps-l76k-or-u-blox?variant=41051191345235)
-
 
 ![T-Beam Supreme](/img/hardware/T-BEAM-S3-Supreme.jpg)
 


### PR DESCRIPTION
This PR adds information on entering firmware download mode for select S3 devices that routinely have issues when attempting to flash. 

- Heltec Wireless Tracker
- T-Beam Supreme S3