### PR TITLE
Fix typos in Meshtastic flasher URLs

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
@@ -12,7 +12,7 @@ import Link from "@docusaurus/Link";
 ## Flash Firmware
 
 :::info
-You may now use the [Meshtastic Web Flasher](https://flasher.mesthastic.org) to download and copy firmware to your nRF52 or RP2040-based devices. Alternatively, follow the instructions below to download and install firmware.
+You may now use the [Meshtastic Web Flasher](https://flasher.meshtastic.org) to download and copy firmware to your nRF52 or RP2040-based devices. Alternatively, follow the instructions below to download and install firmware.
 :::
 
 ### nRF52

--- a/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
@@ -10,7 +10,7 @@ import Link from "@docusaurus/Link";
 Meshtastic uses the [littlefs](https://github.com/littlefs-project/littlefs) library to store configuration, logs, and other data in the internal flash of nRF52 & RP2040 devices. Updating the firmware does _not_ erase this additional data, which can cause issues when the format and location of data changes between releases.
 
 :::info
-You may now use the [Meshtastic Web Flasher](https://flasher.mesthastic.org) to Factory Erase your nRF52 or RP2040-based devices.  Visit the flasher, select your board, and click the trash can icon to the right of the Flash button. This will open a dialogue to begin the erase procedure. 
+You may now use the [Meshtastic Web Flasher](https://flasher.meshtastic.org) to Factory Erase your nRF52 or RP2040-based devices.  Visit the flasher, select your board, and click the trash can icon to the right of the Flash button. This will open a dialogue to begin the erase procedure. 
 
 Alternatively, follow the instructions below.
 :::


### PR DESCRIPTION
A simple PR for a couple of typos I noticed on the homepage.