### PR TITLE
Client apps support other connection types than Bluetooth

### DIFF
--- a/docs/about/overview/index.mdx
+++ b/docs/about/overview/index.mdx
@@ -8,7 +8,7 @@ description: "Discover the basics of Meshtastic's operation, from sending messag
 
 ## How it works
 
-When you send a message on your Meshtastic companion app, it is relayed to the radio using Bluetooth. That message is then broadcasted by the radio. If it hasn't received a confirmation from any other device after a certain timeout, it will retransmit the message up to three times.
+When you send a message on your Meshtastic companion app, it is relayed to the radio using Bluetooth, Wi-Fi/Ethernet or serial connection. That message is then broadcasted by the radio. If it hasn't received a confirmation from any other device after a certain timeout, it will retransmit the message up to three times.
 
 When a receiving radio captures a packet, it checks to see if it has heard that message before. If it has it ignores the message. If it hasn't heard the message, it will rebroadcast it.
 

--- a/docs/software/android/installation.mdx
+++ b/docs/software/android/installation.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ## Installation Methods
 
-Our Android application is available on our F-Droid repo and Google Play Store. This allows you to connect to your Meshtastic device from your Android phone.
+Our Android application is available on our F-Droid repo and Google Play Store. This allows you to connect to your Meshtastic device from your Android phone via Bluetooth, Wi-Fi (if on the same network) or USB On-The-Go (OTG).
 
 The minimum Android version is 5.0 (Lollipop 2014, first BLE support), however Android 6 (Marshmallow 2015) is recommended as Bluetooth is more stable.
 

--- a/docs/software/android/usage.mdx
+++ b/docs/software/android/usage.mdx
@@ -19,7 +19,7 @@ You will need a device with Meshtastic installed to go any further. See the [get
 
 [![Search for devices](/img/android/android-settings-none-c.webp)](/img/android/android-settings-none.webp)
 
-To find devices to connect via Bluetooth click the "+" button on the bottom right corner.
+To find devices to connect via Bluetooth click the "+" button on the bottom right corner. Devices connected via Wi-Fi or Ethernet using the same network as your phone should be found automatically, or can be manually selected by entering its IP address. If you connect the device via USB OTG to your phone, it will be found automatically.
 
 [![Device available to select](/img/android/android-settings-connect-sm.webp)](/img/android/android-settings-connect.webp)
 


### PR DESCRIPTION
In the overview, only Bluetooth was mentioned. Furthermore, the Android app documentation only mentions Bluetooth as well.