### PR TITLE
bump prince pdf version to 15.3 latest

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Install Prince
       run: |
-        curl https://www.princexml.com/download/prince-14.2-linux-generic-x86_64.tar.gz -O
+        curl https://www.princexml.com/download/prince-15.3-linux-generic-x86_64.tar.gz -O
         tar zxf prince-14.2-linux-generic-x86_64.tar.gz
         cd prince-14.2-linux-generic-x86_64
         yes "" | sudo ./install.sh


### PR DESCRIPTION
## What
Bumps prince (pdf generator library) to version 15.3

## Why
webp support was added in 15 https://www.princexml.com/releases/15/