### PR TITLE
Add MQTT Map Report and Client Proxy config options

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 If your device is connected to Internet via wifi or ethernet, you can enable it to forward packets along to an MQTT server. This allows users on the local mesh to communicate with users on the internet. One or more channels must also be enabled as uplink and/or downlink for packets to be transmitted from and/or to your mesh (See [channels](/docs/configuration/radio/channels#downlink-enabled)). Without these settings enabled, the node will still connect to the MQTT server but only send status messages.
 
-The MQTT module config options are: Enabled, Server Address, Username, Password, Encryption Enabled, JSON Enabled, TLS Enabled, and Root Topic. MQTT Module config uses an admin message sending a `ConfigModule.MQTT` protobuf.
+The MQTT module config options are: Enabled, Server Address, Username, Password, Encryption Enabled, JSON Enabled, TLS Enabled, Root Topic, Client Proxy Enabled, Map Reporting Enabled (with Position Precision and Publish Interval). MQTT Module config uses an admin message sending a `ConfigModule.MQTT` protobuf.
 
 ## Settings
 
@@ -53,6 +53,26 @@ If true, we attempt to establish a secure connection using TLS.
 
 The root topic to use for MQTT messages. This is useful if you want to use a single MQTT server for multiple meshtastic networks and separate them via ACLs.
 
+### Client Proxy Enabled
+If true, let the device use the client's (e.g. your phone's) network connection to connect to the MQTT server. If false, it uses the device's network connection which you have to enable via the [network settings](/docs/configuration/radio/network).
+
+### Map Reporting Enabled
+
+Available from firmware version 2.3.2 on.
+If true, your node will periodically send an unencrypted map report to the MQTT server to be displayed by online maps that support this packet. This report includes the following information:
+- The node's long and short name and ID;
+- The node's position (with configurable precision) and altitude;
+- The node's hardware model and [role](/docs/configuration/radio/device/#roles);
+- The node's firmware version;
+- The node's LoRa region, modem preset and primary channel name; 
+- Whether the node can be reached on the default channel with known key;
+- Number of local online nodes (heard in the last 2 hours, excluding those heard via MQTT).
+
+#### Map Report Position Precision
+The precision to use for the position in the map report. Defaults to a maximum deviation of around 1459m.
+
+#### Map Report Publish Interval
+How often we should publish the map report to the MQTT server in seconds. Defaults to 900 seconds (15 minutes).
 
 ## MQTT Module Config Client Availability
 <Tabs

--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -115,20 +115,22 @@ All MQTT config options are available on iOS, iPadOS and macOS at Settings > Mod
 
 :::info
 
-All MQTT module config options are available in the python CLI. Example commands are below:
+The following configuration options are available in the Python CLI:
 
 :::
 
-|         Setting         | Acceptable Values |        Default      |
-| :---------------------: | :---------------: | :-----------------: |
-|      mqtt.enabled       |  `true`, `false`  |       `false`       |
-|      mqtt.address       |     `string`      |`mqtt.meshtastic.org`|
-|      mqtt.username      |     `string`      |       `meshdev`     |
-|      mqtt.password      |     `string`      |     `large4cats`    |
-| mqtt.encryption_enabled |  `true`, `false`  |        `false`      |
-|    mqtt.json_enabled    |  `true`, `false`  |        `false`      |
-|    mqtt.tls_enabled     |  `true`, `false`  |        `false`      |
-|        mqtt.root        |     `string`      |                     |
+|         Setting              | Acceptable Values |        Default      |
+| :--------------------------: | :---------------: | :-----------------: |
+|      mqtt.enabled            |  `true`, `false`  |       `false`       |
+|      mqtt.address            |     `string`      |`mqtt.meshtastic.org`|
+|      mqtt.username           |     `string`      |       `meshdev`     |
+|      mqtt.password           |     `string`      |     `large4cats`    |
+| mqtt.encryption_enabled      |  `true`, `false`  |        `false`      |
+|    mqtt.json_enabled         |  `true`, `false`  |        `false`      |
+|    mqtt.tls_enabled          |  `true`, `false`  |        `false`      |
+|        mqtt.root             |     `string`      |                     |
+| mqtt.proxy_to_client_enabled |  `true`, `false`  |        `false`      |
+| mqtt.map_reporting_enabled   |  `true`, `false`  |        `false`      |
 
 :::tip
 


### PR DESCRIPTION
Closes #1108.

Currently you cannot yet set the position precision and publish interval via the CLI, so I've not added those to the table.

I also added the Client Proxy config, which was explained on the page but not as a config option.
