### PR TITLE
Update client-api.mdx

### DIFF
--- a/docs/development/device/client-api.mdx
+++ b/docs/development/device/client-api.mdx
@@ -63,7 +63,7 @@ UUID
 Properties
 Description (including human readable name)
 
-8ba2bcc2-ee02-4a55-a531-c525c5e454d5
+2c55e69e-4993-11ed-b878-0242ac120002
 read
 fromradio - contains a newly received FromRadio packet destined towards the phone (up to MAXPACKET bytes per packet).
 After reading the ESP32 will put the next packet in this mailbox. If the FIFO is empty it will put an empty packet in this


### PR DESCRIPTION
Update to the newest fromradio characteristic. The old UUID is used by legacy firmwares.