### PR TITLE
Add descriptions to all configuration documents

### DIFF
--- a/docs/configuration/module/ambient-lighting.mdx
+++ b/docs/configuration/module/ambient-lighting.mdx
@@ -2,6 +2,7 @@
 id: ambient-lighting
 title: Ambient Lighting Module Usage
 sidebar_label: Ambient Lighting
+description: Configuration details to manage LEDs on your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/audio.mdx
+++ b/docs/configuration/module/audio.mdx
@@ -2,6 +2,7 @@
 id: audio
 title: Audio Module Configuration
 sidebar_label: Audio
+description: Configuration details for the Audio Module of your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/canned-message.mdx
+++ b/docs/configuration/module/canned-message.mdx
@@ -2,6 +2,7 @@
 id: canned-message
 title: Canned Message Module Configuration
 sidebar_label: Canned Message
+description: Configuration details for canned (predefined) messages on your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/detection-sensor.mdx
+++ b/docs/configuration/module/detection-sensor.mdx
@@ -2,6 +2,7 @@
 id: detection-sensor
 title: Detection Sensor Module Usage
 sidebar_label: Detection Sensor
+description: Configuration details for the Detection Sensor Module of your Meshtastic device. Used for motion, reed, and other open/closed gate systems.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/external-notification.mdx
+++ b/docs/configuration/module/external-notification.mdx
@@ -2,6 +2,7 @@
 id: external-notification
 title: External Notification Module Configuration
 sidebar_label: External Notification
+description: This module will allow you to connect a buzzer, speaker, LED, or other similar accessory to your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/index.mdx
+++ b/docs/configuration/module/index.mdx
@@ -4,6 +4,7 @@ title: Module Configuration
 sidebar_label: Module Config
 sidebar_position: 2
 slug: /configuration/module
+description: Learn how to configure all of the different modules on your Meshtastic device.
 ---
 
 Modules are included in the firmware and allow users to extend the functionality of their mesh or device.

--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -2,6 +2,7 @@
 id: mqtt
 title: MQTT Module Configuration
 sidebar_label: MQTT
+description: Learn to manage MQTT servers, encryption, and more for your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/neighbor-info.mdx
+++ b/docs/configuration/module/neighbor-info.mdx
@@ -2,6 +2,7 @@
 id: neighbor-info
 title: Neighbor Info Module Usage
 sidebar_label: Neighbor Info
+description: This module allows you to send information about your immediate(0 hop) neighbors.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/paxcounter.mdx
+++ b/docs/configuration/module/paxcounter.mdx
@@ -2,6 +2,7 @@
 id: paxcounter
 title: Paxcounter Module Usage
 sidebar_label: Paxcounter
+description: This module uses WiFi and BLE to count people or devices passing by your Meshtastic device. Used in retail, museums, etc.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/range-test.mdx
+++ b/docs/configuration/module/range-test.mdx
@@ -2,6 +2,7 @@
 id: range-test
 title: Range Test Module Configuration
 sidebar_label: Range Test
+description: Learn to configure the range test module to create reports, maps, and more.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/remote-hardware.mdx
+++ b/docs/configuration/module/remote-hardware.mdx
@@ -2,6 +2,7 @@
 id: remote-hardware
 title: Remote Hardware Module Usage
 sidebar_label: Remote Hardware
+description: The Remote Hardware Module allows to read, write and watch GPIO pins on a remote node.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/serial.mdx
+++ b/docs/configuration/module/serial.mdx
@@ -2,6 +2,7 @@
 id: serial
 title: Serial Module Configuration
 sidebar_label: Serial
+description: This module is an interface to talk to and control your Meshtastic device over a serial port.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/store-and-forward-module.mdx
+++ b/docs/configuration/module/store-and-forward-module.mdx
@@ -2,6 +2,7 @@
 id: store-and-forward-module
 title: Store & Forward Module Settings
 sidebar_label: Store & Forward
+description: This module allows you to resend text messages after a device has been temporarily not in LoRa range of the mesh.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -2,6 +2,7 @@
 id: telemetry
 title: Telemetry Module Configuration
 sidebar_label: Telemetry
