### PR TITLE
enforce trailing slash in docusaurus

### DIFF
--- a/docs/configuration/module/canned-message.mdx
+++ b/docs/configuration/module/canned-message.mdx
@@ -23,7 +23,7 @@ Enables the canned message module.
 
 Sends a bell character with each message.
 
-The [External Notification Module](external-notification) can be set up to beep when a new message arrives.
+The [External Notification Module](external-notification.mdx) can be set up to beep when a new message arrives.
 This module can also be configured to beep only when a message contains the bell character.
 
 ### Messages

--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -65,5 +65,5 @@ This configures the frequency the radio is set to.  Check out the [frequency cal
 - If you are part of a large mesh and don't know what a setting does, don't change it (unless you're super curious).
 - Leave your [MAX HOPS](/docs/configuration/radio/lora#max-hops) set to 3 unless you're sure you need more (or less) to reach your destination node.
 - TEST your settings and hardware before you install in hard-to-reach locations.
-- Connecting a node to the [public MQTT server](./module/mqtt#connect-to-the-default-public-server) may publish the locations of all nodes in your mesh to the internet.  This will also add every globally connected node to your node database and potentially flood your mesh with all types of packets.
+- Connecting a node to the [public MQTT server](/docs/configuration/module/mqtt#connect-to-the-default-public-server) may publish the locations of all nodes in your mesh to the internet.  This will also add every globally connected node to your node database and potentially flood your mesh with all types of packets.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,7 @@ const config = {
         "An open source, off-grid, decentralized, mesh network built to run on affordable, low-power devices",
     url: "https://meshtastic.org",
     baseUrl: "/",
+    trailingSlash: true,
     onBrokenLinks: "throw",
     onBrokenMarkdownLinks: "warn",
     favicon: "design/web/favicon.ico",


### PR DESCRIPTION
## What
We turned on trailing slashes in #958 but missed the docusaurus config which adds the trailing slash to each link on the page

## Why
We need consistency to avoid duplicate pages in Search Engines

## Test
Build/run locally and check navigation links, they should all end in a trailing slash