### PR TITLE
Update traceroute.mdx with correct Apple iOS instructions

### DIFF
--- a/docs/configuration/module/traceroute.mdx
+++ b/docs/configuration/module/traceroute.mdx
@@ -41,7 +41,7 @@ Under the node list, long hold a destination node and select 'Traceroute' to sen
 
 Make sure the app is at least version 2.0.9.
 
-Under Contacts > Direct Messages, long hold a destination node and select 'Trace Route' to send the request. Depending on the amount of hops that is needed, this might take a while. The result will be shown in the Mesh Log.
+Under the node list, long hold a destination node and select 'Trace Route' to send the request. Depending on the amount of hops that is needed, this might take a while. The result will be shown in the Mesh Log.
 
 </TabItem>
 <TabItem value="cli">


### PR DESCRIPTION
Corrected Apple iOS instruction. Traceroute function is on the nodes screen, not in the contact list/direct messages screen (as at iOS app v2.2.26),