### PR TITLE
FAQ accordion open sets nearest heading hash in url

### DIFF
--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -190,38 +190,38 @@ If you use your ham radio license with Meshtastic, consider both the privileges 
 
 ## Overview
 
-<FaqAccordion rows={Faq.general} slug="general" />
+<FaqAccordion rows={Faq.general} />
 
 ## Android Client
 
-<FaqAccordion rows={Faq.android} slug="android" />
+<FaqAccordion rows={Faq.android} />
 
 ## Apple Clients
 
-<FaqAccordion rows={Faq.apple} slug="apple" />
+<FaqAccordion rows={Faq.apple} />
 
 ## Channels
 
-<FaqAccordion rows={Faq.channels} slug="channels" />
+<FaqAccordion rows={Faq.channels} />
 
 ## Python CLI
 
-<FaqAccordion rows={Faq.python} slug="python" />
+<FaqAccordion rows={Faq.python} />
 
 ## Devices
 
-<FaqAccordion rows={Faq.devices} slug="devices" />
+<FaqAccordion rows={Faq.devices} />
 
 ## Amateur Radio (ham)
 
 Meshtastic can be used by both unlicensed people and licensed HAM operators.
 
-<FaqAccordion rows={Faq.ham} slug="ham" />
+<FaqAccordion rows={Faq.ham} />
 
 ## Mesh
 
-<FaqAccordion rows={Faq.mesh} slug="mesh" />
+<FaqAccordion rows={Faq.mesh} />
 
 ## Modules
 
-<FaqAccordion rows={Faq.modules} slug="modules" />
+<FaqAccordion rows={Faq.modules} />

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -63,7 +63,7 @@ const updateUrlWithNearestHeadingId = (targetElementUuid: string): void => {
 
   // If they're all collapsed, remove the hash
   if (!targetElement) {
-    window.location.hash = "";
+    history.pushState(null, null, window.location.origin + window.location.pathname + window.location.search);
   }
 };
 

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -49,7 +49,7 @@ const findNearestHeading = (element: Element): Element | null => {
  */
 const updateUrlWithNearestHeadingId = (targetElementUuid: string): void => {
   const targetElement: HTMLElement | null = document.getElementById(
-    `accordion__heading-${targetElementUuid}`,
+    `accordion__heading-${targetElementUuid[0]}`,
   );
 
   const nearestHeading: Element | null = targetElement
@@ -63,7 +63,7 @@ const updateUrlWithNearestHeadingId = (targetElementUuid: string): void => {
 
   // If they're all collapsed, remove the hash
   if (!targetElement) {
-    window.location.hash = '';
+    window.location.hash = "";
   }
 };
 

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -1,4 +1,3 @@
-import BrowserOnly from "@docusaurus/BrowserOnly";
 import {
   Accordion,
   AccordionItem,
@@ -21,7 +20,8 @@ export interface Faq {
  * @return {Element|null} The heading or null
  */
 const findNearestHeading = (element: Element): Element | null => {
-  const isHeading = (element: Element): boolean => /^H[1-6]$/.test(element.tagName);
+  const isHeading = (element: Element): boolean =>
+    /^H[1-6]$/.test(element.tagName);
   let currentElement: Element | null = element;
 
   while (currentElement !== null) {
@@ -47,25 +47,33 @@ const findNearestHeading = (element: Element): Element | null => {
  * @param  {[type]} void [description]
  * @return {[type]}      [description]
  */
-const updateURLWithNearestHeadingId = (targetElementUuid: string): void => {
-  const targetElement: HTMLElement | null = document.getElementById(`accordion__heading-${targetElementUuid}`);
+const updateUrlWithNearestHeadingId = (targetElementUuid: string): void => {
+  const targetElement: HTMLElement | null = document.getElementById(
+    `accordion__heading-${targetElementUuid}`,
+  );
 
-  const nearestHeading: Element | null = targetElement ? findNearestHeading(targetElement) : null;
+  const nearestHeading: Element | null = targetElement
+    ? findNearestHeading(targetElement)
+    : null;
 
-  if (nearestHeading && nearestHeading.id) {
-    window.history.pushState({}, '', `#${nearestHeading.id}`);
+  // Add the hash without scrolling the page
+  if (nearestHeading?.id) {
+    window.history.pushState({}, "", `#${nearestHeading.id}`);
   }
-}
 
-export const FaqAccordion = ({
-  rows,
-}: { rows: Faq[] }): JSX.Element => {
+  // If they're all collapsed, remove the hash
+  if (!targetElement) {
+    window.location.hash = '';
+  }
+};
+
+export const FaqAccordion = ({ rows }: { rows: Faq[] }): JSX.Element => {
   return (
     <Accordion
       allowMultipleExpanded={true}
       allowZeroExpanded={true}
       onChange={(itemUuids) => {
-        updateURLWithNearestHeadingId(itemUuids);
+        updateUrlWithNearestHeadingId(itemUuids);
       }}
     >
       {rows.map((row, index) => (


### PR DESCRIPTION
## What
- Updates the FaqAccordion component so that when an accordion is opened, the hash of the nearest heading is added to the url of the page 
    - This **no longer** automatically opens accordion items for the user
- Remove `slug` from Faq.mdx because it's no longer needed 🥳 

## Why
- Better for sharing, auto scrolls user to the right section
- Handling auto opening was extremely complex and caused an issue where we had to wait for client side rendering to handle FAQs. This causes other issues like generating PDFs of the docs is not possible.