### PR TITLE
Update Traceroute

### DIFF
--- a/docs/configuration/module/traceroute.mdx
+++ b/docs/configuration/module/traceroute.mdx
@@ -9,7 +9,6 @@ import TabItem from "@theme/TabItem";
 
 ## Overview 
 
-
 Due to the limited bandwidth of LoRa, Meshtastic does not keep track of the nodes a message used to hop to the destination. However, from firmware 2.0.8 on, there is a Traceroute Module that can show you this.
 
 Only nodes that know the encryption key of the channel you use can be tracked. Also note that a message may arrive via multiple routes due to duplication because of rebroadcasting. This module will only track the hops of the first packet containing the traceroute request that arrived at the destination.


### PR DESCRIPTION
Two changes:
- Trace route log only on iOS/iPadOS 17+ and macOS 14+
- Document repeater role behavior. Closes #1028 