### PR TITLE
Add notes about public MQTT server having a lot of traffic

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -131,6 +131,10 @@ All MQTT module config options are available for the Web UI.
 
 ## Connect to the Default Public Server
 
+:::important
+The default channel (LongFast) on the public server usually has a lot of traffic. Your device may get overloaded and may no longer function properly anymore. It is recommended to use a different channel or to use your own MQTT server if you experience issues.
+:::
+
 <Tabs
 defaultValue="apple"
 values={[

--- a/docs/software/mqtt/index.mdx
+++ b/docs/software/mqtt/index.mdx
@@ -17,6 +17,8 @@ You can find the settings available for MQTT [here](/docs/configuration/module/m
 
 :::important
 When MQTT is turned on, you are potentially broadcasting your entire mesh's traffic onto the public internet. This includes messages and position information.
+
+The default channel (LongFast) on the public MQTT server usually has a lot of traffic. Your device may get overloaded and may no longer function properly anymore. It is recommended to use a different channel or to use your own MQTT server if you experience issues.
 :::
 
 ## Software Integrations


### PR DESCRIPTION
Several people have experienced various issues (not receiving messages, not being able to connect to the WebUI, not being able to change settings, etc.) when using the default channel on the public MQTT server, which has a lot of traffic. Since there isn't much we can do about it at this point, I think it's good to warn users about this.