### PR TITLE
run pdf action on pull_request

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,14 +1,9 @@
 name: Generate Documentation PDF
 on:
-  # # Triggers the workflow on push but only for the master branch
-  push:
-    branches: [master]
+  pull_request:
+    types:
+      - closed
 
-  # Note: This is different from "pull_request". Need to specify ref when doing checkouts.
-  pull_request_target:
-    branches: [master]
-    paths-ignore:
-      - "**.md"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Run this workflow on pull requests
Without the check `if: github.event.pull_request.merged` under `Create request artifacts` this would cause a new PDF to be created for every PR, but that check should limit it to when PRs are merged

## Why
PDF generation still isn't running, I think because it was restricted to **pushes** to master? Frustrating that this can't be tested without merging.

I am basing this solution off of this answer https://stackoverflow.com/questions/60710209/trigger-github-actions-only-when-pr-is-merged