### PR TITLE
Fix EU-433 power limit in radio-settings.mdx

### DIFF
--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -24,7 +24,7 @@ Power limits will generally be lifted in the software if `is_licensed` is set to
 
 ### 433 MHz
 
-The maximum power allowed for Europe is +14 dBm ERP ([Effective Radiated Power](https://en.wikipedia.org/wiki/Effective_radiated_power)).
+The maximum power allowed for Europe is +10 dBm ERP ([Effective Radiated Power](https://en.wikipedia.org/wiki/Effective_radiated_power)).
 
 The band range is from 433 to 434 MHz.
 


### PR DESCRIPTION
In Europe, a maximum power of 10 mW ERP, i.e., +10 dBm, is allowed in the 433 MHz SRD band (see ETSI EN 300 220-2, V3.2.1, Table B.1 (Annex B), Item H).

This is related to https://github.com/meshtastic/firmware/pull/2696 which also quotes the specs from the corresponding entry in the ETSI standard.