### PR TITLE
Increase clarity around Power Saving and ROUTER

### DIFF
--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -30,20 +30,22 @@ The device config options are: Role, Serial Output, and Debug Log. Device config
 
 This table shows the **default** values after selecting a preset. As always, individual settings can be adjusted after choosing a preset.
 
-| Device Role    | Bluetooth/Wi-Fi Enabled | Screen Enabled | Power Consumption | Retransmit | Prioritized Routing | Visible in Nodes List |
-| -------------- | ----------------------- | -------------- | ----------------- | ---------- | ------------------- | --------------------- |
-| CLIENT         | Yes                     | Yes            | Regular           | Yes        | No                  | Yes                   |
-| CLIENT_MUTE    | Yes                     | Yes            | Lowest            | No         | No                  | Yes                   |
-| CLIENT_HIDDEN  | Yes                     | Yes            | Lowest            | Local only | No                  | No                    |
-| TRACKER        | Yes                     | No             | Regular           | No         | No                  | Yes                   |
-| LOST_AND_FOUND | Yes                     | No             | Regular           | No         | No                  | Yes                   |
-| SENSOR         | Yes                     | No             | High              | No         | No                  | Yes                   |
-| TAK            | Yes                     | Optional       | Regular           | Yes        | No                  | Yes                   |
-| TAK_TRACKER    | Yes                     | Optional       | Regular           | Yes        | No                  | Yes                   |
-| ROUTER         | No                      | No             | High              | Yes        | Yes                 | Yes                   |
-| ROUTER_CLIENT  | Yes                     | Yes            | Highest           | Yes        | Yes                 | Yes                   |
-| REPEATER       | Yes                     | No             | High              | Yes        | Yes                 | No                    |
+| Device Role    | BLE/WiFi/Serial | Screen Enabled | Power Consumption | Retransmit | Prioritized Routing | Visible in Nodes List |
+| -------------- | --------------- | -------------- | ----------------- | ---------- | ------------------- | --------------------- |
+| CLIENT         | Yes             | Yes            | Regular           | Yes        | No                  | Yes                   |
+| CLIENT_MUTE    | Yes             | Yes            | Lowest            | No         | No                  | Yes                   |
+| CLIENT_HIDDEN  | Yes             | Yes            | Lowest            | Local only | No                  | No                    |
+| TRACKER        | Yes             | No             | Regular           | No         | No                  | Yes                   |
+| LOST_AND_FOUND | Yes             | No             | Regular           | No         | No                  | Yes                   |
+| SENSOR         | Yes             | No             | High              | No         | No                  | Yes                   |
+| TAK            | Yes             | Optional       | Regular           | Yes        | No                  | Yes                   |
+| TAK_TRACKER    | Yes             | Optional       | Regular           | Yes        | No                  | Yes                   |
+| ROUTER         | No<sup>1</sup>  | No             | High              | Yes        | Yes                 | Yes                   |
+| ROUTER_CLIENT  | Yes             | Yes            | Highest           | Yes        | Yes                 | Yes                   |
+| REPEATER       | Yes             | No             | High              | Yes        | Yes                 | No                    |
 
