### PR TITLE
bump prince pdf version to 15.3 latest

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Install Prince
       run: |
         curl https://www.princexml.com/download/prince-15.3-linux-generic-x86_64.tar.gz -O
-        tar zxf prince-14.2-linux-generic-x86_64.tar.gz
-        cd prince-14.2-linux-generic-x86_64
+        tar zxf prince-15.3-linux-generic-x86_64.tar.gz
+        cd prince-15.3-linux-generic-x86_64
         yes "" | sudo ./install.sh
 
     - name: Build PDF


### PR DESCRIPTION
It helps if you remember to update all of the version references.

Workflow is failing at the moment https://github.com/meshtastic/meshtastic/actions/runs/8113746877/job/22177764976