### PR TITLE
Update lora.mdx

### DIFF
--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -51,7 +51,7 @@ The Presets available are as follows, and follow a linear pattern of Fastest \<\
 
 7. `LONG_SLOW`
 
-8. `VERY_LONG_SLOW` (Slowest, lowest bandwidth, highest airtime, longest range)
+8. `VERY_LONG_SLOW` (Slowest, lowest bandwidth, highest airtime, longest range. Not recommended for regular usage as does not form meshes well and is unreliable)
 
 ### Max Hops
 


### PR DESCRIPTION
I've noticed a tendency of users to set to very-long-slow because they think the only disadvantage is speed.

As per conversations with Garth, very-long-slow is unreliable, rarely ACKs and does not form meshes well. This is mentioned nowhere in the docs.