### PR TITLE
Glossary of terms page

### DIFF
--- a/docs/about/contributing.mdx
+++ b/docs/about/contributing.mdx
@@ -4,6 +4,7 @@ sidebar_label: Contributing
 slug: /contributing
 sidebar_position: 3
 ---
+
 ### Volunteer Based Development
 
 Meshtastic is a team of volunteers, and as such there are always plenty of ways to help. This project gets great contributions from people in their off hours. Those contributors work on the features they are interested in. It is a very open and welcoming developer community, and we are always looking for help to improve Meshtastic.

--- a/docs/legal/index.mdx
+++ b/docs/legal/index.mdx
@@ -4,6 +4,7 @@ sidebar_label: Legal
 slug: /legal
 sidebar_position: 9
 ---
+
 ## Disclaimers
 
 **Project Status:** Meshtastic is now at a stage where it offers a _mostly_ stable and reliable functionality, thanks to the dedicated efforts of our development team. While the core aspects of the project are well-established, we are still rapidly evolving and actively adding new features. As we continue to innovate and expand, some features in our current builds are in development, reflecting our commitment to continuous improvement and growth. We appreciate your engagement as we advance further in this exciting journey.

--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -61,7 +61,7 @@ Module | [Software Modules](/docs/configuration/module/) | [Hardware Modules](/d
 Node
 : A unit within the Meshtastic network that can send, receive, and relay messages, helping to form and extend the mesh network's coverage.
 
-NRF52
+NRF52 | [Drivers](/docs/getting-started/serial-drivers/nrf52/) | [Firmware](/docs/getting-started/flashing-firmware/nrf52/)
 : A microcontroller chipset made by Nordic, used by a number of devices used by several devices such as the RAK Meshtastic Starter Kit and the Lilygo T-Echo. Lower power usage than ESP32.
 
 Packet

--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -1,0 +1,119 @@
+---
+id: glossary
+title: Glossary of Terms
+slug: /terms/
+---
+
+App
+: An application that connects to a Meshtastic node, typically for the purpose of sending or receiving data through the mesh network.
+
+Application
+: An application that connects to a Meshtastic node, typically for the purpose of sending or receiving data through the mesh network.
+
+Band
+: A range of frequencies used for LoRa, dependent on region. Meshtastic further divides these bands into channels. Sometimes identified by the lower and upper bounds of the range (e.g. 902-928MHz), sometimes identified by a center frequency within the range (e.g. 915MHz), and sometimes only by the region they apply to (e.g. US).
+
+Broadcast
+: Sending a message or data from one device to all other devices within range in the Meshtastic network, rather than to a specific recipient.
+
+Channel
+: At least two definitions in Meshtastic usage: 1) One of 8 configurable channels in firmware, each supporting a separate name and encryption, with one set as primary and the rest secondary. 2) A specific range of frequency within a LoRa band that a device can be configured to use.
+
+CLI
+: Command Line Interface, a text-based interface used for interacting with software or devices like Meshtastic.
+
+Client
+: A device or application that connects to a Meshtastic node, typically for the purpose of sending or receiving data through the mesh network.
+
+Device
+: A physical piece of hardware that utilizes the Meshtastic software and LoRa (Long Range) radio technology to create a decentralized, long-range mesh network.
+
+ESP32
+: A chipset of microcontroller made/designed by Espressif, used by a number of devices. Higher power usage than NRF52, but often cheaper and supports WiFi if desired.
+
+Firmware
+: The low-level software programmed onto a Meshtastic device, controlling its hardware functions and enabling it to communicate within the mesh network using LoRa technology.
+
+Flash
+: To program or write firmware onto the device's memory. It involves transferring the Meshtastic firmware onto the device's onboard storage.
+
+Flashing
+: The process of updating or installing firmware on a Meshtastic device. This is typically done using a computer to load new firmware versions or custom software to enhance or modify device functionality.
+
+GPIO
+: General Purpose Input/Output. An uncommitted digital signal pin on a device
+
+LoRa
+: A low-power, long-range wireless communication technology used by Meshtastic devices to enable communication over distances of several kilometers without the need for cellular, Wi-Fi, or other traditional network infrastructures.
+
+LoS
+: Line of Sight, a pathway through only air between two points.
+
+Mesh
+: In the context of Meshtastic and networking, a mesh refers to a network topology where devices (nodes) are interconnected, allowing them to directly and dynamically communicate with each other. This setup enables data to be relayed across the network, improving coverage and reliability, especially in challenging environments.
+
+Message
+: A piece of data or text sent between Meshtastic devices over the mesh network, which can include text communications, GPS location updates, and other small data payloads.
+
+Mhz
+: Megahertz, a unit of frequency equal to one million hertz, used to specify the operating frequency of LoRa devices in the Meshtastic network, affecting range and data rate.
+
+Module
+: A component or add-on for a Meshtastic device, typically referring to a hardware piece such as a LoRa radio module, that provides specific functionalities like communication or GPS tracking.
+
+MQTT
+: A lightweight messaging protocol designed for small sensors and mobile devices, enabling efficient data transmission in the Meshtastic network for Internet connectivity and integration with IoT platforms. See https://en.wikipedia.org/wiki/MQTT. In Meshtastic, MQTT is used to connect a node to the internet, and can be used to connect multiple meshes to each other.
+
+Node
+: A unit within the Meshtastic network that can send, receive, and relay messages, helping to form and extend the mesh network's coverage.
+
+NRF52
+: A chipset of microcontroller made by Nordic, used by a number of devices. Lower power usage than ESP32.
+
+Packet
+: A formatted unit of data sent over the network. In Meshtastic, packets carry messages, GPS locations, and other information through the LoRa mesh network.
+
+Protobuf
+: Protocol Buffers, a method developed by Google for serializing structured data, used in Meshtastic for efficient communication protocol between devices.
+
+PSK
+: Pre-Shared Key, a secret code or passphrase used in Meshtastic channels for encryption, ensuring that only devices with the matching PSK can communicate within that specific channel.
+
+Repeater
+: Infrastructure node for extending network coverage by relaying messages with minimal overhead. Not visible in Nodes list.
+
+Router
+: Infrastructure node for extending network coverage by relaying messages. Visible in Nodes list.
+
+rp2040
+: A microcontroller chip developed by Raspberry Pi, featuring dual ARM Cortex-M0+ processors.
+
+RX
+: Short for Receive.
+
+Sensor
+: A device component that detects and responds to some type of input from the physical environment. In Meshtastic, sensors can be used to gather environmental data (e.g., temperature, humidity, GPS location) which can then be transmitted over the mesh network for monitoring or other applications.
+
+Serial
+: A communication protocol used for the transmission of data between the Meshtastic device and a computer or other devices. Typically over USB or UART.
+
+SNR
+: Signal-to-Noise Ratio, a measure used in communications to quantify the level of a desired signal to the level of background noise. In Meshtastic and other wireless systems, a higher SNR indicates a clearer signal that can enhance the reliability and quality of data transmission.
+
+SWR
+: Standing Wave Ratio, a measure of the efficiency of the radio frequency (RF) power transmission from a transmitter through a transmission line to an antenna in Meshtastic devices. It indicates the ratio of the amplitude of a standing wave at maximum to the amplitude at minimum, with an ideal SWR close to 1:1, signifying that most of the power is transmitted to the antenna with minimal reflections.
+
+SX1262
+: A model of LoRa transceiver module known for its low power consumption and long-range capabilities, commonly used in Meshtastic devices for communication.
+
+Telemetry
+: The sending of sensor data or system metrics over the mesh network.
+
+Tranceiver
+: A device capable of both transmitting and receiving communications.
+
+Transmit
+: The act of sending data, such as messages or GPS locations, from one Meshtastic device to another over the LoRa network.
+
+TX
+: Short for Transmit.

