### PR TITLE
Heltec LoRa 32 v3.1 added

### DIFF
--- a/docs/hardware/devices/heltec/index.mdx
+++ b/docs/hardware/devices/heltec/index.mdx
@@ -96,6 +96,27 @@ Image Source: [Heltec](<https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-
 
 </TabItem>
 
+<TabItem value="v3.1">
+
+## HELTEC v3.1
+
+On the top right side of the board where it normally says "V3" next to the U.FL/IPEX antenna connector, there is a "V3.1" instead of "V3". These started appearing around November 2023.
+
+[V3.0 schematic](https://web.archive.org/web/20221127054612/https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-WB32LA(F)_V3_Schematic_Diagram.pdf)
+
+[V3.1 schematic](https://resource.heltec.cn/download/WiFi_LoRa_32_V3/HTIT-WB32LA(F)_V3.1_Schematic_Diagram.pdf)
+
+The schematic between V3.0 and V3.1 is virtually identical, with only two differences:
+
+- V3.0 has a [FDG6322C](https://www.mouser.com/datasheet/2/308/1/FDG6322C_D-2312203.pdf) in the power supply circuitry. (FDG6322C is a dual N & P channel digital FET on the output of the LDO regulator. Seems like a cost cutting measure, but it might impact the maximum current or stability of the 3.3V rail.)
+
+- V3.0 had different ESP32-S3 antenna filters:
+  - V3.0: L11 = 1.6nH, C15 = 6.9pF, C24 = 2.4pF
+  - V3.1: L11 = 1.8pF(?), C15 = 2.7nH (?), C24 = 1.8pF
+Question marks above on V3.1 because pF are typically capacitors and nH are typically inductors. Did they mess something up, or did this require an odd swap like this? TODO: someone please confirm the V3.1 ESP-S3 Bluetooth and Wifi are functional with Meshtastic.
+
+</TabItem>
+
 <TabItem value="Wireless Stick Lite V3">
 
 ## HELTEC Wireless Stick Lite V3


### PR DESCRIPTION
I don't know what I'm doing with Meshtastic documentation, I've only done this by hand and hoping it compiles/displays correctly. Someone who knows more about documentation please review how it displays before pushing this live.

---

Heltec LoRa 32 v3.1 has two schematic changes from v3.0

Two people have mentioned it on Discord and one person has mentioned it on Facebook.

OLED screen appears to show a booted Meshtastic. (That shouldn't be an issue as the changes are PSU + ESP32-S3 RF, but at least the 3.3V rail is maybe not impacted?)

- https://discord.com/channels/867578229534359593/871553168369148024/1202361664608149555

- https://discord.com/channels/867578229534359593/919642584480112750/1171093224060883065

- https://www.facebook.com/groups/730536684339042/posts/1486317198760983/

- V3.1 schematic: https://resource.heltec.cn/download/WiFi_LoRa_32_V3/HTIT-WB32LA(F)_V3.1_Schematic_Diagram.pdf

- v3.0 schematic (deleted from Heltec's website!) https://web.archive.org/web/20221127054612/https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-WB32LA(F)_V3_Schematic_Diagram.pdf