### PR TITLE
Update base-boards.mdx to correct list of slots on RAK19003.

### DIFF
--- a/docs/hardware/devices/rak/base-boards.mdx
+++ b/docs/hardware/devices/rak/base-boards.mdx
@@ -97,7 +97,6 @@ Further information on the RAK19007 can be found on the [RAK Documentation Cente
 - [RAK19003](https://store.rakwireless.com/products/wisblock-base-board-rak19003) - WisBlock's Mini Base Board.
   - **Slots**
     - (x1) Core Module slot
-    - (x1) WisBlock IO Module slot
     - (x2) WisBlock Sensor Module slots
   - **Buttons**
     - (x1) Reset Button


### PR DESCRIPTION
Documentation incorrectly listed the WisBlock IO Module slot on the RAK19003 Mini Base Board, update to correct.