### PR TITLE
Clarify step 4 a bit in the private primary/default secondary tip

### DIFF
--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -29,7 +29,7 @@ If you'd like to connect with other Meshtastic users but only share your locatio
 1. Ensure you have not changed the LoRa [Modem Preset](/docs/configuration/radio/lora#modem-preset) from the default `unset` / `LONG_FAST`.
 2. On your PRIMARY channel, set anything you'd like for the channel's name and choose a random PSK.
 3. Enable a SECONDARY channel named "LongFast" with PSK "AQ==".
-4. Since the radio's frequency is automatically changed based on your PRIMARY channel's name, you will have to manually set it back to your region's default (in LoRa settings) in order to interface with users on the default channel:
+4. If your LoRa channel is set to the default (`0`), the radio's frequency will be automatically changed based on your PRIMARY channel's name. In this case, you will have to manually set it back to your region's default (in LoRa settings) in order to interface with users on the default channel:
 
 ### Default Primary Channels by Region
 


### PR DESCRIPTION
I think users would reasonably assume that the LoRa channel is by default set to their region's channel and are unaware of the default hashing algo used to generate the channel number. Rewriting this way makes it less likely for users to make this mistake.