### PR TITLE
paxcounter is esp32 only

### DIFF
--- a/docs/configuration/module/paxcounter.mdx
+++ b/docs/configuration/module/paxcounter.mdx
@@ -12,7 +12,7 @@ The Paxcounter module counts the number of people passing by a specific area by 
 In order to use this module, make sure your devices have firmware version 2.2.17 or higher.
 
 :::info
-To operate the Paxcounter Module, it is mandatory to switch off both WiFi and Bluetooth in your Network and Bluetooth settings.
+This module can only be used with ESP32 devices. To operate the Paxcounter Module, it is mandatory to switch off both WiFi and Bluetooth in your Network and Bluetooth settings.
 :::
 
 ## Paxcounter Module Config Values


### PR DESCRIPTION
Adds to the info admonition that module can only be used with esp32 devices. 