### PR TITLE
MQTT subpage path forwarding

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -58,6 +58,10 @@
       "destination": "/docs/software/integrations/mqtt"
     },
     {
+      "source": "/docs/software/mqtt/:path*/",
+      "destination": "/docs/software/integrations/mqtt/:path*/"
+    },
+    {
       "source": "/docs/getting-started/faq",
       "destination": "/docs/faq/"
     }


### PR DESCRIPTION
This PR redirects the MQTT subpages from the old software/mqtt/* to the new software/integrations/mqtt/*