--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -17,7 +17,7 @@ Broadcast
 : Sending a message or data from one device to all other devices within range in the Meshtastic network, rather than to a specific recipient.
 
 Channel
-: At least two definitions in Meshtastic usage: 1) One of 8 configurable channels in firmware, each supporting a separate name and encryption, with one set as primary and the rest secondary. 2) A specific range of frequency within a LoRa band that a device can be configured to use.
+: At least two definitions in Meshtastic usage: 1) One of 8 configurable channels in the firmware, each supporting a separate name and encryption, with one set as primary and the rest secondary. 2) A specific frequency within a LoRa band that a device can be configured to use.
 
 CLI
 : Command Line Interface, a text-based interface used for interacting with software or devices like Meshtastic.
@@ -55,20 +55,20 @@ Mesh
 Message
 : A piece of data or text sent between Meshtastic devices over the mesh network, which can include text communications, GPS location updates, and other small data payloads.
 
-Mhz
-: Megahertz, a unit of frequency equal to one million hertz, used to specify the operating frequency of LoRa devices in the Meshtastic network, affecting range and data rate.
+MHz
+: Megahertz, a unit of frequency equal to one million hertz (cycles per second), used to specify the operating frequency of LoRa devices in the Meshtastic network, affecting range and data rate.
 
 Module
