### PR TITLE
Add Link Back

### DIFF
--- a/docs/development/reference/github.mdx
+++ b/docs/development/reference/github.mdx
@@ -75,6 +75,8 @@ A description about the project
 
 <!--Repobeats image here-->
 
+Repobeats images can be generated at [repobeats.axiom.co](https://repobeats.axiom.co/)
+
 <!--If the repository is a library, include this section-->
 
 ## Installation & Usage


### PR DESCRIPTION
### What 

Adds repobeats link back which was inadvertently removed in #1107 

### Why

This is used across multiple project repositories and is useful for those creating new repos for the project. 