### PR TITLE
Add new "channel" field for MQTT JSON downlink

### DIFF
--- a/docs/software/integrations/mqtt/home-assistant.mdx
+++ b/docs/software/integrations/mqtt/home-assistant.mdx
@@ -268,7 +268,7 @@ First, create an input text helper entity. The preferred way to configure an inp
 
 ### Create a Send Message Automation
 
-This automation will check the send box for changes.  After typing a message, either hit enter or click off the box and the automation will send a text string in JSON to the mqtt broker. Make sure to call your channel "mqtt" and to update the device ID and `from` field in the example below. 
+This automation will check the send box for changes.  After typing a message, either hit enter or click off the box and the automation will send a text string in JSON to the mqtt broker. Make sure to publish to a channel called "mqtt" and to update the device ID and `from` field in the example below. A field `channel` can be added to transmit on a different channel index than the primary, or a `to` field can be added with a node number to send a DM.
 
 ```yaml
 - alias: Meshtastic - Send Automation

--- a/docs/software/integrations/mqtt/index.mdx
+++ b/docs/software/integrations/mqtt/index.mdx
@@ -98,11 +98,13 @@ If the message received contains valid JSON in the payload, the JSON is deserial
 
 
 #### JSON downlink to instruct a node to send a message
-You can also send a JSON message to the topic `msh/2/json/mqtt/` to instruct a gateway node to send a message to the mesh. Note that the channel **must** be called "mqtt". The JSON message should contain the following fields:
+You can also send a JSON message to the topic `msh/2/json/mqtt/` to instruct a gateway node to send a message to the mesh. Note that the channel you publish it on **must** be called "mqtt". The JSON message should contain the following fields:
 
 ```json
 {
-   "from": <node number>,
+   "from": <node number of MQTT node>,
+   "to": <node number of recipient for a DM (optional)>,
+   "channel": <channel index (optional)>,
    "type": "type",
    "payload": {
        "key":"value"
@@ -111,7 +113,7 @@ You can also send a JSON message to the topic `msh/2/json/mqtt/` to instruct a g
 }
 ```
 
-`from` and `payload` fields are required for a valid envelope (note that in firmware &lt;2.2.20 a field `sender` was required, but this is no longer the case). The `from` field should be equal to the node number of the node that will transmit the message. Optionally, you can specify a destination by setting the `to` field to the node number of the destination. If the `to` field is not set, the message will be broadcast to all nodes on the mesh.
+`from` and `payload` fields are required for a valid envelope (note that in firmware &lt;2.2.20 a field `sender` was required, but this is no longer the case). The `from` field should be equal to the node number of the node that will transmit the message. Optionally, you can specify a different channel than the primary channel by setting the `channel` field to a channel index (0-7). Furthermore, you can send a direct message by setting the `to` field to the node number of the destination. If the `to` field is not set, the message will be broadcast to all nodes on the mesh.
 
 Currently two types of messages are supported: `"sendtext"` and `"sendposition"`.
 For the type `sendtext`, the `payload` should be a string containing the text to send. For the type `sendposition`, the payload should be an object with the fields `latitude_i`, `longitude_i`, `altitude` (optional) and `time` (optional).

--- a/docs/software/integrations/mqtt/nodered.mdx
+++ b/docs/software/integrations/mqtt/nodered.mdx
@@ -54,13 +54,15 @@ The JSON output only publishes the following subset of the messages on a Meshtas
 > Protobufs are mesh native.
 
 #### 1. Using JSON-encoded messages
-Make sure that option *JSON Output Enabled* is set in MQTT module options and your channel is called "mqtt".
+Make sure that option *JSON Output Enabled* is set in MQTT module options and you have a channel called "mqtt".
 
-Below is a valid JSON envelope for information sent by MQTT to a device for broadcast onto the mesh.
+Below is a valid JSON envelope for information sent by MQTT to a device for broadcast onto the mesh. The `to` field is optional and can be omitted for broadcast. The `channel` field is also optional and can be omitted to send to the primary channel.
 
 ```json
 {
   "from":<node number of the transmitter>,
+  "to": <node number of the receiver for a DM (optional)>,
+  "channel": <channel index (optional)>,
   "type":"sendtext",
   "payload": text or a json object go here
 }
@@ -979,7 +981,7 @@ The flow is:
 ]
 ```
 
-Sending a position to a device for broadcast to the mesh is much easier with JSON. It requires a channel called "mqtt". This introduces a new MQTT Service Envelope type: "sendposition". A valid MQTT envelope and message to broadcast lat, lon, altitude (optional) and time (optional) looks like this:
+Sending a position to a device for broadcast to the mesh is much easier with JSON. It requires the message to be published to a channel called "mqtt". You can let the message send out to a different channel by setting the `channel` field to a channel index (0-7). Then use the MQTT Service Envelope type: "sendposition". A valid MQTT envelope and message to broadcast lat, lon, altitude (optional) and time (optional) looks like this:
 
 ```json
 {


### PR DESCRIPTION
From PR https://github.com/meshtastic/firmware/pull/3183. Still needs to be published on a channel called "mqtt", but then you can specify which channel to transmit on.