### PR TITLE
Add Donate Button to Nav Bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,6 @@ const config = {
       },
     },
     navbar: {
-      title: "Meshtastic",
       hideOnScroll: true,
       logo: {
         alt: "Meshtastic Logo",
@@ -38,6 +37,10 @@ const config = {
         {
           label: "Downloads",
           to: "downloads",
+        },
+        {
+          label: "Donate",
+          to: "docs/contributing/#supporting-and-contributing-to-meshtastic",
         },
         {
           label: "About",


### PR DESCRIPTION
What this PR does:
- Adds a donate button to the Nav Bar. Added to the left side as the right side is collapsed when viewing on smaller screens. Still partially blocked on smaller screens in vertical mode but most visible and selectable. 
- Removes the title from the Nav Bar. This was redundant imo, and mostly cutoff on mobile devices anyways. This makes it looks cleaner. 
