### PR TITLE
Fix frequency calculator default and update field order

### DIFF
--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -1,5 +1,6 @@
+import { Config_LoRaConfig_ModemPreset } from "@buf/meshtastic_protobufs.bufbuild_es/meshtastic/config_pb";
 import { Protobuf, Types } from "@meshtastic/js";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 interface Region {
   freqStart: number;
@@ -273,18 +274,18 @@ const modemPresets = new Map<
 
 export const FrequencyCalculator = (): JSX.Element => {
   const [modemPreset, setModemPreset] =
-    React.useState<Protobuf.Config.Config_LoRaConfig_ModemPreset>(
+    useState<Protobuf.Config.Config_LoRaConfig_ModemPreset>(
       Protobuf.Config.Config_LoRaConfig_ModemPreset.LONG_FAST,
     );
   const [region, setRegion] =
-    React.useState<Protobuf.Config.Config_LoRaConfig_RegionCode>(
+    useState<Protobuf.Config.Config_LoRaConfig_RegionCode>(
       Protobuf.Config.Config_LoRaConfig_RegionCode.US,
     );
-  const [channel, setChannel] = React.useState<Types.ChannelNumber>(
-    Types.ChannelNumber.PRIMARY,
+  const [channel, setChannel] = useState<Types.ChannelNumber>(
+    Types.ChannelNumber.Primary,
   );
-  const [numChannels, setNumChannels] = React.useState<number>(0);
-  const [channelFrequency, setChannelFrequency] = React.useState<number>(0);
+  const [numChannels, setNumChannels] = useState<number>(0);
+  const [channelFrequency, setChannelFrequency] = useState<number>(0);
 
   useEffect(() => {
     const selectedRegion = RegionData.get(region);
@@ -344,6 +345,12 @@ export const FrequencyCalculator = (): JSX.Element => {
           ))}
         </select>
       </div>
+
+      <div className="flex gap-2 mb-4">
+        <label className="font-semibold">Number of channels:</label>
+        <input type="number" disabled={true} value={numChannels} />
+      </div>
+
       <div className="flex gap-2">
         <label>Channel:</label>
         <select
@@ -358,10 +365,6 @@ export const FrequencyCalculator = (): JSX.Element => {
         </select>
       </div>
 
-      <div className="flex gap-2">
-        <label className="font-semibold">Number of channels:</label>
-        <input type="number" disabled={true} value={numChannels} />
-      </div>
       <div className="flex gap-2">
         <label className="font-semibold">Channel Frequency:</label>
         <input type="number" disabled={true} value={channelFrequency} />

--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -1,4 +1,3 @@
-import { Config_LoRaConfig_ModemPreset } from "@buf/meshtastic_protobufs.bufbuild_es/meshtastic/config_pb";
 import { Protobuf, Types } from "@meshtastic/js";
 import React, { useEffect, useState } from "react";
 


### PR DESCRIPTION
## Changes

Set default value to `ChannelNumber.Primary`  instead of `ChannelNumber.PRIMARY` which doesn't exist. This caused the "Channel Frequency" value to be empty by default even though channel 1 is selected.

Also moved "Number of channels" below "Region" as that's what it depends on. Having it listed below "Channel" selection made it seem like the number of channels depended on the channel you were on.

## Screenshots

Before
<img src="https://github.com/meshtastic/meshtastic/assets/14356561/be089f38-5b07-46b6-8911-8935e540af05" width="650">


After
<img src="https://github.com/meshtastic/meshtastic/assets/14356561/3fe42177-6de9-4f42-8e69-710d7ad44030" width="650">
