### PR TITLE
Update RAK Core Modules

### DIFF
--- a/docs/hardware/devices/rak/core-modules.mdx
+++ b/docs/hardware/devices/rak/core-modules.mdx
@@ -99,7 +99,7 @@ This will use IO6 on a RAK4631
 ## RAK11200 - ESP32
 
 :::info
-Only supported on the RAK5005-O / RAK19007 and the RAK19001 base boards.
+Only supported on the RAK5005-O base board.
 :::
 
 The RAK11200 does not contain a LoRa transceiver, and thus needs to be added separately in the form of the [RAK13300 LPWAN module](https://store.rakwireless.com/products/rak13300-wisblock-lpwan). This occupies the IO Port of the base board.


### PR DESCRIPTION
RAK11200 is only supported on the RAK5005-O. It does not work on the 19007/19001s. 