### PR TITLE
Add device role comparison table

### DIFF
--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -39,13 +39,13 @@ This table shows the **default** values after selecting a preset. As always, ind
 | CLIENT         | Yes                     | Yes            | Regular           | Yes        | No                  | Yes                   |
 | CLIENT_MUTE    | Yes                     | Yes            | Lowest            | No         | No                  | Yes                   |
 | CLIENT_HIDDEN  | Yes                     | Yes            | Lowest            | Local only | No                  | No                    |
-| TRACKER        | No                      | No             | Regular           | No         | No                  | Yes                   |
-| LOST_AND_FOUND | No                      | No             | Regular           | No         | No                  | Yes                   |
-| SENSOR         | No                      | No             | High              | No         | No                  | Yes                   |
+| TRACKER        | Yes                     | No             | Regular           | No         | No                  | Yes                   |
+| LOST_AND_FOUND | Yes                     | No             | Regular           | No         | No                  | Yes                   |
+| SENSOR         | Yes                     | No             | High              | No         | No                  | Yes                   |
 | TAK            | Yes                     | Optional       | Low               | Yes        | No                  | Yes                   |
 | ROUTER         | No                      | No             | High              | Yes        | Yes                 | Yes                   |
 | ROUTER_CLIENT  | Yes                     | Yes            | Highest           | Yes        | Yes                 | Yes                   |
-| REPEATER       | No                      | No             | High              | Yes        | Yes                 | No                    |
+| REPEATER       | Yes                     | No             | High              | Yes        | Yes                 | No                    |
 
 
 ### Rebroadcast Mode

--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -30,6 +30,24 @@ Acceptable values:
 | `CLIENT_HIDDEN`  |                                                                                                                            Client Hidden - Used for nodes that "only speak when spoken to." Turns off all of the routine broadcasts but allows for ad-hoc communication. Still rebroadcasts, but with local only rebroadcast mode (known meshes only). Can be used for clandestine operation or to dramatically reduce airtime / power consumption                                                                                                                             |
 | `LOST_AND_FOUND` |                                                                                                                                                                                                  Lost and Found - Used to automatically send a text message with current position at frequent intervals to the primary channel for the device: "I'm lost! Position: lat / long"                                                                                                                                                                                                   |
 
+#### Role Comparison
+
+This table shows the **default** values after selecting a preset. As always, individual settings can be adjusted after choosing a preset.
+
+| Device Role    | Bluetooth/Wi-Fi Enabled | Screen Enabled | Power Consumption | Retransmit | Prioritized Routing | Visible in Nodes List |
+| -------------- | ----------------------- | -------------- | ----------------- | ---------- | ------------------- | --------------------- |
+| CLIENT         | Yes                     | Yes            | Regular           | Yes        | No                  | Yes                   |
+| CLIENT_MUTE    | Yes                     | Yes            | Lowest            | No         | No                  | Yes                   |
+| CLIENT_HIDDEN  | Yes                     | Yes            | Lowest            | Local only | No                  | No                    |
+| TRACKER        | No                      | No             | Regular           | No         | No                  | Yes                   |
+| LOST_AND_FOUND | No                      | No             | Regular           | No         | No                  | Yes                   |
+| SENSOR         | No                      | No             | High              | No         | No                  | Yes                   |
+| TAK            | Yes                     | Optional       | Low               | Yes        | No                  | Yes                   |
+| ROUTER         | No                      | No             | High              | Yes        | Yes                 | Yes                   |
+| ROUTER_CLIENT  | Yes                     | Yes            | Highest           | Yes        | Yes                 | Yes                   |
+| REPEATER       | No                      | No             | High              | Yes        | Yes                 | No                    |
+
+
 ### Rebroadcast Mode
 
 This setting defines the device's behavior for how messages are rebroadcasted.


### PR DESCRIPTION
## What
1. Adds a comparison table of device role default settings

## Why
1. Misunderstanding of Device Roles: There's a common misunderstanding about the roles of devices within the mesh
2. There's a need for improved educational resources and documentation to clarify device roles and optimal configurations within the network.


# IMPORTANT
For feedback or discussion on specific values, please either comment in the [Google Sheet](https://docs.google.com/spreadsheets/d/1sN0EzJEhlG_shaCdwolba_jQLpuApypmQ3KpjguMYpU/edit#gid=72390815) OR comment inline under the `Files changed` tab.

## Screenshots
<img width="891" alt="Screenshot 2024-02-04 at 8 50 17 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/cbcf3c2e-6aa2-4fd7-a177-e2aee5905b13">


