### PR TITLE
Update device.mdx

### DIFF
--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -40,7 +40,7 @@ This table shows the **default** values after selecting a preset. As always, ind
 | SENSOR         | Yes                     | No             | High              | No         | No                  | Yes                   |
 | TAK            | Yes                     | Optional       | Regular           | Yes        | No                  | Yes                   |
 | TAK_TRACKER    | Yes                     | Optional       | Regular           | Yes        | No                  | Yes                   |
-| ROUTER         | No (serial unreliable)  | No             | High              | Yes        | Yes                 | Yes                   |
+| ROUTER         | No                      | No             | High              | Yes        | Yes                 | Yes                   |
 | ROUTER_CLIENT  | Yes                     | Yes            | Highest           | Yes        | Yes                 | Yes                   |
 | REPEATER       | Yes                     | No             | High              | Yes        | Yes                 | No                    |
 

--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -40,7 +40,7 @@ This table shows the **default** values after selecting a preset. As always, ind
 | SENSOR         | Yes                     | No             | High              | No         | No                  | Yes                   |
 | TAK            | Yes                     | Optional       | Regular           | Yes        | No                  | Yes                   |
 | TAK_TRACKER    | Yes                     | Optional       | Regular           | Yes        | No                  | Yes                   |
-| ROUTER         | No                      | No             | High              | Yes        | Yes                 | Yes                   |
+| ROUTER         | No (serial unreliable)  | No             | High              | Yes        | Yes                 | Yes                   |
 | ROUTER_CLIENT  | Yes                     | Yes            | Highest           | Yes        | Yes                 | Yes                   |
 | REPEATER       | Yes                     | No             | High              | Yes        | Yes                 | No                    |
 
@@ -61,6 +61,12 @@ This setting defines the device's behavior for how messages are rebroadcasted.
 Acceptable values: `true` or `false`
 
 Disabling this will disable the SerialConsole by not initializing the StreamAPI.
+
+:::info
+
+Devices utilizing "sleep" to save power will have unreliable serial output, as it is disabled when the device enters sleep. For ROUTER role, consider switching to ROUTER_CLIENT.
+
+:::
 
 ### Debug Log
 


### PR DESCRIPTION
Added notes to clarify that devices utilizing sleep (such as router mode) will have unreliable serial output.