### PR TITLE
Add notes that JSON is not supported on the nRF52 platform

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -38,6 +38,10 @@ Whether to send encrypted or unencrypted packets to MQTT. This parameter is only
 
 ### JSON Enabled
 
+:::note
+JSON is not supported on the nRF52 platform.
+:::
+
 Enable the sending / consumption of JSON packets on MQTT. These packets are not encrypted, but offer an easy way to integrate with systems that can read JSON.
 
 ### TLS Enabled

--- a/docs/configuration/radio/network.mdx
+++ b/docs/configuration/radio/network.mdx
@@ -167,7 +167,7 @@ All Network config options are available in the Web UI.
 
 ### WiFi Client
 
-With `network.wifi_ssid` & `network.wifi_psk` populated, the device will know to connect to your network. Make sure you are in range of your WiFi. If you have a single Meshtastic device on your local network it's easy to connect to your device with DNS `http://meshtastic.local`. If you have multiple Meshtastic devices you will need to connect using their respective IP addresses.
+With `network.wifi_ssid` & `network.wifi_psk` populated, the device will know to connect to your network. Make sure you are in range of your WiFi and it is a 2.4GHz-only network. If you have a single Meshtastic device on your local network it's easy to connect to your device with DNS `http://meshtastic.local`. If you have multiple Meshtastic devices you will need to connect using their respective IP addresses.
 
 ### Disable WiFi
 

--- a/docs/software/integrations/mqtt/index.mdx
+++ b/docs/software/integrations/mqtt/index.mdx
@@ -54,6 +54,10 @@ The payload is a raw protobuf, whose definitions for Meshtastic can be found [he
 If [encryption_enabled](/docs/configuration/module/mqtt#encryption-enabled) is set to true, the payload of the MeshPacket will remain encrypted with the key for the specified channel.
 
 #### JSON topic
+:::note
+JSON is not supported on the nRF52 platform.
+:::
+
 If [JSON is enabled](/docs/configuration/module/mqtt#json-enabled), packets from the following [port numbers](/docs/development/firmware/portnum) are serialized to JSON: `TEXT_MESSAGE_APP`, `TELEMETRY_APP`, `NODEINFO_APP`, `POSITION_APP`, `WAYPOINT_APP`, `NEIGHBORINFO_APP`, `TRACEROUTE_APP`, `DETECTION_SENSOR_APP`, `PAXCOUNTER_APP` and `REMOTE_HARDWARE_APP`. These are then forwarded to the topic:
 
 `msh/2/json/CHANNELNAME/USERID`.
@@ -123,7 +127,7 @@ For the type `sendtext`, the `payload` should be a string containing the text to
 Check out [MQTT Settings](/docs/configuration/module/mqtt) for full information. For quick start instructions, read on.
 
 - Connect your gateway node to wifi, by setting the `network.wifi_ssid`, `network.wifi_psk` and `network.wifi_enabled` preferences.
-- Alternatively use the RAK4631 with Ethernet Module RAK13800, by setting `network.eth_mode` and `network.eth_enabled`.
+- Alternatively use the RAK4631 with Ethernet Module RAK13800, by setting `network.eth_mode` and `network.eth_enabled` (note that JSON is not supported on the nRF52 platform).
 - Configure your broker settings: `mqtt.address`, `mqtt.username`, and `mqtt.password`. If all are left blank, the device will connect to the Meshtastic broker.
 - Set `uplink_enabled` and `downlink_enabled` as appropriate for each channel. Most users will just have a single channel (at channel index 0). `meshtastic --ch-index 0 --ch-set uplink_enabled true`
 

--- a/docs/software/integrations/mqtt/nodered.mdx
+++ b/docs/software/integrations/mqtt/nodered.mdx
@@ -54,6 +54,10 @@ The JSON output only publishes the following subset of the messages on a Meshtas
 > Protobufs are mesh native.
 
 #### 1. Using JSON-encoded messages
+:::note 
+JSON is not supported on the nRF52 platform.
+:::
+
 Make sure that option *JSON Output Enabled* is set in MQTT module options and you have a channel called "mqtt".
 
 Below is a valid JSON envelope for information sent by MQTT to a device for broadcast onto the mesh. The `to` field is optional and can be omitted for broadcast. The `channel` field is also optional and can be omitted to send to the primary channel.


### PR DESCRIPTION
Until https://github.com/meshtastic/firmware/issues/2804 gets fixed. 

Also added a small note that when connecting to Wi-Fi, it should be a 2.4GHz-only network (applies for both ESP32 and Pico W).