-: A component or add-on for a Meshtastic device, typically referring to a hardware piece such as a LoRa radio module, that provides specific functionalities like communication or GPS tracking.
+: At least two definitions in Meshtastic usage: 1) A software plug-in to expand the capabilities of a Meshtastic device. 2) A hardware component or add-on for a Meshtastic device, such as a temperature sensor or GPS.
 
 MQTT
-: A lightweight messaging protocol designed for small sensors and mobile devices, enabling efficient data transmission in the Meshtastic network for Internet connectivity and integration with IoT platforms. See https://en.wikipedia.org/wiki/MQTT. In Meshtastic, MQTT is used to connect a node to the internet, and can be used to connect multiple meshes to each other.
+: An acronym for Message Queuing Telemetry Transport, is a lightweight messaging protocol designed for small sensors and mobile devices, enabling efficient data transmission in the Meshtastic network for Internet connectivity and integration with IoT platforms. See https://en.wikipedia.org/wiki/MQTT. In Meshtastic, MQTT is used to connect a node to the internet, and can be used to connect multiple meshes to each other.
 
 Node
 : A unit within the Meshtastic network that can send, receive, and relay messages, helping to form and extend the mesh network's coverage.
 
 NRF52
-: A chipset of microcontroller made by Nordic, used by a number of devices. Lower power usage than ESP32.
+: A microcontroller chipset made by Nordic, used by a number of devices used by several devices such as the RAK Meshtastic Starter Kit and the Lilygo T-Echo. Lower power usage than ESP32.
 
 Packet
 : A formatted unit of data sent over the network. In Meshtastic, packets carry messages, GPS locations, and other information through the LoRa mesh network.
@@ -89,7 +89,7 @@ rp2040
 : A microcontroller chip developed by Raspberry Pi, featuring dual ARM Cortex-M0+ processors.
 
 RX
-: Short for Receive.
+: Abbreviation for Receive.
 
 Sensor
 : A device component that detects and responds to some type of input from the physical environment. In Meshtastic, sensors can be used to gather environmental data (e.g., temperature, humidity, GPS location) which can then be transmitted over the mesh network for monitoring or other applications.
@@ -103,9 +103,6 @@ SNR
 SWR
 : Standing Wave Ratio, a measure of the efficiency of the radio frequency (RF) power transmission from a transmitter through a transmission line to an antenna in Meshtastic devices. It indicates the ratio of the amplitude of a standing wave at maximum to the amplitude at minimum, with an ideal SWR close to 1:1, signifying that most of the power is transmitted to the antenna with minimal reflections.
 
-SX1262
-: A model of LoRa transceiver module known for its low power consumption and long-range capabilities, commonly used in Meshtastic devices for communication.
-
 Telemetry
 : The sending of sensor data or system metrics over the mesh network.
 
@@ -116,4 +113,4 @@ Transmit
 : The act of sending data, such as messages or GPS locations, from one Meshtastic device to another over the LoRa network.
 
 TX
-: Short for Transmit.
+: Abbreviation for Transmit.

--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -43,7 +43,7 @@ LoRa
 LoS
 : Line of Sight, a pathway through only air between two points.
 
-Mesh | [Algorythm](/docs/overview/mesh-algo/)
+Mesh | [Algorithm](/docs/overview/mesh-algo/)
 : In the context of Meshtastic and networking, a mesh refers to a network topology where devices (nodes) are interconnected, allowing them to directly and dynamically communicate with each other. This setup enables data to be relayed across the network, improving coverage and reliability, especially in challenging environments.
 
 Message

--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -25,6 +25,9 @@ Client
 Device
 : A physical piece of hardware that utilizes the Meshtastic software and LoRa (Long Range) radio technology to create a decentralized, long-range mesh network.
 
+DFU
+: Device Firmware Update, a state which a device is placed into for it to receive a firmware update
+
 ESP32 | [Drivers](/docs/getting-started/serial-drivers/esp32/) | [Firmware](/docs/getting-started/flashing-firmware/esp32/)
 : A chipset of microcontroller made/designed by Espressif, used by a number of devices. Higher power usage than NRF52, but often cheaper and supports WiFi if desired. 
 

--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -4,10 +4,7 @@ title: Glossary of Terms
 slug: /terms/
 ---
 
-App
-: An application that connects to a Meshtastic node, typically for the purpose of sending or receiving data through the mesh network.
-
-Application
+App / Application / Client Application
 : An application that connects to a Meshtastic node, typically for the purpose of sending or receiving data through the mesh network.
 
 Band
@@ -16,10 +13,10 @@ Band
 Broadcast
 : Sending a message or data from one device to all other devices within range in the Meshtastic network, rather than to a specific recipient.
 
