### PR TITLE
Update Tabs CSS

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -250,6 +250,8 @@ td {
   border-bottom-color: var(--ifm-tabs-color-inactive-border);
   border-radius: 0;
   margin-right: 4px;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 .tabs__item--active {


### PR DESCRIPTION
Added CSS to change look of tabs. Gives inactive tabs the inactive color to better display to users that they can be clicked. Also makes them line up on the left the same as the content.

![image](https://github.com/meshtastic/meshtastic/assets/6912600/6a46025f-5c82-4ab6-af59-638c4fde393a)

Will close #650 in favor of this. 