### PR TITLE
Channel Number to Frequency Slot

### DIFF
--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -17,7 +17,7 @@ Meshtastic is **not** LoRaWAN, Helium or TTN (TheThingsNetwork). Meshtastic uses
 Power limits will generally be lifted in the software if `is_licensed` is set to `true`. See [HAM Mode](/docs/faq#amateur-radio-ham) for more information.
 :::
 
-## Channel Frequency Calculator
+## Frequency Slot Calculator
 
 <FrequencyCalculator />
 

--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -100,9 +100,9 @@ Allows you to enable and disable transmit (TX) from the LoRa radio. Useful for h
 
 Defaults to true
 
-### Channel Number
+### Frequency Slot
 
-This is controlling the actual hardware frequency the radio is transmitting on. A channel number between 1 and NUM_CHANNELS (whatever the max is in the current region). If this is ZERO/UNSET then the rule is "use the old channel name hash based algorithm to derive the channel number".
+This setting controls the actual hardware frequency at which the radio transmits, represented by a frequency slot between 1 and NUM_SLOTS (the maximum for the current region). If set to `0`/UNSET, the device reverts to the older channel name hash-based algorithm for determining the frequency slot.
 
 :::info
 LoRa Channel Configuration should not to be confused with messaging [Channel Configuration](/docs/configuration/radio/channels). See [Chat Channels VS Lora Modem Channels](/docs/configuration/tips#chat-channels-vs-lora-modem-channels) for further clarification.

--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -102,11 +102,7 @@ Defaults to true
 
 ### Frequency Slot
 
-This setting controls the actual hardware frequency at which the radio transmits, represented by a frequency slot between 1 and NUM_SLOTS (the maximum for the current region). If set to `0`/UNSET, the device reverts to the older channel name hash-based algorithm for determining the frequency slot.
-
-:::info
-LoRa Channel Configuration should not to be confused with messaging [Channel Configuration](/docs/configuration/radio/channels). See [Chat Channels VS Lora Modem Channels](/docs/configuration/tips#chat-channels-vs-lora-modem-channels) for further clarification.
-:::
+This setting controls the actual hardware frequency at which the radio transmits, represented by a frequency slot between 1 and NUM_SLOTS (the maximum for the current region and modem preset). If set to `0`/UNSET, the device reverts to the older channel name hash-based algorithm for determining the frequency slot.
 
 ### Ignore Incoming Array
 

--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -356,12 +356,12 @@ export const FrequencyCalculator = (): JSX.Element => {
       </div>
 
       <div className="flex gap-2 mb-4">
-        <label className="font-semibold">Number of channels:</label>
+        <label className="font-semibold">Number of slots:</label>
         <input type="number" disabled={true} value={numChannels} />
       </div>
 
       <div className="flex gap-2">
-        <label>Channel:</label>
+        <label>Frequency Slot:</label>
         <select
           value={channel}
           onChange={(e) => setChannel(Number.parseInt(e.target.value))}
@@ -375,7 +375,7 @@ export const FrequencyCalculator = (): JSX.Element => {
       </div>
 
       <div className="flex gap-2">
-        <label className="font-semibold">Channel Frequency:</label>
+        <label className="font-semibold">Slot Frequency:</label>
         <input type="number" disabled={true} value={channelFrequency} />
       </div>
     </div>

--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -375,7 +375,7 @@ export const FrequencyCalculator = (): JSX.Element => {
       </div>
 
       <div className="flex gap-2">
-        <label className="font-semibold">Slot Frequency:</label>
+        <label className="font-semibold">Frequency of slot:</label>
         <input type="number" disabled={true} value={channelFrequency} />
       </div>
     </div>


### PR DESCRIPTION
### What

Changes the channel number to frequency slot. Closes #1017 


### Why

Channel number under the LoRa settings often gets confused with the channels used for communication. The decision was made to update this to "frequency slot" to avoid the confusion. All reference to "channel number" for the lora setting will be changed to "frequency slot". In the next breaking change the Protobuf will also be changed to match. 