-Channel
+Channel | [Configuration](/docs/configuration/radio/channels/) | [Frequency Calculator](/docs/overview/radio-settings/#channel-frequency-calculator)
 : At least two definitions in Meshtastic usage: 1) One of 8 configurable channels in the firmware, each supporting a separate name and encryption, with one set as primary and the rest secondary. 2) A specific frequency within a LoRa band that a device can be configured to use.
 
-CLI
+CLI | [Guide](/docs/software/python/cli/)
 : Command Line Interface, a text-based interface used for interacting with software or devices like Meshtastic.
 
 Client
@@ -28,16 +25,13 @@ Client
 Device
 : A physical piece of hardware that utilizes the Meshtastic software and LoRa (Long Range) radio technology to create a decentralized, long-range mesh network.
 
-ESP32
-: A chipset of microcontroller made/designed by Espressif, used by a number of devices. Higher power usage than NRF52, but often cheaper and supports WiFi if desired.
+ESP32 | [Drivers](/docs/getting-started/serial-drivers/esp32/) | [Firmware](/docs/getting-started/flashing-firmware/esp32/)
+: A chipset of microcontroller made/designed by Espressif, used by a number of devices. Higher power usage than NRF52, but often cheaper and supports WiFi if desired. 
 
-Firmware
-: The low-level software programmed onto a Meshtastic device, controlling its hardware functions and enabling it to communicate within the mesh network using LoRa technology.
+Firmware | [Guide](https://meshtastic.org/docs/getting-started/flashing-firmware/)
+: The low-level software programmed onto a Meshtastic device, controlling its hardware functions and enabling it to communicate within the mesh network using LoRa technology. Firmware
 
-Flash
-: To program or write firmware onto the device's memory. It involves transferring the Meshtastic firmware onto the device's onboard storage.
-
-Flashing
+Flash/Flashing | [Guide](https://meshtastic.org/docs/getting-started/flashing-firmware/)
 : The process of updating or installing firmware on a Meshtastic device. This is typically done using a computer to load new firmware versions or custom software to enhance or modify device functionality.
 
 GPIO
@@ -49,7 +43,7 @@ LoRa
 LoS
 : Line of Sight, a pathway through only air between two points.
 
-Mesh
+Mesh | [Algorythm](/docs/overview/mesh-algo/)
 : In the context of Meshtastic and networking, a mesh refers to a network topology where devices (nodes) are interconnected, allowing them to directly and dynamically communicate with each other. This setup enables data to be relayed across the network, improving coverage and reliability, especially in challenging environments.
 
 Message
@@ -58,10 +52,10 @@ Message
 MHz
 : Megahertz, a unit of frequency equal to one million hertz (cycles per second), used to specify the operating frequency of LoRa devices in the Meshtastic network, affecting range and data rate.
 
-Module
+Module | [Software Modules](/docs/configuration/module/) | [Hardware Modules](/docs/hardware/devices/)
 : At least two definitions in Meshtastic usage: 1) A software plug-in to expand the capabilities of a Meshtastic device. 2) A hardware component or add-on for a Meshtastic device, such as a temperature sensor or GPS.
 
-MQTT
+[MQTT](/docs/software/integrations/mqtt/)
 : An acronym for Message Queuing Telemetry Transport, is a lightweight messaging protocol designed for small sensors and mobile devices, enabling efficient data transmission in the Meshtastic network for Internet connectivity and integration with IoT platforms. See https://en.wikipedia.org/wiki/MQTT. In Meshtastic, MQTT is used to connect a node to the internet, and can be used to connect multiple meshes to each other.
 
 Node
@@ -73,16 +67,16 @@ NRF52
 Packet
 : A formatted unit of data sent over the network. In Meshtastic, packets carry messages, GPS locations, and other information through the LoRa mesh network.
 
-Protobuf
+Protobuf | [Reference](/docs/development/reference/protobufs/)
 : Protocol Buffers, a method developed by Google for serializing structured data, used in Meshtastic for efficient communication protocol between devices.
 
-PSK
+PSK | [Encryption](/docs/overview/encryption/)
 : Pre-Shared Key, a secret code or passphrase used in Meshtastic channels for encryption, ensuring that only devices with the matching PSK can communicate within that specific channel.
 
