### PR TITLE
Note how rebroadcast mode impacts mqtt

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -19,7 +19,7 @@ The MQTT module config options are: Enabled, Server Address, Username, Password,
 
 ### Enabled
 
-Enables the MQTT module.
+Enables the MQTT module.[^1]
 
 ### Server Address
 
@@ -283,3 +283,5 @@ Navigate to Radio Config > Device > Network: Turn on the slider for **Enabled** 
 
 </TabItem>
 </Tabs>
+
+[^1]: [Device Role Presets](https://meshtastic.org/docs/configuration/radio/device/#roles) that set [Rebroadcast Mode](https://meshtastic.org/docs/configuration/radio/device/#rebroadcast-mode) will impact whether packets from other nodes are rebroadcast over MQTT.

--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -16,7 +16,7 @@ The device config options are: Role, Serial Output, and Debug Log. Device config
 | Device Role    | Description                                                                                                               | Best Uses                                                                                                                              |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | CLIENT         | App connected or stand alone messaging device.                                                                            | General use for individuals needing to communicate over the Meshtastic network with support for client applications.                   |
-| CLIENT_MUTE    | Device that does not forward packets from other devices.                                                                  | Situations where a device needs to participate in the network without assisting in packet routing, reducing network load.              |
+| CLIENT_MUTE    | Device that does not forward packets from other devices.[^2]                                                              | Situations where a device needs to participate in the network without assisting in packet routing, reducing network load.              |
 | CLIENT_HIDDEN  | Device that only broadcasts as needed for stealth or power savings.                                                       | Use in stealth/hidden deployments or to reduce airtime/power consumption while still participating in the network.                     |
 | TRACKER        | Broadcasts GPS position packets as priority.                                                                              | Tracking the location of individuals or assets, especially in scenarios where timely and efficient location updates are critical.      |
 | LOST_AND_FOUND | Broadcasts location as message to default channel regularly for to assist with device recovery.                           | Used for recovery efforts of a lost device.                                                                                            |
@@ -34,7 +34,7 @@ This table shows the **default** values after selecting a preset. As always, ind
 | Device Role    | BLE/WiFi/Serial | Screen Enabled | Power Consumption | Retransmit | Prioritized Routing | Visible in Nodes List |
 | -------------- | --------------- | -------------- | ----------------- | ---------- | ------------------- | --------------------- |
 | CLIENT         | Yes             | Yes            | Regular           | Yes        | No                  | Yes                   |
-| CLIENT_MUTE    | Yes             | Yes            | Lowest            | No         | No                  | Yes                   |
+| CLIENT_MUTE    | Yes             | Yes            | Lowest            | No[^2]     | No                  | Yes                   |
 | CLIENT_HIDDEN  | Yes             | Yes            | Lowest            | Local only | No                  | No                    |
 | TRACKER        | Yes             | No             | Regular           | No         | No                  | Yes                   |
 | LOST_AND_FOUND | Yes             | No             | Regular           | No         | No                  | Yes                   |
@@ -44,8 +44,6 @@ This table shows the **default** values after selecting a preset. As always, ind
 | ROUTER         | No[^1]          | No             | High              | Yes        | Yes                 | Yes                   |
 | ROUTER_CLIENT  | Yes             | Yes            | Highest           | Yes        | Yes                 | Yes                   |
 | REPEATER       | Yes             | No             | High              | Yes        | Yes                 | No                    |
-
-[^1]: The Router role enables [Power Saving](/docs/configuration/radio/power/#power-saving) by default. Consider ROUTER_CLIENT if BLE/WiFi/Serial are still needed.
 
 ### Rebroadcast Mode
 
@@ -179,3 +177,6 @@ All device config options are available in the Web UI.
 
 </TabItem>
 </Tabs>
+
+[^1]: The Router role enables [Power Saving](/docs/configuration/radio/power/#power-saving) by default. Consider ROUTER_CLIENT if BLE/WiFi/Serial are still needed.
+[^2]: Roles such as client_mute, sensor, and client_hidden do not rebroadcast received packets, as such these roles may not be suitable as MQTT gateways.


### PR DESCRIPTION
## What
Adds footnotes to both Configuration pages for both Device and MQTT to explain that role or rebroadcast mode will impact MQTT as well.

## Screenshots
<img width="852" alt="Screenshot 2024-03-17 at 4 35 31 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/a9865a34-0c5b-46ca-92ff-f1511c3eef40">
<img width="426" alt="Screenshot 2024-03-17 at 4 35 25 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/072298df-db39-4989-a41c-a252c188dfa9">
<img width="871" alt="Screenshot 2024-03-17 at 4 24 50 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/5ffce1c4-b057-44e0-9974-83355bc65f7e">
<img width="627" alt="Screenshot 2024-03-17 at 4 24 42 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/acc20491-ea89-4e42-860d-2afd71734b4a">
<img width="508" alt="Screenshot 2024-03-17 at 4 24 37 PM" src="https://github.com/meshtastic/meshtastic/assets/5215365/398365f0-3d93-46eb-a616-c23d79c91b98">
