### PR TITLE
improve title/meta description for sharing and SEO

### DIFF
--- a/docs/software/integrations/mqtt/index.mdx
+++ b/docs/software/integrations/mqtt/index.mdx
@@ -1,6 +1,6 @@
 ---
 id: mqtt
-title: MQTT | MQTT Integrations Overview
+title: MQTT | Integrations Overview
 sidebar_label: MQTT
 sidebar_position: 6
 description: Bridging mesh networks over the internet and integrating Meshtastic protocols with popular technologies such as Home Assistant, Node Red, and Adafruit IO.


### PR DESCRIPTION
### What

Updates the title for the MQTT page and  adds a meta description.

### Why

Original lacked hardly any info other than "MQTT"

<img width="625" alt="Screenshot 2024-03-05 at 12 11 04 PM" src="https://github.com/meshtastic/meshtastic/assets/6912600/26ee75b3-251a-49e0-a469-b10473b62e5b">


