### PR TITLE
Update power.mdx

### DIFF
--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -38,7 +38,7 @@ Should be set to floating point value between 2 and 6
 
 #### Calibration Process ([Attribution](https://wiki.uniteng.com/en/meshtastic/nano-g1-explorer#calibration-process))
 
-1. Install the rechargeable Li-Polymer battery.
+1. Install the rechargeable battery.
 2. Charge the battery until full. Indication of this state may vary depending on device. At this point, the battery voltage should be 4.2V +-1%.
 3. Input the "Battery Charge Percent" displayed on the screen or in your connected app into the calculator below.
 4. If "Battery Charge Percent" (e.g., B 3.82V 60%) is not displayed on the screen, it means that the default value of "Operative Adc Multiplier" is too high. Lower the "Operative Adc Multiplier" to a smaller number (it is recommended to decrease by 0.1) until the screen displays "Battery Charge Percent". Enter the current "Operative Adc Multiplier" in use into the "Operative Adc Multiplier" field in the calculator. Also, input the "Battery Charge Percent" displayed on the screen into the calculator.


### PR DESCRIPTION
Removed the specific reference to lipo batteries, as instructions also apply to lithium ion batteries such as 18650s.