+##### Citations
+1. Caution: The Router role enables [Power Saving](/docs/configuration/radio/power/#power-saving) by default. Consider ROUTER_CLIENT if BLE/WiFi/Serial are still needed.
 
 ### Rebroadcast Mode
 

--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -40,12 +40,11 @@ This table shows the **default** values after selecting a preset. As always, ind
 | SENSOR         | Yes             | No             | High              | No         | No                  | Yes                   |
 | TAK            | Yes             | Optional       | Regular           | Yes        | No                  | Yes                   |
 | TAK_TRACKER    | Yes             | Optional       | Regular           | Yes        | No                  | Yes                   |
-| ROUTER         | No<sup>1</sup>  | No             | High              | Yes        | Yes                 | Yes                   |
+| ROUTER         | No[^1]          | No             | High              | Yes        | Yes                 | Yes                   |
 | ROUTER_CLIENT  | Yes             | Yes            | Highest           | Yes        | Yes                 | Yes                   |
 | REPEATER       | Yes             | No             | High              | Yes        | Yes                 | No                    |
 
-##### Citations
-1. Caution: The Router role enables [Power Saving](/docs/configuration/radio/power/#power-saving) by default. Consider ROUTER_CLIENT if BLE/WiFi/Serial are still needed.
+[^1]: The Router role enables [Power Saving](/docs/configuration/radio/power/#power-saving) by default. Consider ROUTER_CLIENT if BLE/WiFi/Serial are still needed.
 
 ### Rebroadcast Mode
 

--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -20,7 +20,7 @@ The power config options are: Power Saving, Shutdown after losing power, ADC Mul
 ### Power Saving
 
 :::warning 
-Enabling Power Saving will disable Bluetooth, Serial, and WiFi, preventing further changes to the device. Press the user button or reset the device to make changes.
+If enabled, to modify settings afterward, wake the device by pressing the user button or resetting.
 :::
 
 If enabled, turns off Bluetooth, Serial, WiFi, and Screen. Useful when a device is powered from a low-current source (i.e. solar). To see device roles this is enabled for by default, visit [Device Config](/docs/configuration/radio/device).

--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -19,7 +19,13 @@ The power config options are: Power Saving, Shutdown after losing power, ADC Mul
 
 ### Power Saving
 
-If set, Bluetooth, Wifi, and screen (if applicable) are turned off. When using the Router device role, this setting is on by default. The assumption for a Router is that the device will be used in a standalone manner where these features are not needed, and will be shut off to conserve power. This is especially useful when a device is powered from a low-current source (i.e. solar).
+:::warning 
+Enabling Power Saving will disable Bluetooth, Serial, and WiFi, preventing further changes to the device. Press the user button or reset the device to make changes.
+:::
+
+If enabled, turns off Bluetooth, Serial, WiFi, and Screen. Useful when a device is powered from a low-current source (i.e. solar). To see device roles this is enabled for by default, visit [Device Config](/docs/configuration/radio/device).
+
+
 
 ### Shutdown after losing power
 

--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -23,9 +23,7 @@ The power config options are: Power Saving, Shutdown after losing power, ADC Mul
 If enabled, to modify settings afterward, wake the device by pressing the user button or resetting.
 :::
 
-If enabled, turns off Bluetooth, Serial, WiFi, and Screen. Useful when a device is powered from a low-current source (i.e. solar). To see device roles this is enabled for by default, visit [Device Config](/docs/configuration/radio/device).
-
-
+When activated, this feature disables Bluetooth, Serial, WiFi, and the device's screen to conserve power. This is particularly beneficial for devices relying on low-current power sources, like solar panels. For details on which device roles have this feature enabled by default, please check the [Device Config](/docs/configuration/radio/device) section.
 
 ### Shutdown after losing power
 

--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -20,7 +20,7 @@ The power config options are: Power Saving, Shutdown after losing power, ADC Mul
 ### Power Saving
 
 :::warning 
-If enabled, to modify settings afterward, wake the device by pressing the user button or resetting.
+If enabled, modifications to settings can be made by waking the device through pressing the user button, resetting, or through the [admin channel](/docs/configuration/remote-admin/) for remote administration.
 :::
 
 When activated, this feature disables Bluetooth, Serial, WiFi, and the device's screen to conserve power. This is particularly beneficial for devices relying on low-current power sources, like solar panels. For details on which device roles have this feature enabled by default, please check the [Device Config](/docs/configuration/radio/device) section.


### PR DESCRIPTION
## What
Solves #1055 
1. Adds `Serial` to the BLE/WiFi column in the device comparison table
2. Adds a citation to the ROUTER role
3. Adds `Serial` to disabled items under the Power Saving configuration
4. Adds a Warning admonition about how to make changes after turning on Power Saving

## Why
We want to make it more clear that enabling these settings will interfere with making further changes to the device without resetting it.

## Screenshots
<img width="895" alt="Screenshot 2024-03-01 at 5 50 24 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/b78dd2f0-1b7e-4a9d-a76f-e37b1e1103ac">
<img width="889" alt="Screenshot 2024-03-01 at 5 50 08 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/ddcf95bb-1088-4315-8594-d92dde1fba66">
