### PR TITLE
Update Python CLI Installation

### DIFF
--- a/docs/software/python-cli/installation.mdx
+++ b/docs/software/python-cli/installation.mdx
@@ -28,6 +28,8 @@ After ensuring the requirements are met, follow the installation instructions fo
 
 ### Installation Instructions
 
+To install the Meshtastic CLI, select the tab for your operating system and follow the step-by-step instructions for installing via `pip`. For Ubuntu only, you can alternatively install the [Standalone version](#standalone-installation-ubuntu-only) if you prefer.
+
 <Tabs
 groupId="operating-system"
 queryString="install-python-cli"


### PR DESCRIPTION
### What
- Updated the installation instructions for the Meshtastic Python CLI.
- Reorganized the content with appropriate headings for better structure.
- Removed reference to the Windows standalone executable, which is no longer available.

### Why
- Provide clearer and more up-to-date instructions for users to install the Meshtastic Python CLI.
- Improve the overall readability and navigation of the documentation by using headings and organizing the content logically.
- Reflect the accurate availability of standalone executables, as the Windows version is no longer provided. This closes #1129.