### PR TITLE
Getting started descriptions

### DIFF
--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -8,7 +8,7 @@ sidebar_position: 4
 
 ## Roles
 
-Leave your [ROLE](/docs/configuration/radio/device#role) set to `CLIENT` unless you're sure another role would suit the node's purpose.  All `CLIENT` nodes will "repeat" and "route" packets.  Roles are for very specific applications so please [read the documentation](/docs/configuration/radio/device#role) before changing your node's role.
+Leave your [ROLE](/docs/configuration/radio/device#roles) set to `CLIENT` unless you're sure another role would suit the node's purpose.  All `CLIENT` nodes will "repeat" and "route" packets.  Roles are for very specific applications so please [read the documentation](/docs/configuration/radio/device#roles) before changing your node's role.
 
 :::info
 
@@ -59,7 +59,7 @@ There are 8 total messaging channels. Channel 0 is your PRIMARY channel, with ch
 
 ### Radio Config: LoRa Frequency Slot
 
-This property, formerly known as "LoRa Channel Number", configures the frequency the radio is set to. Check out the [frequency calculator](/docs/overview/radio-settings#channel-frequency-calculator) to view the relationship between "frequency slot" and radio frequency.
+This property, formerly known as "LoRa Channel Number", configures the frequency the radio is set to. Check out the [frequency calculator](/docs/overview/radio-settings#frequency-slot-calculator) to view the relationship between "frequency slot" and radio frequency.
 
 ## Best Practices
 - If you are part of a large mesh and don't know what a setting does, don't change it (unless you're super curious).

--- a/docs/getting-started/flashing-firmware/esp32/cli-script.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/cli-script.mdx
@@ -3,6 +3,7 @@ id: cli-script
 title: Flashing with the CLI
 sidebar_label: CLI Script (Advanced Users)
 sidebar_position: 3
+description: Instructions for using the CLI to flash Meshtastic firmware to an ESP32 chipset device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/flashing-firmware/esp32/external-serial-adapter.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/external-serial-adapter.mdx
@@ -3,6 +3,7 @@ id: external-serial-adapter
 title: Flashing with an External Serial Adapter
 sidebar_label: External Serial Adapter (Advanced Users)
 sidebar_position: 4
+description: Instructions for using an external serial adapter to flash Meshtastic firmware to an ESP32 chipset device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/flashing-firmware/esp32/index.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/index.mdx
@@ -3,6 +3,7 @@ id: flashing-esp32-devices
 title: Flash ESP32 Devices
 sidebar_label: ESP32 Device
 sidebar_position: 2
+description: Instructions to flash Meshtastic firmware to an ESP32 chipset device.
 ---
 
 :::info

--- a/docs/getting-started/flashing-firmware/esp32/web-flasher.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/web-flasher.mdx
@@ -3,6 +3,7 @@ id: web-flasher
 title: Meshtastic Web Flasher
 sidebar_label: Web Flasher (recommended)
 sidebar_position: 1
+description: Instructions for using the Web Flasher(recommended) to flash Meshtastic firmware to an ESP32 chipset device.
 ---
 
 import Link from "@docusaurus/Link";

--- a/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
@@ -3,6 +3,7 @@ id: convert-rak4631r
 title: Convert RAK4631-R to RAK4631
 sidebar_label: Convert RAK4631-R
 sidebar_position: 4
+description: Instructions for converting the RAK4631-R to RAK-4631 using Python and adafruit-nrfutil.
 ---
 
 The only difference between the _RAK4631-R_ (RUI3) and the _RAK4631_ (Arduino) is the bootloader it is shipped with - the hardware is the same.

--- a/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
@@ -3,6 +3,7 @@ id: drag-n-drop
 title: Drag & Drop nRF52 & RP2040 Firmware Updates
 sidebar_label: Drag & Drop (recommended)
 sidebar_position: 1
+description: Instructions for using the Drag & Drop(recommended) file method to flash Meshtastic firmware to nRF52 or RP2040 chipset devices.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/flashing-firmware/nrf52/index.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/index.mdx
@@ -3,6 +3,7 @@ id: flashing-nrf52-devices
 title: Flash nRF52 & RP2040 Devices
 sidebar_label: nRF52/RP2040 Device
 sidebar_position: 2
+description: Instructions to flash Meshtastic firmware to nRF52 or RP2040 chipset devices.
 ---
 
 ## Flashing Methods for nRF52 and RP2040 Devices

--- a/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
@@ -3,6 +3,7 @@ id: nrf52-erase
 title: Flash nRF52/RP2040 Factory Erase
 sidebar_label: Factory Erase
 sidebar_position: 3
+description: Instructions for factory erasing an nRF52 or RP2040 device.
 ---
 
 import Link from "@docusaurus/Link";

--- a/docs/getting-started/flashing-firmware/nrf52/ota.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/ota.mdx
@@ -3,6 +3,7 @@ id: ota
 title: nRF52 OTA Firmware Updates
 sidebar_label: Over-The-Air
 sidebar_position: 2
+description: Instructions for using the Over-The-Air(OTA) method to flash Meshtastic firmware to nRF52 chipset devices.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/flashing-firmware/nrf52/update-techo-booloader.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/update-techo-booloader.mdx
@@ -3,6 +3,7 @@ id: update-techo-bootloader
 title: How to Update the LilyGo T-Echo Bootloader to the Latest Version
 sidebar_label: Update T-Echo Bootloader
 sidebar_position: 5
+description: Instructions for updating the T-Echo bootloader to the latest version for use with Meshtastic.
 ---
 
 If you're experiencing issues with updating or flashing newer versions of the Meshtastic firmware, and your LilyGo T-Echo is not running the latest bootloader version (0.6.1), updating the bootloader may resolve these problems.

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -4,6 +4,7 @@ title: Getting Started
 sidebar_label: Getting Started
 slug: /getting-started
 sidebar_position: 2
+description: The official Meshtastic guide to get you started. Covers all devices and configurations.
 ---
 
 import Link from "@docusaurus/Link";

--- a/docs/getting-started/initial-config.mdx
+++ b/docs/getting-started/initial-config.mdx
@@ -4,6 +4,7 @@ title: Initial Configuration
 sidebar_label: Initial Configuration
 slug: /getting-started/initial-config
 sidebar_position: 4
+description: Getting started with the initial configuration of your Meshtastic device including serial, bluetooth, LoRa, and more.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/serial-drivers/serial-drivers-esp32.mdx
+++ b/docs/getting-started/serial-drivers/serial-drivers-esp32.mdx
@@ -3,6 +3,7 @@ id: esp32
 title: ESP32 Serial Drivers
 sidebar_label: ESP32 Drivers
 sidebar_position: 1
+description: Instructions for installing ESP32 USB serial drivers to interact with a Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/serial-drivers/serial-drivers-nrf52.mdx
+++ b/docs/getting-started/serial-drivers/serial-drivers-nrf52.mdx
@@ -3,6 +3,7 @@ id: nrf52
 title: nRF52/RP2040 Serial Drivers
 sidebar_label: nRF52/RP2040 Drivers
 sidebar_position: 2
+description: Instructions for installing nRF52 and RP2040 USB serial drivers to interact with a Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
+++ b/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
@@ -3,6 +3,7 @@ id: test-serial-driver-installation
 title: Test Serial Driver Installation
 sidebar_label: Test Serial Driver Installation
 sidebar_position: 3
+description: Instructions for testing serial driver installation on Linux, macOS, or Windows.
 ---
 
 import Link from "@docusaurus/Link";

--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -13,7 +13,7 @@ Band
 Broadcast
 : Sending a message or data from one device to all other devices within range in the Meshtastic network, rather than to a specific recipient.
 
-Channel | [Configuration](/docs/configuration/radio/channels/) | [Frequency Calculator](/docs/overview/radio-settings/#channel-frequency-calculator)
+Channel | [Configuration](/docs/configuration/radio/channels/) | [Frequency Calculator](/docs/overview/radio-settings/#frequency-slot-calculator)
 : At least two definitions in Meshtastic usage: 1) One of 8 configurable channels in the firmware, each supporting a separate name and encryption, with one set as primary and the rest secondary. 2) A specific frequency within a LoRa band that a device can be configured to use.
 
 CLI | [Guide](/docs/software/python/cli/)


### PR DESCRIPTION
## What
1. Adds descriptions for all docs under the `getting-started` category
2. Fixes some broken links after we changed `channel` -> `frequency-slot`
