### PR TITLE
Add meta descriptions for all of the pages under About

### DIFF
--- a/docs/about/contributing.mdx
+++ b/docs/about/contributing.mdx
@@ -3,6 +3,7 @@ title: Contributing to Meshtastic
 sidebar_label: Contributing
 slug: /contributing
 sidebar_position: 3
+description: "Get involved with Meshtastic's open-source project. Contribute to device firmware, web apps, or mobile and desktop apps. Your expertise can help enhance this volunteer-driven communication platform."
 ---
 
 import Link from "@docusaurus/Link"

--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -3,6 +3,7 @@ id: faq
 title: FAQs
 slug: /faq
 sidebar_position: 3
+description: "Find answers to your Meshtastic questions: from getting started, device setup, to advanced features. Learn about app compatibility, channel sharing, and HAM license benefits. Dive into our comprehensive FAQ."
 ---
 
 import { FaqAccordion } from "/src/components/FaqAccordion";

--- a/docs/about/introduction.mdx
+++ b/docs/about/introduction.mdx
@@ -3,6 +3,7 @@ title: Introduction
 sidebar_label: Introduction
 slug: /introduction
 sidebar_position: 1
+description: "Discover Meshtastic: a community-driven, open-source project using LoRa radios for long-range, off-grid communication."
 ---
 
 import Link from "@docusaurus/Link";

--- a/docs/about/overview/encryption.mdx
+++ b/docs/about/overview/encryption.mdx
@@ -4,6 +4,7 @@ title: Meshtastic Encryption
 sidebar_label: Encryption
 slug: /overview/encryption
 sidebar_position: 3
+description: "Understand Meshtastic's encryption: optional network-wide AES256 security for off-grid communication, ensuring confidentiality against passive eavesdropping."
 ---
 
 

--- a/docs/about/overview/index.mdx
+++ b/docs/about/overview/index.mdx
@@ -3,6 +3,7 @@ title: Overview
 sidebar_label: Overview
 slug: /overview
 sidebar_position: 2
+description: "Discover the basics of Meshtastic's operation, from sending messages via the companion app to the network's intelligent rebroadcast system for extended reach."
 ---
 
 ## How it works

--- a/docs/about/overview/mesh-alg.mdx
+++ b/docs/about/overview/mesh-alg.mdx
@@ -4,6 +4,7 @@ title: Mesh Broadcast Algorithm
 slug: /overview/mesh-algo
 sidebar_label: Mesh Algorithm
 sidebar_position: 2
+description: "Discover the Meshtastic Mesh Broadcast Algorithm: a simple, yet effective routing protocol designed for off-grid communication using LoRa technology."
 ---
 
 ## Current Algorithm

--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -4,6 +4,7 @@ title: Radio Settings
 slug: /overview/radio-settings
 sidebar_label: Radio Settings
 sidebar_position: 1
+description: "Maximize your Meshtastic device's potential with detailed radio settings instructions, including frequency bands, data rates, and encryption options."
 ---
 
 import {FrequencyCalculator} from "/src/components/tools/FrequencyCalculator";

--- a/docs/about/overview/range-test.mdx
+++ b/docs/about/overview/range-test.mdx
@@ -4,6 +4,7 @@ title: Range Tests
 slug: /overview/range-tests
 sidebar_label: Range Tests
 sidebar_position: 4
+description: "Explore Meshtastic's impressive range achievements with detailed modem settings and device configurations for both ground and air records."
 ---
 
 import Tabs from "@theme/Tabs";


### PR DESCRIPTION
## What
1. Adds meta descriptions for all of the pages under About

## Why
1. Good for SEO
2. Shows up on aggregate pages (e.g. /docs/configuration/)