### PR TITLE
fix Android .html redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -41,11 +41,11 @@
       "destination": "/docs/hardware/devices/rak/core-module#gpio"
     },
     {
-      "source": "/software/android-too-old",
+      "source": "/software/android-too-old(.*)",
       "destination": "/docs/software/android/installation"
     },
     {
-      "source": "/docs/software/android/android-installation",
+      "source": "/docs/software/android/android-installation(.*)",
       "destination": "/docs/software/android/installation"
     },
     {


### PR DESCRIPTION
add regular expression pattern `(.*)` to match path variations