+description: This module allows sharing of Device, Environment, and Air Quality metrics from your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/module/traceroute.mdx
+++ b/docs/configuration/module/traceroute.mdx
@@ -2,6 +2,7 @@
 id: traceroute
 title: Traceroute Module Usage
 sidebar_label: Traceroute
+description: The traceroute module allows you to understand the path a message took to reach the final destination over the mesh.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/bluetooth.mdx
+++ b/docs/configuration/radio/bluetooth.mdx
@@ -2,6 +2,7 @@
 id: bluetooth
 title: Bluetooth Settings
 sidebar_label: Bluetooth
+description: Configure Bluetooth settings on your Meshtastic device for connectivity with smartphones and other devices.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/channels.mdx
+++ b/docs/configuration/radio/channels.mdx
@@ -2,6 +2,7 @@
 id: channels
 title: Channel Configuration
 sidebar_label: Channels
+description: Understand how to configure channels on your Meshtastic device, including private channels, encryption, MQTT, and location precision.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -2,6 +2,7 @@
 id: device
 title: Device Configuration
 sidebar_label: Device
+description: Learn about and compare device roles such as Client, Repeater, and Router as well as other Device settings.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/display.mdx
+++ b/docs/configuration/radio/display.mdx
@@ -2,6 +2,7 @@
 id: display
 title: Display Configuration
 sidebar_label: Display
+description: Details on the configuration options for the display on your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/index.mdx
+++ b/docs/configuration/radio/index.mdx
@@ -3,6 +3,7 @@ id: config
 title: Radio Configuration
 sidebar_label: Radio Config
 sidebar_position: 1
+description: Dive into the technical specifics of configuring your Meshtastic radio settings, including frequency ranges, power limits, and channels for optimal communication.
 ---
 
 There are several config sections in the Meshtastic firmware, these are broken out so they can be sent as small admin messages over the mesh.

--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -2,6 +2,7 @@
 id: lora
 title: LoRa Configuration
 sidebar_label: LoRa
+description: Understanding the LoRa configuration settings on your Meshtastic device including region, modem, hop limit, and more.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/network.mdx
+++ b/docs/configuration/radio/network.mdx
@@ -2,6 +2,7 @@
 id: network
 title: Network Configuration
 sidebar_label: Network
+description: Learn about network configuration for your Meshtastic device including NTP, WiFi, and Ethernet.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/position.mdx
+++ b/docs/configuration/radio/position.mdx
@@ -2,6 +2,7 @@
 id: position
 title: Position Configuration
 sidebar_label: Position
+description: GPS position configuration settings for your Meshtastic device including update intervals, broadcast settings, and GPIO.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -2,6 +2,7 @@
 id: power
 title: Power Configuration
 sidebar_label: Power
+description: Settings for advanced users who want to adjust the power configuration on their Meshtastic device.
 ---
 
 import Admonition from "@theme/Admonition";

--- a/docs/configuration/radio/user.mdx
+++ b/docs/configuration/radio/user.mdx
@@ -2,6 +2,7 @@
 id: user
 title: User Configuration
 sidebar_label: User
+description: Details on Long Name, Short Name, and Licensed operation.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -3,6 +3,7 @@ id: remote-admin
 title: Remote Node Administration
 sidebar_label: Remote Nodes
 sidebar_position: 3
+description: An advanced feature which allows remote administration of a device through a secure channel on the Mesh instead of via Bluetooth, Serial, or IPv4.
 ---
 
 :::caution Disclaimer

--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -1,7 +1,7 @@
 ---
 id: tips
 title: Configuration Tips
-description: Common Settings & Solutions
+description: Tips and Solutions to help you get the most out of your Meshtastic device and network.
 sidebar_label: Tips
 sidebar_position: 4
 ---


### PR DESCRIPTION
## What
Adds descriptions to all pages under Configuration

## Why
- Makes preview links in Discord look better easier to understand
- SEO results look better and should rank higher