### PR TITLE
Name secondary channel LongFast

### DIFF
--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -28,7 +28,7 @@ If you'd like to connect with other Meshtastic users but only share your locatio
 
 1. Ensure you have not changed the LoRa [Modem Preset](/docs/configuration/radio/lora#modem-preset) from the default `unset` / `LONG_FAST`.
 2. On your PRIMARY channel, set anything you'd like for the channel's name and choose a random PSK.
-3. Enable a SECONDARY channel with a blank name (will default to LongFast) with PSK "AQ==".
+3. Enable a SECONDARY channel named "LongFast" with PSK "AQ==".
 4. Since the radio's frequency is automatically changed based on your PRIMARY channel's name, you will have to manually set it back to your region's default (in LoRa settings) in order to interface with users on the default channel:
 
 ### Default Primary Channels by Region


### PR DESCRIPTION
Apple doesn't automatically name every channel.