-Repeater
+Repeater | [Role Definitions](/docs/configuration/radio/device/#roles)
 : Infrastructure node for extending network coverage by relaying messages with minimal overhead. Not visible in Nodes list.
 
-Router
+Router | [Role Definitions](/docs/configuration/radio/device/#roles)
 : Infrastructure node for extending network coverage by relaying messages. Visible in Nodes list.
 
 rp2040

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 require("dotenv").config();
+import remarkDefList from "remark-deflist";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -121,6 +122,7 @@ const config = {
           editUrl: "https://github.com/meshtastic/meshtastic/edit/master/",
           breadcrumbs: false,
           showLastUpdateAuthor: true,
+          remarkPlugins: [remarkDefList],
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",
+    "remark-deflist": "^1.0.0",
     "swr": "^2.2.4",
     "tailwindcss": "^3.4.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ dependencies:
   react-icons:
     specifier: ^4.12.0
     version: 4.12.0(react@18.2.0)
+  remark-deflist:
+    specifier: ^1.0.0
+    version: 1.0.0
   swr:
     specifier: ^2.2.4
     version: 2.2.4(react@18.2.0)
@@ -6689,6 +6692,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /mdast-util-phrasing@3.0.1:
+    resolution: {integrity: sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==}
+    dependencies:
+      '@types/mdast': 3.0.15
+      unist-util-is: 5.2.1
+    dev: false
+
   /mdast-util-phrasing@4.0.0:
     resolution: {integrity: sha512-xadSsJayQIucJ9n053dfQwVu1kuXg7jCTdYsMK8rqzKZh52nLfSH/k0sAxE0u+pj/zKZX+o5wB+ML5mRayOxFA==}
     dependencies:
@@ -6706,6 +6716,19 @@ packages:
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
+
+  /mdast-util-to-markdown@1.5.0:
+    resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
+    dependencies:
+      '@types/mdast': 3.0.15
+      '@types/unist': 2.0.10
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 3.0.1
+      mdast-util-to-string: 3.2.0
+      micromark-util-decode-string: 1.1.0
+      unist-util-visit: 4.1.2
+      zwitch: 2.0.4
+    dev: false
 
   /mdast-util-to-markdown@2.1.0:
     resolution: {integrity: sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==}
@@ -8671,6 +8694,17 @@ packages:
     engines: {node: '>= 0.10'}
     dev: false
 
+  /remark-deflist@1.0.0:
+    resolution: {integrity: sha512-sDHM+ZbgWC6wwaxltMdH5x+XYMW8VpjyeHyC2ZCI106+iYgbPv8lBYKiNqdW0Cs0FVox/LysYhb3qIZe1b0cmg==}
+    dependencies:
+      mdast-util-from-markdown: 1.3.1
+      mdast-util-to-markdown: 1.5.0
+      mdast-util-to-string: 3.2.0
+      unist-util-visit: 4.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /remark-directive@3.0.0:
     resolution: {integrity: sha512-l1UyWJ6Eg1VPU7Hm/9tt0zKtReJQNOA4+iDMAxTyZNWnJnFlbS/7zhiel/rogTLQ2vMYwDzSJa4BiVNqGlqIMA==}
     dependencies:
@@ -9598,6 +9632,12 @@ packages:
       crypto-random-string: 4.0.0
     dev: false
 
+  /unist-util-is@5.2.1:
+    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
+    dependencies:
+      '@types/unist': 2.0.10
+    dev: false
+
   /unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
     dependencies:
@@ -9630,11 +9670,26 @@ packages:
     dependencies:
       '@types/unist': 3.0.2
 
+  /unist-util-visit-parents@5.1.3:
+    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
+    dependencies:
+      '@types/unist': 2.0.10
+      unist-util-is: 5.2.1
+    dev: false
+
   /unist-util-visit-parents@6.0.1:
     resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
     dependencies:
       '@types/unist': 3.0.2
       unist-util-is: 6.0.0
+
+  /unist-util-visit@4.1.2:
+    resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
+    dependencies:
+      '@types/unist': 2.0.10
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
+    dev: false
 
   /unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}


### PR DESCRIPTION
## What
1. Adds a new `/docs/terms/` page to the site which has a list of common terms and their definitions
2. Adds [definition lists](https://docusaurus.community/knowledge/markdown/definition-lists/)
3. Fixes a markdown issue with two pages causing failed builds in some cases(contributing and legal)

## Why
We (Discord #docs) believe that it will be useful to have a standardized way of defining terms so that Meshtastic users can reliably find definitions without asking others.
Description lists are the semantic way of handling this in html https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl

## Screenshots
<img width="311" alt="Screenshot 2024-02-10 at 11 39 57 AM" src="https://github.com/meshtastic/meshtastic/assets/5215365/46c4ee7c-6bf8-48a5-80b5-91eb66932693">
<img width="952" alt="Screenshot 2024-02-10 at 11 39 53 AM" src="https://github.com/meshtastic/meshtastic/assets/5215365/47af602c-50df-4a30-8ec2-24c411e26fab">
