### PR TITLE
Spell out explicitly what channel config options need to match

### DIFF
--- a/docs/configuration/radio/channels.mdx
+++ b/docs/configuration/radio/channels.mdx
@@ -17,6 +17,8 @@ The Channels config options are: Index, Roles, and Settings. Channel config uses
 **Channel Settings** contain information for segregating message groups, configuring optional encryption, and enabling or disabling messaging over internet gateways. These settings **are** unique and configurable per channel.
 :::
 
+Note that for successful communication to occur between nodes on a channel, both the channel settings `Name` and `PSK` must match across devices, as well as radio settings (see [here](/docs/configuration/tips) for more details). The channel config values (`Index`, `Role`) do not need to match.
+
 ## Channel Config Values
 
 ### Index


### PR DESCRIPTION
Currently the settings that need to match is only implicitly specified in the docs on the tips page. While you can infer that channel names need to match for communication to work, it seems like it'd be easier for new users to understand what's going on by adding that information here in the initial config pages.