### PR TITLE
Update index.mdx

### DIFF
--- a/docs/hardware/devices/rak/index.mdx
+++ b/docs/hardware/devices/rak/index.mdx
@@ -24,4 +24,6 @@ Please see the RAK documentation for the correct way to connect your hardware to
 - RAK's [GitHub Page](https://github.com/RAKWireless/WisBlock) for the WisBlock
 - Purchase links
   - See purchase links under specific base boards, core modules, and peripherals
-  - US Distributor [RAK Wireless Starter Kit](https://store.rakwireless.com/products/wisblock-meshtastic-starter-kit)
+  - China RAK Direct [RAK Wireless Starter Kit w/ Gen2 Base board](https://store.rakwireless.com/products/wisblock-meshtastic-starter-kit)
+  - US Distributor Rokland [RAK Wireless Starter Kit w/ Gen2 Base board](https://store.rokland.com/products/rak-wireless-wisblock-meshtastic-starter-kit)
+  - US Distributor Rokland [RAK Wireless Starter Kit w/ Gen1 Base board](https://store.rokland.com/products/rakwireless-meshtastic-starter-kit-alternative-with-rak5005-o-base)


### PR DESCRIPTION
US distributor link was linking to RAKs website which ships from China. Re-added correct US distributor links via Rokland for Gen1 and Gen2 kits. Rokland will be restocking Gen2 kits within the next few weeks. Gen1 kits are in stock.