### PR TITLE
docs: make atak plugin install more explicit

### DIFF
--- a/docs/software/integrations/atak-plugin.mdx
+++ b/docs/software/integrations/atak-plugin.mdx
@@ -23,11 +23,13 @@ The ATAK plugin does not permit any Meshtastic configuration. The plugin does th
 
 2. Set the device's role to `TAK` in the [device configuration settings](/docs/configuration/radio/device/).
 
-3. With the Meshtastic Android App running in the background (to ensure the IMeshService is alive), launch ATAK (with the Meshtastic ATAK-Plugin installed or install it once ATAK is running) and you should observe a green Meshtastic icon in the bottom right. If the icon is red, then the plugin was not able to bind to the IMeshService provided by the Meshtastic Android App. If this is the case, check to ensure the Meshtastic Android App is functioning. The plugin will reconnect after a failed bind without restarting ATAK.
+3. Install the release of the Meshtastic ATAK-Plugin that matches your version of ATAK on all parties' devices from the [project's GitHub Releases](https://github.com/meshtastic/ATAK-Plugin/releases).
+
+4. With the Meshtastic Android App running in the background (to ensure the IMeshService is alive), launch ATAK (with the Meshtastic ATAK-Plugin installed or install it once ATAK is running) and you should observe a green Meshtastic icon in the bottom right. If the icon is red, then the plugin was not able to bind to the IMeshService provided by the Meshtastic Android App. If this is the case, check to ensure the Meshtastic Android App is functioning. The plugin will reconnect after a failed bind without restarting ATAK. If you do not see a Meshtastic icon, make sure that you have installed the Meshtastic ATAK-Plugin correctly.
 
 ## Standalone TAK Tracker usage
 
-For devices with GPS available, configuring the device's role to `TAK_TRACKER` will allow the Meshtastic to transmit TAK PLI (Position Location Information) independently of ATAK. This data can be received and displayed within ATAK EUDs connected to a Meshtastic device and configured with the Meshtastic ATAK plugin (provided they are configured on the same Meshtastic channels). 
+For devices with GPS available, configuring the device's role to `TAK_TRACKER` will allow the Meshtastic to transmit TAK PLI (Position Location Information) independently of ATAK. This data can be received and displayed within ATAK EUDs connected to a Meshtastic device and configured with the Meshtastic ATAK plugin (provided they are configured on the same Meshtastic channels).
 
 A couple of important notes regarding this setup:
 


### PR DESCRIPTION
Reading the docs before, I totally missed that there was a separate thing to install, and that the "Meshtastic" that shows up in the ATAK plugins list isn't the "Meshtastic ATAK Plugin".

This PR makes that step a little more explicit, and adds a common troubleshooting indicator that it hasn't happened.