### PR TITLE
Add direct links to board tabs

### DIFF
--- a/docs/hardware/devices/heltec/index.mdx
+++ b/docs/hardware/devices/heltec/index.mdx
@@ -10,6 +10,7 @@ import TabItem from "@theme/TabItem";
 
 <Tabs
 groupId="heltec"
+queryString="heltec"
 defaultValue="v3"
 values={[
 {label: 'LoRa32 V2.1', value: 'v2.1'},

--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -28,110 +28,110 @@ Please do your research and choose the board that meets your needs (or maybe alr
 Modular hardware system with Base, Core and Peripheral modules including the low-power and solar ready nRF52840-based Meshtastic Starter Kit (19007 & 4631).
 
 [**WisBlock Core Modules**](./rak/core-module/)<br/>
-| Name     | MCU      | Radio  |     WiFi     | BT  |  GPS   |
-|:---------|:---------|:-------|:------------:|:---:|:------:|
-| RAK4631  | nRF52840 | SX1262 |      NO      | 5.0 | add-on |
-| RAK11200 | ESP32    | add-on | 2.4GHz b/g/n | 4.2 | add-on |
-| RAK11310 | RP2040   | SX1262 |      NO      | NO  | add-on |
+| Name                                           | MCU      | Radio  |     WiFi     | BT  |  GPS   |
+|:-----------------------------------------------|:---------|:-------|:------------:|:---:|:------:|
+| [RAK4631](./rak/core-module?rakcore=RAK4631)   | nRF52840 | SX1262 |      NO      | 5.0 | add-on |
+| [RAK11200](./rak/core-module?rakcore=RAK11200) | ESP32    | add-on | 2.4GHz b/g/n | 4.2 | add-on |
+| [RAK11310](./rak/core-module?rakcore=RAK11310) | RP2040   | SX1262 |      NO      | NO  | add-on |
 
 [**Base Boards**](./rak/base-board/)<br/>
-RAK5005-O<br/>
-RAK19007<br/>
-RAK19003<br/>
-RAK19001<br/>
+[RAK5005-O](./rak/base-board?rakbase=RAK5005-O)<br/>
+[RAK19007](./rak/base-board?rakbase=RAK19007)<br/>
+[RAK19003](./rak/base-board?rakbase=RAK19003)<br/>
+[RAK19001](./rak/base-board?rakbase=RAK19001)<br/>
 
 [**WisBlock Displays**](./rak/screens/)<br/>
-RAK1921<br/>
-RAK1400<br/>
+[RAK1921](./rak/screens?rakscreens=OLED)<br/>
+[RAK1400](./rak/screens?rakscreens=E-Ink)<br/>
 
 [**WisBlock Peripherals**](./rak/peripherals/)<br/>
-RAK1910 GPS<br/>
-RAK12500 GPS<br/>
-RAK18001 Buzzer<br/>
-RAK13002 IO<br/>
+[RAK1910](./rak/peripherals?rakmodules=GPS) GPS<br/>
+[RAK12500](./rak/peripherals?rakmodules=GPS) GPS<br/>
+[RAK18001](./rak/peripherals?rakmodules=Buzzer) Buzzer<br/>
+[RAK13002](./rak/peripherals?rakmodules=IO) IO<br/>
 RAK14001 RGB LED<br/>
 RAK12002 RTC<br/>
-RAK1910 Temperature and Humidity Sensor<br/>
-RAK1902 Barometric Pressure Sensor<br/>
-RAK1906 Environment Sensor<br/>
+[RAK1910](./rak/peripherals?rakmodules=Sensors&sensors=RAK1901) Temperature and Humidity Sensor<br/>
+[RAK1902](./rak/peripherals?rakmodules=Sensors&sensors=RAK1902) Barometric Pressure Sensor<br/>
+[RAK1906](./rak/peripherals?rakmodules=Sensors&sensors=RAK1906) Environment Sensor<br/>
 RAK12013 Radar Sensor<br/>
 
 ### [LILYGO® T-Beam](./tbeam/)
 Boards complete with GPS, 18650 battery holder, and optional screen.
 
-| Name            | MCU      | Radio             |     WiFi     | BT  | GPS |
-|:----------------|:---------|:------------------|:------------:|:---:|:---:|
-| T-Beam v0.7     | ESP32    | SX1276            | 2.4GHz b/g/n | 4.2 | YES |
-| T-Beam v1.1     | ESP32    | SX1276            | 2.4GHz b/g/n | 4.2 | YES |
-| T-Beam with M8N | ESP32    | SX1276<br/>SX1262 | 2.4GHz b/g/n | 4.2 | YES |
-| T-Beam S3-Core  | ESP32-S3 | SX1262            | 2.4GHz b/g/n | 5.0 | YES |
-| T-BeamSUPREME   | ESP32-S3 | SX1262            | 2.4GHz b/g/n | 5.0 | YES |
+| Name                                     | MCU      | Radio             |     WiFi     | BT  | GPS |
+|:-----------------------------------------|:---------|:------------------|:------------:|:---:|:---:|
+| [T-Beam v0.7](./tbeam/?t-beam=0.7)       | ESP32    | SX1276            | 2.4GHz b/g/n | 4.2 | YES |
+| [T-Beam v1.1](./tbeam/?t-beam=1.1)       | ESP32    | SX1276            | 2.4GHz b/g/n | 4.2 | YES |
+| [T-Beam with M8N](./tbeam/?t-beam=m8n)   | ESP32    | SX1276<br/>SX1262 | 2.4GHz b/g/n | 4.2 | YES |
+| [T-Beam S3-Core](./tbeam/?t-beam=s3core) | ESP32-S3 | SX1262            | 2.4GHz b/g/n | 5.0 | YES |
+| [T-BeamSUPREME](./tbeam/?t-beam=supreme) | ESP32-S3 | SX1262            | 2.4GHz b/g/n | 5.0 | YES |
 
 ### [LILYGO® T-Echo](./techo/)
 All-in-one unit with E-Ink screen, GPS and battery in injection-molded case.  Features the low-power nRF52840 for long battery life.
 
-| Name   | MCU      | Radio  | WiFi | BT  | GPS |
-|:-------|:---------|:-------|:----:|:---:|:---:|
-| T-Echo | nRF52840 | SX1262 |  NO  | 5.0 | YES |
+| Name               | MCU      | Radio  | WiFi | BT  | GPS |
+|:-------------------|:---------|:-------|:----:|:---:|:---:|
+| [T-Echo](./techo/) | nRF52840 | SX1262 |  NO  | 5.0 | YES |
 
 ### [LILYGO® LoRa](./lora/)
 Inexpensive basic ESP32-based boards.
 
-| Name              | MCU      | Radio                        |     WiFi     | BT  | GPS |
-|:------------------|:---------|:-----------------------------|:------------:|:---:|:---:|
-| LoRa32 V1         | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
-| LoRa32 V1.3       | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
-| LoRa32 V2.0       | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
-| LoRa32 V2.1-1.6   | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
-| LoRa32 V2.1-1.8   | ESP32    | SX1280                       | 2.4GHz b/g/n | 4.2 | NO  |
-| LoRa32 T3-S3 V1.0 | ESP32-S3 | SX1262<br/>SX1276<br/>SX1280 | 2.4GHz b/g/n | 5.0 | NO  |
+| Name                                       | MCU      | Radio                        |     WiFi     | BT  | GPS |
+|:-------------------------------------------|:---------|:-----------------------------|:------------:|:---:|:---:|
+| [LoRa32 V1](./lora/?t-lora=v1)             | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
+| [LoRa32 V1.3](./lora/?t-lora=v1.3)         | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
+| [LoRa32 V2.0](./lora/?t-lora=v2.0)         | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
+| [LoRa32 V2.1-1.6](./lora/?t-lora=v2.1)     | ESP32    | SX127x                       | 2.4GHz b/g/n | 4.2 | NO  |
+| [LoRa32 V2.1-1.8](./lora/?t-lora=v2.1-1.8) | ESP32    | SX1280                       | 2.4GHz b/g/n | 4.2 | NO  |
+| [LoRa32 T3-S3 V1.0](./lora/?t-lora=S3-v1)  | ESP32-S3 | SX1262<br/>SX1276<br/>SX1280 | 2.4GHz b/g/n | 5.0 | NO  |
 
 ### [LILYGO® T-Deck](./tdeck/)
 Standalone device with screen and keyboard
 
-| Name   | MCU         | Radio  | WiFi | BT  | GPS |
-|:-------|:------------|:-------|:----:|:---:|:---:|
-| T-Deck | ESP32-S3FN8 | SX1262 | YES  | 5.0 | NO  |
+| Name               | MCU         | Radio  | WiFi | BT  | GPS |
+|:-------------------|:------------|:-------|:----:|:---:|:---:|
+| [T-Deck](./tdeck/) | ESP32-S3FN8 | SX1262 | YES  | 5.0 | NO  |
 
 ### [LILYGO® T-Watch S3](./twatch/)
 
-| Name       | MCU      | Radio  | WiFi | BT  | GPS |
-|:-----------|:---------|:-------|:----:|:---:|:---:|
-| T-Watch S3 | ESP32-S3 | SX1262 | YES  | 5.0 | NO  |
+| Name                    | MCU      | Radio  | WiFi | BT  | GPS |
+|:------------------------|:---------|:-------|:----:|:---:|:---:|
+| [T-Watch S3](./twatch/) | ESP32-S3 | SX1262 | YES  | 5.0 | NO  |
 
 ### [HELTEC® LoRa 32](./heltec/)
 Inexpensive basic ESP32-based boards.
 
-| Name                   | MCU         | Radio  |     WiFi     | BT  | GPS |
-|:-----------------------|:------------|:-------|:------------:|:---:|:---:|
-| LoRa32 V2.1            | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
-| LoRa32 V3              | ESP32       | SX1262 | 2.4GHz b/g/n | 4.2 | NO  |
-| Wireless Stick Lite V3 | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
-| Wireless Tracker       | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
-| Wireless Paper         | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| Name                                                              | MCU         | Radio  |     WiFi     | BT  | GPS |
+|:------------------------------------------------------------------|:------------|:-------|:------------:|:---:|:---:|
+| [LoRa32 V2.1](./heltec/?heltec=v2.1)                              | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
+| [LoRa32 V3](./heltec/?heltec=v23)                                 | ESP32       | SX1262 | 2.4GHz b/g/n | 4.2 | NO  |
+| [Wireless Stick Lite V3](./heltec/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [Wireless Tracker](./heltec/?heltec=tracker)                      | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
+| [Wireless Paper](./heltec/?heltec=paper)                          | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 
 ### [Nano Series](./nano/)
 Portable and durable devices designed for Meshtastic.
 
-| Name             | MCU         | Radio  |     WiFi     | BT  | GPS |
-|:-----------------|:------------|:-------|:------------:|:---:|:---:|
-| Nano G1          | ESP32 WROOM | SX1276 | 2.4GHz b/g/n | 4.2 | YES |
-| Nano G1 Explorer | ESP32 WROOM | SX1262 | 2.4GHz b/g/n | 4.2 | YES |
-| Nano G2 Ultra    | NRF52840    | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
+| Name                                         | MCU         | Radio  |     WiFi     | BT  | GPS |
+|:---------------------------------------------|:------------|:-------|:------------:|:---:|:---:|
+| [Nano G2 Ultra](./nano/?nano-series=g2)      | NRF52840    | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
+| [Nano G1 Explorer](./nano/?nano-series=g1-e) | ESP32 WROOM | SX1262 | 2.4GHz b/g/n | 4.2 | YES |
+| [Nano G1](./nano/?nano-series=g1)            | ESP32 WROOM | SX1276 | 2.4GHz b/g/n | 4.2 | YES |
 
 ### [Station G1](./station-g1/)
 High power LoRa transceiver designed for Meshtastic Licensed HAM operation.
 
-| Name       | MCU         | Radio  |     WiFi     | BT  | GPS |
-|:-----------|:------------|:-------|:------------:|:---:|:---:|
-| Station G1 | ESP32 WROOM | SX1262 | 2.4GHz b/g/n | 4.2 | YES |
+| Name                        | MCU         | Radio  |     WiFi     | BT  | GPS |
+|:----------------------------|:------------|:-------|:------------:|:---:|:---:|
+| [Station G1](./station-g1/) | ESP32 WROOM | SX1262 | 2.4GHz b/g/n | 4.2 | YES |
 
 ### [Raspberry Pi Pico](./raspberry-pi/)
 Fast versatile boards using the RP2040.
 
-| Name              | MCU    | Radio  |     WiFi      |      BT       | GPS |
-|:------------------|:-------|:-------|:-------------:|:-------------:|:---:|
-| Raspberry Pi Pico | RP2040 | SX1262 | 2.4GHz b/g/n  | not supported | NO  |
+| Name                                 | MCU    | Radio  |     WiFi     |      BT       | GPS |
+|:-------------------------------------|:-------|:-------|:------------:|:-------------:|:---:|
+| [Raspberry Pi Pico](./raspberry-pi/) | RP2040 | SX1262 | 2.4GHz b/g/n | not supported | NO  |
 
 [**Pico Peripherals**](./raspberry-pi/peripherals/)<br/>
 SSD1306 OLED Display<br/>

--- a/docs/hardware/devices/lora/index.mdx
+++ b/docs/hardware/devices/lora/index.mdx
@@ -12,6 +12,7 @@ Further information on the LILYGO® LoRa devices can be found on LILYGO®'s [Git
 
 <Tabs
 groupId="t-lora"
+queryString="t-lora"
 defaultValue="v1"
 values={[
 {label: 'Lora V1', value: 'v1'},

--- a/docs/hardware/devices/nano/index.mdx
+++ b/docs/hardware/devices/nano/index.mdx
@@ -14,6 +14,7 @@ For a full and complete comparison of the different devices in the Nano series, 
 
 <Tabs
 groupId="nano-series"
+queryString="nano-series"
 defaultValue="g2"
 values={[
 {label: 'Nano G2 Ultra', value:'g2'},

--- a/docs/hardware/devices/rak/base-boards.mdx
+++ b/docs/hardware/devices/rak/base-boards.mdx
@@ -12,6 +12,7 @@ import TabItem from "@theme/TabItem";
 
 <Tabs
 groupId="rakbase board"
+queryString="rakbase"
 defaultValue="RAK19007"
 values={[
 {label: 'RAK5005-O', value: 'RAK5005-O'},

--- a/docs/hardware/devices/rak/core-modules.mdx
+++ b/docs/hardware/devices/rak/core-modules.mdx
@@ -12,6 +12,7 @@ import TabItem from "@theme/TabItem";
 
 <Tabs
 groupId="rakcore"
+queryString="rakcore"
 defaultValue="RAK4631"
 values={[
 {label: 'RAK4631', value: 'RAK4631'},

--- a/docs/hardware/devices/rak/peripherals.mdx
+++ b/docs/hardware/devices/rak/peripherals.mdx
@@ -10,6 +10,7 @@ import TabItem from "@theme/TabItem";
 
 <Tabs
 groupId="rakmodules"
+queryString="rakmodules"
 defaultValue="GPS"
 values={[
 {label: 'GPS Module', value: 'GPS'},
@@ -63,6 +64,7 @@ Further information on the RAK13002 can be found on the [RAK Documentation Cente
 <TabItem value="Sensors">
 <Tabs
 groupId="sensors"
+queryString="sensors"
 defaultValue="RAK1901"
 values={[
 {label: 'RAK1901', value: 'RAK1901'},

--- a/docs/hardware/devices/rak/screens.mdx
+++ b/docs/hardware/devices/rak/screens.mdx
@@ -12,6 +12,7 @@ There are currently two different screens supported by the RAK WisBlock system:
 
 <Tabs
 groupId="rakscreens"
+queryString="rakscreens"
 defaultValue="OLED"
 values={[
 {label: 'OLED Display', value: 'OLED'},

--- a/docs/hardware/devices/tbeam/index.mdx
+++ b/docs/hardware/devices/tbeam/index.mdx
@@ -14,6 +14,7 @@ Further information on the LILYGO® T-Beam devices can be found on LILYGO®'s [G
 
 <Tabs
 groupId="t-beam"
+queryString="t-beam"
 defaultValue="sx1262"
 values={[
 {label: 'T-Beam v0.7', value:'0.7'},


### PR DESCRIPTION
This PR add links to each board's details page from the supported devices index
[preview link](https://sandbox-git-link-to-tabs-pdxlocations.vercel.app/docs/hardware/devices/)