### PR TITLE
Standardize devices: Resource/Purchase Links, Page/SEO Titles, URL Structure

### DIFF
--- a/docs/hardware/devices/heltec/buttons.mdx
+++ b/docs/hardware/devices/heltec/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 id: buttons
-title: Hardware Buttons
+title: Heltec LoRa 32 Hardware Buttons
 sidebar_label: Buttons
 sidebar_position: 1
 ---

--- a/docs/hardware/devices/heltec/enclosures.mdx
+++ b/docs/hardware/devices/heltec/enclosures.mdx
@@ -1,6 +1,6 @@
 ---
 id: enclosures
-title: Enclosures
+title: Heltec LoRa 32 Enclosures
 sidebar_label: Enclosures
 sidebar_position: 2
 ---

--- a/docs/hardware/devices/heltec/index.mdx
+++ b/docs/hardware/devices/heltec/index.mdx
@@ -140,8 +140,10 @@ Image Source: [Heltec](https://resource.heltec.cn/download/Wireless_Stick_Lite_V
 ### Resources
 
 - Firmware file: `firmware-heltec-wsl-v3-X.X.X.xxxxxxx.bin`
-- Purchase link: [Heltec](https://heltec.org/project/wireless-stick-lite-v2/)
-- Purchase link: [AliExpress](https://www.aliexpress.us/item/3256805256996507.html)
+- Purchase Links:
+  - International
+    - [Heltec](https://heltec.org/project/wireless-stick-lite-v2/)
+    - [AliExpress](https://www.aliexpress.us/item/3256805256996507.html)
 
 </TabItem>
 
@@ -200,8 +202,10 @@ Image Source: [Heltec](https://heltec.org/project/wireless-tracker/)
 ### Resources
 
 - Firmware file: `firmware-heltec-wireless-tracker-X.X.X.xxxxxxx.bin`
-- Purchase link: [Heltec](https://heltec.org/project/wireless-tracker/)
-- Purchase link: [AliExpress](https://www.aliexpress.us/item/3256805495189423.html)
+- Purchase Links:
+  - International
+    - [Heltec](https://heltec.org/project/wireless-tracker/)
+    - [AliExpress](https://www.aliexpress.us/item/3256805495189423.html)
 
 </TabItem>
 
@@ -241,8 +245,10 @@ This device may have issues charging a connected battery if utilizing a USB-C to
 ### Resources
 
 - Firmware file: `firmware-heltec-wireless-paper-X.X.X.xxxxxxx.bin`
-- Purchase link: [Heltec](https://heltec.org/project/wireless-paper/)
-- Purchase link: [AliExpress](https://www.aliexpress.us/item/3256805461611876.html)
+- Purchase Links: 
+  - International
+    - [Heltec](https://heltec.org/project/wireless-paper/)
+    - [AliExpress](https://www.aliexpress.us/item/3256805461611876.html)
 
 </TabItem>
 </Tabs>

--- a/docs/hardware/devices/lora/buttons.mdx
+++ b/docs/hardware/devices/lora/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 id: buttons
-title: Hardware Buttons
+title: LILYGO® TTGO Lora Hardware Buttons
 sidebar_label: Buttons
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/lora/enclosures.mdx
+++ b/docs/hardware/devices/lora/enclosures.mdx
@@ -1,6 +1,6 @@
 ---
 id: enclosures
-title: Enclosures
+title: LILYGO® TTGO Lora Enclosures
 sidebar_label: Enclosures
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/lora/gpio.mdx
+++ b/docs/hardware/devices/lora/gpio.mdx
@@ -1,6 +1,6 @@
 ---
 id: gpio
-title: GPIO
+title: LILYGO® TTGO Lora GPIO
 sidebar_label: GPIO
 sidebar_position: 4
 ---

--- a/docs/hardware/devices/lora/index.mdx
+++ b/docs/hardware/devices/lora/index.mdx
@@ -51,9 +51,11 @@ This board is still in production but for various reasons not recommended for ne
 ### Resources
 
 - Firmware file: `firmware-tlora-v1-X.X.X.xxxxxxx.bin`
-- Purchase Links
-  - [AliExpress](https://www.aliexpress.com/item/32996759721.html)
-  - US Distributor [Rokland](https://store.rokland.com/products/lilygo-ttgo-lora32-v1-0-wireless-module-esp32-lora-915mhz-oled-0-96-inch-display-wifi-bluetooth-esp-32-antenna-ch9102-q184?ref=8Bb2mUO5i-jKwt)
+- Purchase Links:
+  - US
+    - [Rokland](https://store.rokland.com/products/lilygo-ttgo-lora32-v1-0-wireless-module-esp32-lora-915mhz-oled-0-96-inch-display-wifi-bluetooth-esp-32-antenna-ch9102-q184?ref=8Bb2mUO5i-jKwt)
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/32996759721.html)
 
 ![LILYGO® TTGO Lora V1](/img/hardware/lora-v1.png)
 
@@ -89,8 +91,9 @@ This board is still in production but for various reasons not recommended for ne
 ### Resources
 
 - Firmware file: `firmware-tlora_v1_3-X.X.X.xxxxxxx.bin`
-- Purchase links
-  - [AliExpress](https://www.aliexpress.com/item/4000628100802.html)
+- Purchase Links:
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/4000628100802.html)
 
 ![LILYGO® TTGO Lora V1.3](/img/hardware/lora-v1.3.png)
 ![LILYGO® TTGO Lora V1.3 pin map](/img/hardware/lora-v1.3_pinmap.webp)
@@ -130,8 +133,9 @@ This board is still in production but for various reasons not recommended for ne
 ### Resources
 
 - Firmware file: `firmware-tlora-v2-X.X.X.xxxxxxx.bin`
-- Purchase links
-  - [AliExpress](https://www.aliexpress.com/item/32846302183.html)
+- Purchase Links:
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/32846302183.html)
 
 ![LILYGO® TTGO Lora V2](/img/hardware/lora-v2.0.png)
 
@@ -172,9 +176,12 @@ Early versions of some of these boards contained the wrong component in the LiPo
 ### Resources
 
 - Firmware file: `firmware-tlora-v2-1-1.6-X.X.X.xxxxxxx.bin`
-- Purchase Links
-  - [AliExpress](https://www.aliexpress.com/item/32915894264.html)
-  - US Distributor [Rokland](https://store.rokland.com/products/lilygo-ttgo-lora32-v2-1_1-6-version-915mhz-esp32-lora-oled-0-96-inch-sd-card-bluetooth-wifi-wireless-module-esp-32-sma-q211?ref=8Bb2mUO5i-jKwt)
+- Purchase Links:
+  - US
+    - [Rokland](https://store.rokland.com/products/lilygo-ttgo-lora32-v2-1_1-6-version-915mhz-esp32-lora-oled-0-96-inch-sd-card-bluetooth-wifi-wireless-module-esp-32-sma-q211?ref=8Bb2mUO5i-jKwt)
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/32915894264.html)
+    - [Lilygo](https://www.lilygo.cc/products/lora3)
 
 ![TTGO Lora V2.1-1.6](/img/hardware/lora-v2.1-1.6.png)
 
@@ -261,8 +268,12 @@ If after successfully flashing the device and the screen remains black, you may 
 ### Resources
 
 - Firmware file: `firmware-tlora-t3s3-v1.xxxxxxx.bin`
-- Purchase links
-  - [AliExpress](https://www.aliexpress.com/item/1005004627139838.html)
+- Purchase Links:
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/1005004627139838.html)
+    - [Amazon](https://www.amazon.com/LILYGO-ESP32-S3-Development-Wireless-Display/dp/B0BW5W9QXZ)
+    - [Lilygo](https://www.lilygo.cc/products/t3s3-v1-0)
+    - [Tindie](https://www.tindie.com/products/lilygo/lilygo-t3-s3-v10-esp32-s3-lora-sx1280-24g/)
 
 ![TTGO Lora T3S3 V1](/img/hardware/lora-t3s3.jpg)
 

--- a/docs/hardware/devices/lora/index.mdx
+++ b/docs/hardware/devices/lora/index.mdx
@@ -269,9 +269,10 @@ If after successfully flashing the device and the screen remains black, you may 
 
 - Firmware file: `firmware-tlora-t3s3-v1.xxxxxxx.bin`
 - Purchase Links:
+  - US
+    - [Amazon](https://www.amazon.com/LILYGO-ESP32-S3-Development-Wireless-Display/dp/B0BW5W9QXZ)
   - International
     - [AliExpress](https://www.aliexpress.com/item/1005004627139838.html)
-    - [Amazon](https://www.amazon.com/LILYGO-ESP32-S3-Development-Wireless-Display/dp/B0BW5W9QXZ)
     - [Lilygo](https://www.lilygo.cc/products/t3s3-v1-0)
     - [Tindie](https://www.tindie.com/products/lilygo/lilygo-t3-s3-v10-esp32-s3-lora-sx1280-24g/)
 

--- a/docs/hardware/devices/nano/buttons.mdx
+++ b/docs/hardware/devices/nano/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 id: buttons
-title: Hardware Buttons
+title: Nano Series Hardware Buttons
 sidebar_label: Buttons
 sidebar_position: 1
 ---

--- a/docs/hardware/devices/nano/index.mdx
+++ b/docs/hardware/devices/nano/index.mdx
@@ -59,11 +59,11 @@ The Nano G2 Ultra and Nano G1 Explorer have exactly the same Lora front-end circ
 ### Resources
 
 - Firmware file: `firmware-nano-g2-ultra-X.X.X.xxxxxxx.uf2`
-- Official Purchase Links:
-  - [Official Store](https://shop.uniteng.com/product/meshtastic-mesh-device-nano-g2-ultra/)
-  - [Official Tindie Store](https://www.tindie.com/products/neilhao/meshtastic-mesh-device-nano-g2-ultra/)
-
-Further information on the Nano G2 Ultra can be found on [Unit Engineering's Wiki](https://wiki.uniteng.com/en/meshtastic/nano-g2-ultra).
+- [Unit Engineering's Official Wiki](https://wiki.uniteng.com/en/meshtastic/nano-g2-ultra)
+- Purchase Links:
+  - International
+    - [Official Store](https://shop.uniteng.com/product/meshtastic-mesh-device-nano-g2-ultra/)
+    - [Official Tindie Store](https://www.tindie.com/products/neilhao/meshtastic-mesh-device-nano-g2-ultra/)
 
 ![Nano G2 Ultra](/img/hardware/nano_g2_ultra.jpeg)
 
@@ -104,11 +104,11 @@ The Nano G1 Explorer, powered by Meshtastic, is a significant upgrade from the N
 ### Resources
 
 - Firmware file: `firmware-nano-g1-explorer-X.X.X.xxxxxxx.bin`
-- Official Purchase Links:
-  - [Official Store](https://shop.uniteng.com/product/meshtastic-mesh-device-nano-edition/)
-  - [Official Tindie Store](https://www.tindie.com/products/neilhao/meshtastic-mesh-device-nano-g1-explorer/)
-
-Further information on the Nano G1 can be found on [Unit Engineering's Wiki](https://wiki.uniteng.com/en/meshtastic/nano-g1-explorer).
+- [Unit Engineering's Official Wiki](https://wiki.uniteng.com/en/meshtastic/nano-g1-explorer)
+- Purchase Links:
+  - International
+    - [Official Store](https://shop.uniteng.com/product/meshtastic-mesh-device-nano-edition/)
+    - [Official Tindie Store](https://www.tindie.com/products/neilhao/meshtastic-mesh-device-nano-g1-explorer/)
 
 ![Nano G1 Explorer](/img/hardware/nano_g1_explorer.jpeg)
 
@@ -147,8 +147,7 @@ The Nano G1 is the first dedicated hardware device to be designed from scratch p
 ### Resources
 
 - Firmware file: `firmware-nano-g1-X.X.X.xxxxxxx.bin`
-
-Further information on the Nano G1 can be found on [Unit Engineering's Wiki](https://uniteng.com/wiki/doku.php?id=meshtastic:nano).
+- [Unit Engineering's Official Wiki](https://uniteng.com/wiki/doku.php?id=meshtastic:nano)
 
 ![Nano G1](/img/hardware/nano-g1-front.jpg)
 

--- a/docs/hardware/devices/rak/base-boards.mdx
+++ b/docs/hardware/devices/rak/base-boards.mdx
@@ -81,7 +81,7 @@ Further information on the RAK5005-O can be found on the [RAK Documentation Cent
 Further information on the RAK19007 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK19007/Overview/#product-description).
 
 ### Resources
-- Purchase links
+- Purchase Links:
   - US 
     - [Rokland](https://store.rokland.com/products/rak-wireless-wisblock-base-board-2nd-gen-rak19007-ver-b-pid-110082)
   - International
@@ -113,7 +113,7 @@ Further information on the RAK19007 can be found on the [RAK Documentation Cente
 Further information on the RAK19003 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK19003/Overview/#product-description)
 
 ### Resources
-- Purchase links
+- Purchase Links:
   - US 
     - [Rokland](https://store.rokland.com/products/rak-wireless-wisblock-mini-base-board-rak19003-ver-b-pid-306024)
   - International
@@ -152,7 +152,7 @@ Further information on the RAK19003 can be found on the [RAK Documentation Cente
 Further information on the RAK19001 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK19001/Overview/#product-description).
 
 ### Resources
-- Purchase links
+- Purchase Links:
   - US 
     - [Rokland](https://store.rokland.com/products/rak-wireless-wisblock-dual-io-base-board-rak19001-pid-110081)
   - International

--- a/docs/hardware/devices/rak/buttons.mdx
+++ b/docs/hardware/devices/rak/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 id: buttons
-title: Hardware Buttons
+title: RAK WisBlock Hardware Buttons
 sidebar_label: Buttons
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/rak/core-modules.mdx
+++ b/docs/hardware/devices/rak/core-modules.mdx
@@ -49,7 +49,7 @@ Please be aware of the difference between the RAK4631 (Arduino bootloader) and t
 
 - Firmware file: `firmware-rak4631-X.X.X.xxxxxxx.uf2`
 - Further information on the RAK4631 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Overview/#product-description).
-- Purchase Links
+- Purchase Links:
   - US
     - [Rokland - US915 Mhz](https://store.rokland.com/products/rak-wireless-rak4631-nordic-nrf52840-ble-core-module-for-lorawan-with-lora-sx1262)
   - International
@@ -115,7 +115,7 @@ The RAK11200 does not contain a LoRa transceiver, and thus needs to be added sep
 
 - Firmware file: `firmware-rak11200-X.X.X.xxxxxxx.bin`
 - Further information on the RAK11200 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK11200/Overview/#product-description).
-- Purchase Links
+- Purchase Links:
   - International
     - [RAK Wireless Store](https://store.rakwireless.com/products/wiscore-esp32-module-rak11200)
     - [RAK Wireless Aliexpress](https://www.aliexpress.us/item/3256802312474717.html)
@@ -160,7 +160,7 @@ The RAK11200 does not contain a LoRa transceiver, and thus needs to be added sep
 
 - Firmware file: `firmware-rak11310-X.X.X.xxxxxxx.uf2`
 - Further information on the RAK11310 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK11310/Overview/#product-description).
-- Purchase Links
+- Purchase Links:
   - International
     - [RAK Wireless Store](https://store.rakwireless.com/products/rak11310-wisblock-lpwan-module)
     - [RAK Wireless Aliexpress](https://www.aliexpress.us/item/3256803225175784.html)

--- a/docs/hardware/devices/rak/enclosures/harbor-breeze-solar-enclosure.mdx
+++ b/docs/hardware/devices/rak/enclosures/harbor-breeze-solar-enclosure.mdx
@@ -1,6 +1,6 @@
 ---
-id: harbor_breeze_solar
-title: Harbor Breeze Solar Light Enclosure Hack
+id: harbor-breeze-solar-hack
+title: RAK WisBlock Harbor Breeze Solar Light Enclosure Hack
 sidebar_label: Solar Light Enclosure Hack
 sidebar_position: 1
 ---

--- a/docs/hardware/devices/rak/enclosures/index.mdx
+++ b/docs/hardware/devices/rak/enclosures/index.mdx
@@ -1,6 +1,6 @@
 ---
 id: enclosures
-title: Enclosures
+title: RAK WisBlock Enclosures
 sidebar_label: Enclosures
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/rak/enclosures/index.mdx
+++ b/docs/hardware/devices/rak/enclosures/index.mdx
@@ -41,7 +41,7 @@ Download from [Printables](https://www.printables.com/model/286664-rak19003-micr
 
 ## Created by tavdog/Tavis Gustafson
 
-### [Harbor Breeze Meshtastic Hack](./harbor_breeze_solar_enclosure.mdx)
+### [Harbor Breeze Meshtastic Hack](./harbor-breeze-solar-enclosure.mdx)
 
 ![Harbor Breeze Solar LED Meshtastic Hack Complete](/img/enclosures/hbmh_complete.png)
 

--- a/docs/hardware/devices/rak/peripherals.mdx
+++ b/docs/hardware/devices/rak/peripherals.mdx
@@ -40,7 +40,7 @@ To add a GPS to the RAK19003 base board, you need the [RAK12500 GPS sensor](http
 - RAK Documentation Center
   - [RAK12500](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK12500/Overview/#product-description)
   - [RAK1910](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1910/Overview/#product-description)
-- Purchase Links
+- Purchase Links:
   - US
     - [Rokland RAK1910](https://store.rokland.com/products/rak-wireless-rak1910-wisblock-gnss-location-module)
     - [Rokland RAK12500](https://store.rokland.com/products/rak-wireless-rak12500-gnss-gps-location-module-u-blox-zoe-m8q)
@@ -57,7 +57,7 @@ The [RAK18001 Buzzer Module](https://store.rakwireless.com/products/wisblock-buz
 
 ### Resources
 - [RAK Documentation Center RAK18001](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK18001/Overview/#product-description)
-- Purchase Links
+- Purchase Links:
   - International
     - [RAK Wireless](https://store.rakwireless.com/products/wisblock-buzzer-module-rak18001)
 
@@ -79,7 +79,7 @@ There is development activity in progress to get sensors such as this added to t
 
 ### Resources
 - [RAK Documentation Center RAK13002](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK13002/Overview)
-- Purchase Links
+- Purchase Links:
   - US
     - [Rokland](https://store.rokland.com/products/rak-wireless-rak13002-wisblock-io-adapter-module)
   - International
@@ -120,7 +120,7 @@ The [RAK1906 Environment Sensor](https://store.rakwireless.com/products/rak1906-
   - [RAK1901](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1901/Overview/#product-description)
   - [RAK1902](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1902/Overview/#product-description)
   - [RAK1906](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1906/Overview/#product-description)
-- Purchase Links
+- Purchase Links:
   - US
     - [Rokland RAK1901](https://store.rokland.com/products/rak-wireless-rak1901-temperature-and-humidity-sensor-sensirion-shtc3-pid-100001)
     - [Rokland RAK1902](https://store.rokland.com/products/rak-wireless-rak1902-barometric-pressure-sensor-stmicroelectronics-lps22hb-100010-2-pack)

--- a/docs/hardware/devices/rak/peripherals.mdx
+++ b/docs/hardware/devices/rak/peripherals.mdx
@@ -1,6 +1,6 @@
 ---
 id: peripherals
-title: Supported Peripherals
+title: RAK WisBlock Supported Peripherals
 sidebar_label: Peripherals
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/rak/screens.mdx
+++ b/docs/hardware/devices/rak/screens.mdx
@@ -34,7 +34,7 @@ If pin ordering on the OLED board are swapped, there are some tricks to allow ei
 
 ### Resources
 - [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1921/Overview/#product-description)
-- Purchase Links
+- Purchase Links:
   - US
     - [Rokland](https://store.rokland.com/products/rak-wireless-wisblock-oled-display-rak1921-pid-110004)
   - International
@@ -60,7 +60,7 @@ Please note only the white-black display is supported at this time, the white-bl
 ### Resources
 - Firmware for 5005 with RAK14000 e-paper: [`firmware-rak4631_eink-X.X.X.xxxxxxx.uf2`](/downloads)
 - [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK14000/Overview/#product-description)
-- Purchase Links
+- Purchase Links:
   - US
     - [Rokland](https://store.rokland.com/products/rak-wireless-wisblock-epd-module-rak14000-pid-110024)
   - International

--- a/docs/hardware/devices/rak/screens.mdx
+++ b/docs/hardware/devices/rak/screens.mdx
@@ -1,6 +1,6 @@
 ---
 id: screens
-title: Screens
+title: RAK WisBlock Screens
 sidebar_label: Screens
 sidebar_position: 2
 ---

--- a/docs/hardware/devices/raspberry-pi/index.mdx
+++ b/docs/hardware/devices/raspberry-pi/index.mdx
@@ -15,7 +15,7 @@ The Raspberry Pi Pico series is a range of tiny, fast, and versatile boards buil
 Only the Pico W has WiFi/BLE capabilities. Meshtastic supports WiFi on the Pico W (although no web server and HTTP API), but does not currently support BLE.
 :::
 
-### Pico
+## Specifications
 
 - **MCU:**
   - Raspberry Pi RP2040
@@ -46,8 +46,8 @@ LoRa transmissions may interfere with the USB connection. It is recommended to p
 
 :::
 
-### Pico Resources
+### Resources
 
 - Firmware file:`firmware-pico-X.X.X.xxxxxxx.uf2`
-- for Pico W use: `firmware-picow-X.X.X.xxxxxxx.uf2`
+  - for Pico W use: `firmware-picow-X.X.X.xxxxxxx.uf2`
 - [Offical Website for the Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/), including official reseller links.

--- a/docs/hardware/devices/raspberry-pi/peripherals.mdx
+++ b/docs/hardware/devices/raspberry-pi/peripherals.mdx
@@ -1,6 +1,6 @@
 ---
 id: peripherals
-title: Supported Peripherals
+title: Raspberry Pi Pico Supported Peripherals
 sidebar_label: Peripherals
 sidebar_position: 1
 ---

--- a/docs/hardware/devices/station-g1/buttons.mdx
+++ b/docs/hardware/devices/station-g1/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 id: buttons
-title: Hardware Buttons
+title: Station G1 Hardware Buttons
 sidebar_label: Buttons
 sidebar_position: 1
 ---

--- a/docs/hardware/devices/station-g1/index.mdx
+++ b/docs/hardware/devices/station-g1/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 9
 
 The Station G1 is the second dedicated hardware device to be designed from scratch purely for Meshtastic Licensed (HAM) Operation by Neil Hao. It has been designed to be small and compact with the inclusion of 35dBm high power PA.
 
-### Specifications
+## Specifications
 
 - **MCU**
   - ESP32 WROOM (WiFi & Bluetooth)
@@ -25,7 +25,7 @@ The Station G1 is the second dedicated hardware device to be designed from scrat
 - **Connectors**
   - USB-C
 
-### Features
+## Features
 
 - Meshtastic pre-installed
 - User button
@@ -33,12 +33,13 @@ The Station G1 is the second dedicated hardware device to be designed from scrat
 - Optional GPS Module and IO Extension Socket
 - Optional [12V Battery Docker](https://shop.uniteng.com/product/12v-battery-docker-for-station-edition-g1/) which can be used as Backup Power, or in scenarios that require mobility
 
-### Resources
+## Resources
 
 - Firmware file: `firmware-station-g1-X.X.X.xxxxxxx.bin`
-- [Official Store](https://shop.uniteng.com/product/meshtastic-mesh-device-station-edition/)
-- [Official Tindie Store](https://www.tindie.com/products/neilhao/meshtastic-mesh-device-station-edition/)
-
-Further information on the Station G1 can be found on [Unit Engineering's Wiki](https://uniteng.com/wiki/doku.php?id=meshtastic:station).
+- [Unit Engineering's Official Wiki](https://uniteng.com/wiki/doku.php?id=meshtastic:station)
+- Purchase Links:
+  - International
+    - [Official Store](https://shop.uniteng.com/product/meshtastic-mesh-device-station-edition/)
+    - [Official Tindie Store](https://www.tindie.com/products/neilhao/meshtastic-mesh-device-station-edition/)
 
 ![Station G1](/img/hardware/station-g1.jpg)

--- a/docs/hardware/devices/tbeam/buttons.mdx
+++ b/docs/hardware/devices/tbeam/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 id: buttons
-title: Hardware Buttons
+title: T-Beam Hardware Buttons
 sidebar_label: Buttons
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/tbeam/enclosures.mdx
+++ b/docs/hardware/devices/tbeam/enclosures.mdx
@@ -1,6 +1,6 @@
 ---
 id: enclosures
-title: Enclosures
+title: T-Beam Enclosures
 sidebar_label: Enclosures
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/tbeam/index.mdx
+++ b/docs/hardware/devices/tbeam/index.mdx
@@ -57,7 +57,9 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 ### Resources
 
 - Firmware file: `firmware-tbeam0.7-X.X.X.xxxxxxx.bin`
-- Purchase link: [AliExpress](https://www.aliexpress.com/item/4000469332610.html)
+- Purchase Links:
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/4000469332610.html)
 
 ![T-Beam v0.7](/img/hardware/t-beam-v0.7.png)
 ![T-Beam v0.7 pin map](/img/hardware/t-beam_v0.7_pinmap.jpeg)
@@ -92,8 +94,12 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 ### Resources
 
 - Firmware file: `firmware-tbeam-X.X.X.xxxxxxx.bin`
-- Purchase link: [AliExpress](https://www.aliexpress.com/item/4001178678568.html)
-- US Distributor - Purchase link: Rokland [No OLED](https://store.rokland.com/products/lilygo-ttgo-t-beam-v1-1-lora-esp32-development-board-wifi-bluetooth-module-gps-neo-6m-sx1276-915mhz-q219?ref=8Bb2mUO5i-jKwt), [OLED](https://store.rokland.com/products/lilygo-ttgo-meshtastic-t-beam-v1-1-esp32-lora-915-mhz-wireless-module-wifi-gps-neo-6m-with-oled-display-soldered-for-arduino-q349)
+- Purchase Links:
+  - US
+    - [Rokland OLED](https://store.rokland.com/products/lilygo-ttgo-meshtastic-t-beam-v1-1-esp32-lora-915-mhz-wireless-module-wifi-gps-neo-6m-with-oled-display-soldered-for-arduino-q349)
+    - [Rokland No OLED](https://store.rokland.com/products/lilygo-ttgo-t-beam-v1-1-lora-esp32-development-board-wifi-bluetooth-module-gps-neo-6m-sx1276-915mhz-q219?ref=8Bb2mUO5i-jKwt)
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/4001178678568.html)
 
 ![TTGO T-Beam v1.1](/img/hardware/t-beam-v1.1.png)
 ![TTGO T-Beam v1.1 pinmap](/img/hardware/t-beam_v1.1_pinmap.webp)
@@ -128,8 +134,11 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 ### Resources
 
 - Firmware file: `firmware-tbeam-X.X.X.xxxxxxx.bin`
-- Purchase link: [AliExpress](https://www.aliexpress.com/item/32889583204.html)
-- US Distributor - Purchase link: [Rokland](https://store.rokland.com/products/lilygo-ttgo-t-beam-v1-1-ipex-esp32-lora-915mhz-wifi-wireless-bluetooth-module-gps-neo-m8n-ipex-18650-battery-holder-q107?ref=8Bb2mUO5i-jKwt)
+- Purchase Links: 
+  - US
+    - [Rokland](https://store.rokland.com/products/lilygo-ttgo-t-beam-v1-1-ipex-esp32-lora-915mhz-wifi-wireless-bluetooth-module-gps-neo-m8n-ipex-18650-battery-holder-q107?ref=8Bb2mUO5i-jKwt)
+  - International 
+    - [AliExpress](https://www.aliexpress.com/item/32889583204.html)
 
 ![TTGO T-Beam M8N](/img/hardware/t-beam-m8n.png)
 
@@ -163,8 +172,11 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 ### Resources
 
 - Firmware file: `firmware-tbeam-X.X.X.xxxxxxx.bin`
-- Purchase link: [AliExpress](https://www.aliexpress.com/item/4001287221970.html)
-- US Distributor - Purchase link: [Rokland](https://store.rokland.com/products/lilygo-t-beam-v1-1-neo-m8n-gnss-ipex-lora-sx1262-915mhz-wireless-module-wifi-bluetooth-board-q215?ref=8Bb2mUO5i-jKwt)
+- Purchase Links:
+  - US
+    - [Rokland](https://store.rokland.com/products/lilygo-t-beam-v1-1-neo-m8n-gnss-ipex-lora-sx1262-915mhz-wireless-module-wifi-bluetooth-board-q215?ref=8Bb2mUO5i-jKwt)
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/4001287221970.html)
 
 ![T-Beam M8N & SX1262](/img/hardware/t-beam-sx1262.png)
 
@@ -198,7 +210,9 @@ This is an earlier version of the T-Beam board. Due to changes in the design thi
 ### Resources
 
 - Firmware file: `firmware-tbeam-s3-core-X.X.X.xxxxxxx.bin`
-- Purchase Link: [AliExpress](https://www.aliexpress.com/item/1005005418286231.html)
+- Purchase Links: 
+  - International
+    - [AliExpress](https://www.aliexpress.com/item/1005005418286231.html)
 
 ![T-Beam S3-Core](/img/hardware/T-BEAM-S3Core.jpg)
 
@@ -257,10 +271,13 @@ With the device now in the Espressif Firmware Download mode, you can proceed wit
 ### Resources
 
 - Firmware file: `firmware-tbeam-s3-core-X.X.X.xxxxxxx.bin`
-- Purchase links:
-  - LilyGO Store: [Meshtastic T-Beam 433/868/915/923Mhz](https://www.lilygo.cc/products/t-beam-v1-1-esp32-lora-module)
-  - AliExpress: [Meshtastic T-Beam 868/915MHz](https://www.aliexpress.com/item/1005005418286231.html)
-  - US Distributor - Purchase link: Rokland [NEO-M10S](https://store.rokland.com/products/lilygo-t-beam-supreme-esp32-s3-lora-development-board-sx1262-915mhz-gps-l76k-or-u-blox?variant=41051191378003), [Quectel L76K](https://store.rokland.com/products/lilygo-t-beam-supreme-esp32-s3-lora-development-board-sx1262-915mhz-gps-l76k-or-u-blox?variant=41051191345235)
+- Purchase Links:
+  - International
+    - [LilyGO Store](https://www.lilygo.cc/products/t-beam-v1-1-esp32-lora-module)
+    - [AliExpress](https://www.aliexpress.com/item/1005005418286231.html)
+  - US
+    - [Rokland NEO-M10S](https://store.rokland.com/products/lilygo-t-beam-supreme-esp32-s3-lora-development-board-sx1262-915mhz-gps-l76k-or-u-blox?variant=41051191378003)
+    - [Rokland Quectel L76K](https://store.rokland.com/products/lilygo-t-beam-supreme-esp32-s3-lora-development-board-sx1262-915mhz-gps-l76k-or-u-blox?variant=41051191345235)
 
 ![T-Beam Supreme](/img/hardware/T-BEAM-S3-Supreme.jpg)
 

--- a/docs/hardware/devices/tbeam/screens.mdx
+++ b/docs/hardware/devices/tbeam/screens.mdx
@@ -1,16 +1,11 @@
 ---
 id: screens
-title: Screens
+title: T-Beam Screens
 sidebar_label: Screens
 sidebar_position: 2
 ---
 
 ## 0.96 inch OLED I<sup>2</sup>C display
-
-- [Purchase link](https://www.aliexpress.com/item/32922106384.html)
-- US Distributor - Purchase link: [Rokland](https://store.rokland.com/products/lilygo-ttgo-0-96-inch-oled-white-color-text-display-module-l206-for-t-beam-and-t-sim)
-
-![0.96 inch OLED display](/img/hardware/screen.png)
 
 ### Pin map
 
@@ -22,3 +17,12 @@ To attach the screen:
 4. Connect SDA to pin 21
 
 ![Connecting the OLED screen to a T-Beam](/img/hardware/t-beam-screen.jpg)
+
+### Resources
+- Purchase Links:
+  - US
+    [Rokland](https://store.rokland.com/products/lilygo-ttgo-0-96-inch-oled-white-color-text-display-module-l206-for-t-beam-and-t-sim)
+  - International
+    - [Aliexpress](https://www.aliexpress.com/item/32922106384.html)
+
+![0.96 inch OLED display](/img/hardware/screen.png)

--- a/docs/hardware/devices/tbeam/screens.mdx
+++ b/docs/hardware/devices/tbeam/screens.mdx
@@ -21,7 +21,7 @@ To attach the screen:
 ### Resources
 - Purchase Links:
   - US
-    [Rokland](https://store.rokland.com/products/lilygo-ttgo-0-96-inch-oled-white-color-text-display-module-l206-for-t-beam-and-t-sim)
+    - [Rokland](https://store.rokland.com/products/lilygo-ttgo-0-96-inch-oled-white-color-text-display-module-l206-for-t-beam-and-t-sim)
   - International
     - [Aliexpress](https://www.aliexpress.com/item/32922106384.html)
 

--- a/docs/hardware/devices/tdeck/index.mdx
+++ b/docs/hardware/devices/tdeck/index.mdx
@@ -52,9 +52,11 @@ With the device now in the Espressif Firmware Download mode, you can proceed wit
 ## Resources
 
 - Firmware file: `firmware-t-deck-X.X.X.xxxxxxx.bin`
-- Purchase links:
-  - LilyGO Store: [T-Deck 433/868/915Mhz](https://www.lilygo.cc/products/t-deck)
-  - AliExpress: [T-Deck 433/868/915MHz](https://www.aliexpress.us/item/3256805505920840.html)
-  - US Distributor - Purchase link: Rokland [915MHz](https://store.rokland.com/products/lilygo-t-deck-portable-microcontroller-programmer-lora-915-mhz-h642)
+- Purchase Links:
+  - US
+    - [Rokland](https://store.rokland.com/products/lilygo-t-deck-portable-microcontroller-programmer-lora-915-mhz-h642)
+  - International
+    - [LilyGO Store](https://www.lilygo.cc/products/t-deck)
+    - [AliExpress](https://www.aliexpress.us/item/3256805505920840.html)
 
 ![T-Deck](/img/hardware/LILYGO-T-DECK.jpg)

--- a/docs/hardware/devices/techo/buttons.mdx
+++ b/docs/hardware/devices/techo/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 id: buttons
-title: Hardware Buttons
+title: T-Echo Hardware Buttons
 sidebar_label: Buttons
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/techo/enclosures.mdx
+++ b/docs/hardware/devices/techo/enclosures.mdx
@@ -1,6 +1,6 @@
 ---
 id: enclosures
-title: Enclosures
+title: T-Echo Enclosures
 sidebar_label: Enclosures
 sidebar_position: 3
 ---

--- a/docs/hardware/devices/techo/index.mdx
+++ b/docs/hardware/devices/techo/index.mdx
@@ -34,9 +34,12 @@ Further information on the LILYGO® T-Echo devices can be found on LILYGO®'s [G
 ## Resources
 
 - Firmware file: `firmware-t-echo-2.x.x.uf2`
-- Purchase links:
-  - LilyGO Store: [T-Echo Meshtastic 433/868/915MHz](https://www.lilygo.cc/products/t-echo)
-  - AliExpress: [T-Echo Meshtastic 433/868/915MHz with optional BME280 sensor](https://www.aliexpress.com/item/1005003026107533.html)
-  - US Distributor - Rokland: [915MHz](https://store.rokland.com/products/lilygo-ttgo-meshtastic-t-echo-white-lora-sx1262-wireless-module-915mhz-nrf52840-gps-for-arduino?ref=8Bb2mUO5i-jKwt) [915MHz BME280 Kit](https://store.rokland.com/products/lilygo-ttgo-meshtastic-t-echo-white-bme280-lora-sx1262-wireless-module-915mhz-nrf52840-gps-rtc-nfc-for-arduino?ref=8Bb2mUO5i-jKwt)
+- Purchase Links:
+  - US
+    - [Rokland 915MHz](https://store.rokland.com/products/lilygo-ttgo-meshtastic-t-echo-white-lora-sx1262-wireless-module-915mhz-nrf52840-gps-for-arduino?ref=8Bb2mUO5i-jKwt)
+    - [Rokland 915MHz w/ BME280 Kit](https://store.rokland.com/products/lilygo-ttgo-meshtastic-t-echo-white-bme280-lora-sx1262-wireless-module-915mhz-nrf52840-gps-rtc-nfc-for-arduino?ref=8Bb2mUO5i-jKwt)
+  - International
+    - [LilyGO](https://www.lilygo.cc/products/t-echo)
+    - [AliExpress](https://www.aliexpress.com/item/1005003026107533.html)
 
 ![LILYGO T-Echo](/img/hardware/t-echo.svg)

--- a/docs/hardware/devices/twatch/index.mdx
+++ b/docs/hardware/devices/twatch/index.mdx
@@ -57,9 +57,11 @@ With the device now in the Espressif Firmware Download mode, you can proceed wit
 ## Resources
 
 - Firmware file: `firmware-t-watch-X.X.X.xxxxxxx.bin`
-- Purchase links:
-  - LilyGO Store: [T-Watch 433/868/915Mhz](https://www.lilygo.cc/products/t-watch-s3)
-  - AliExpress: [T-Watch 433/868/915MHz](https://www.aliexpress.us/item/3256805456685117.html)
-  - US Distributor - Purchase link: Rokland [915MHz](https://store.rokland.com/products/lilygo-t-watch-s3-open-source-smartwatch-with-lora-and-esp32)
+- Purchase Links:
+  - US
+    - [Rokland](https://store.rokland.com/products/lilygo-t-watch-s3-open-source-smartwatch-with-lora-and-esp32)
+  - International
+    - [LilyGO](https://www.lilygo.cc/products/t-watch-s3)
+    - [AliExpress](https://www.aliexpress.us/item/3256805456685117.html)
 
 ![T-Watch](/img/hardware/LILYGO-T-Watch-S3.jpg)

--- a/vercel.json
+++ b/vercel.json
@@ -71,6 +71,10 @@
     {
       "source": "/docs/legal/licensing/",
       "destination": "/docs/legal/licensing-and-trademark"
+    },
+    {
+      "source": "/docs/hardware/devices/rak/enclosures/harbor_breeze_solar",
+      "destination": "/docs/hardware/devices/rak/enclosures/harbor-breeze-solar-hack"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -71,10 +71,6 @@
     {
       "source": "/docs/legal/licensing/",
       "destination": "/docs/legal/licensing-and-trademark"
-    },
-    {
-      "source": "/docs/hardware/devices/rak/enclosures/harbor_breeze_solar",
-      "destination": "/docs/hardware/devices/rak/enclosures/harbor-breeze-solar-hack"
     }
   ]
 }


### PR DESCRIPTION
## What
1. Standardizes a number of items within Devices
    - Resource and Purchase Links
    - Page/SEO titles are now all prefixed with the device type/name
    - URL structure for the harbor breeze hack uses dashes

## Why
1. Standardization is good!
2. Page/SEO titles matter for usability, accessibility, and search engine rankings
3. We don't use underscores anywhere else that I could find, so changed to dashes and added redirect
