### PR TITLE
Factory Erase nRF/RP2040 with Web Flasher

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
@@ -9,6 +9,12 @@ import Link from "@docusaurus/Link";
 
 Meshtastic uses the [littlefs](https://github.com/littlefs-project/littlefs) library to store configuration, logs, and other data in the internal flash of nRF52 & RP2040 devices. Updating the firmware does _not_ erase this additional data, which can cause issues when the format and location of data changes between releases.
 
+:::info
+You may now use the [Meshtastic Web Flasher](https://flasher.mesthastic.org) to Factory Erase your nRF52 or RP2040-based devices.  Visit the flasher, select your board, and click the trash can icon to the right of the Flash button. This will open a dialogue to begin the erase procedure. 
+
+Alternatively, follow the instructions below.
+:::
+
 ### nRF52
 
 To reset the flash storage on your nRF52 board:


### PR DESCRIPTION
This PR directs users to the new web flasher to factory erase RP2040 & nRF
[preview link](https://sandbox-git-erase-with-flasher-pdxlocations.vercel.app/docs/getting-started/flashing-firmware/nrf52/nrf52-erase)

closes #924 