### PR TITLE
Heltec WSL3 specs clarification

### DIFF
--- a/docs/hardware/devices/heltec/index.mdx
+++ b/docs/hardware/devices/heltec/index.mdx
@@ -100,7 +100,7 @@ This device may have issues charging a connected battery if utilizing a USB-C to
 - **LoRa Transceiver:**
   - Semtech SX1262
 - **Frequency Options:**
-  - 433 MHz
+  - 433 - 510 MHz
   - 470 - 510 MHz
   - 863 - 870 MHz
   - 902 - 928 MHz
@@ -108,7 +108,7 @@ This device may have issues charging a connected battery if utilizing a USB-C to
   - USB-C
   - Antenna:
     - Dedicated 2.4 GHz stamped metal antenna for WiFi/Bluetooth
-    - U.FL/IPEX antenna connector for LoRa
+    - U.FL/IPEX antenna connector for LoRa (next to the V3 icon)
 
 ## Features
 


### PR DESCRIPTION
1. The 433Mhz version has a declared range of 433-510Mhz according to the box and sales page.
2. There are two IPEX connectors, so clarifying here helps at least me.