### PR TITLE
Update Store and Forward documentation

### DIFF
--- a/docs/configuration/module/store-and-forward-module.mdx
+++ b/docs/configuration/module/store-and-forward-module.mdx
@@ -7,19 +7,20 @@ sidebar_label: Store & Forward
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-:::info
-Currently only available for ESP32 based devices with external PSRAM like the tbeam. Requires the device to be set as a ROUTER or ROUTER_CLIENT.
-:::
-
 ## Overview
 
-:::caution
-This is a work in progress and the required client support is not yet available.
+Using this module, a client device can ask a special Store & Forward Router to resend text messages after the client has been temporarily not in LoRa range of the mesh.
+
+:::info
+Only ESP32 based devices with onboard PSRAM like the T-Beam and T3S3 can be a Store & Forward Router. Requires the device to use at least firmware version 2.2.23 and to be set as a `ROUTER` or `ROUTER_CLIENT`.
 :::
 
-The Store & Forward Module is an implementation of a Store and Forward system to enable resilient messaging in the event that a client device is disconnected from the main network.
+When a client device requests the history from the Store & Forward Router, the router will resend the text messages over LoRa that it has received. The router will only return messages that are within the time window the client has requested up to the maximum number of messages configured for the router. 
+The router does not know which messages the client device actually missed, so it is possible that you receive duplicates. 
 
-Because of the increased network traffic for this overhead, it's not advised to use this if you are duty cycle limited for your airtime usage (EU_868 and EU_433) nor is it advised to use this for presets using SF11 or SF12 (e.g. all of the LongRange and VeryLongRange presets).
+:::important
+Be mindful when requesting the history, as the router might send a lot of messages which will burden your mesh for a short period of time.
+:::
 
 ## Details
 
@@ -29,28 +30,22 @@ Because of the increased network traffic for this overhead, it's not advised to 
 
 ### Requirements
 
-Initial Requirements:
+Initial requirements for the Store and Forward Router:
 
-- Must be installed on a ROUTER or ROUTER_CLIENT node.
+- Must be installed on a `ROUTER` or `ROUTER_CLIENT` node.
   - This is an artificial limitation, but is in place to enforce best practices.
   - Router nodes are intended to be always online. If this module misses any messages, the reliability of the stored messages will be reduced.
-- ESP32 Processor based device with external PSRAM. (tbeam > v1.0, T3S3, and maybe others)
+- ESP32 Processor based device with onboard PSRAM (T-Beam > v1.0, T3S3, and maybe others).
 
 ### Usage Overview
 
 - To use / test this you will want at least 3 devices
-  - One ESP32 device with PSRAM configured as a Meshtastic router.
-  - Two others will be regular clients. Nothing special required.
-
-### Meshtastic channel configuration
-
-Don't use this on the "LongRange" channel settings. You're welcome to try and report back, but those channels have a [low bitrate](/docs/overview/radio-settings#presets).
-
-Either use a custom channel configuration with at an at least 1kbit data rate or use a Medium or Short range preset.
+  - One ESP32 device with PSRAM configured as `ROUTER` or `ROUTER_CLIENT`.
+  - Two others will be regular clients. If one client sends a text message when the other is not in range, the other can request the history from the router to receive the missed message when it is back in range.
 
 ### Router setup
 
-- Configure your device as a router.
+- Configure your device as a `ROUTER` or `ROUTER_CLIENT`.
 - Name your router node something that makes it easily identifiable, aka "Router".
 - Configure the Store and Forward module
 
@@ -58,17 +53,18 @@ Either use a custom channel configuration with at an at least 1kbit data rate or
   meshtastic --set store_forward.enabled true
   ```
 
-  ```shell title="Optional - Set maximum number of records to save to device"
-  meshtastic --set store_forward.records 100
+  ```shell title="Optional - Disable sending heartbeat."
+  meshtastic --set store_forward.heartbeat false
   ```
 
   :::tip
-  Best to leave `store_forward.records` at the default (`0`) where the module will use 2/3 of your device's available PSRAM. This is about 11,000 records.
+  Best to disable the heartbeat (which is sent every 15 minutes) when all client devices have identified the router to reduce network traffic.
   :::
 
 ### Client Usage
 
-Currently there are no clients that support store and forward.
+Currently implemented in the Android and Apple apps version 2.2.23 and higher. To request the history from the Store & Forward Router, for Android it is required to send it a direct message containing the text "SF" (without quotes). The router will then respond with the requested messages.
+The Apple apps will also show whether a node is a Store & Forward Router in the node list after it heard the heartbeat. You can then long press the node and select "Client History" to request the history from the router.
 
 ## Settings
 
@@ -82,7 +78,7 @@ The Store & Forward Router sends a periodic message onto the network. This allow
 
 ### History Return Max
 
-Sets the maximum number of messages to return to a client device.
+Sets the maximum number of messages to return to a client device when it requests the history.
 
 ### History Return Window
 
@@ -90,7 +86,7 @@ Limits the time period (in minutes) a client device can request.
 
 ### Records
 
-Set this to the maximum number of records to save. Best to leave this at the default (`0`) where the module will use 2/3 of your device's available PSRAM. This is about 11,000 records.
+Set this to the maximum number of records the router will save. Best to leave this at the default (`0`) where the module will use 2/3 of your device's available PSRAM. This is about 11,000 records.
 
 ### Client Config
 
@@ -135,9 +131,9 @@ Store and Forward configuration is not currently available via the Apple clients
 | :---------------------------------: | :---------------: | :-----: |
 |        store_forward.enabled        |  `true`, `false`  | `false` |
 |       store_forward.heartbeat       |  `true`, `false`  | `false` |
-|  store_forward.history_return_max   |     `integer`     |   `0`   |
-| store_forward.history_return_window |     `integer`     |   `0`   |
-|        store_forward.records        |     `integer`     |   `0`   |
+|  store_forward.history_return_max   |     `integer`     |   `0` (25 messages)  |
+| store_forward.history_return_window |     `integer`     |   `0` (240 minutes)  |
+|        store_forward.records        |     `integer`     |   `0` (≈11,000 records) |
 
 :::tip
 
@@ -164,14 +160,14 @@ meshtastic --set store_forward.heartbeat 0
 ```
 
 
-```shell title="Set store_forward.history_return_max to default"
+```shell title="Set store_forward.history_return_max to default (25 messages)"
 meshtastic --set store_forward.history_return_max 0
 ```
 ```shell title="Set store_forward.history_return_max to 100 messages"
 meshtastic --set store_forward.history_return_max 100
 ```
 
-```shell title="Set store_forward.history_return_window to default"
+```shell title="Set store_forward.history_return_window to default (240 minutes)"
 meshtastic --set store_forward.history_return_window 0
 ```
 ```shell title="Set store_forward.history_return_window to 1 day (1440 minutes)"


### PR DESCRIPTION
- Android and Apple apps support it now for versions and firmware >=2.2.23.
- Fast modem presets not strictly necessary, but be mindful when requesting history.
- Misc.

I'm assuming #1034 gets merged for the updated module configuration for Apple.

