### PR TITLE
Update usage.mdx

### DIFF
--- a/docs/software/python-cli/usage.mdx
+++ b/docs/software/python-cli/usage.mdx
@@ -197,7 +197,7 @@ meshtastic --ble Meshtastic_1234 --export-config > config.yaml
 #### Send a command to a remote device using the --dest option:
 
 ```shell
-meshtastic --dest '!fe1932db4' --set device.is_managed false --ble Meshtastic_9abc
+meshtastic --dest !fe1932db4 --set device.is_managed false --ble Meshtastic_9abc
 ```
 
 #### For debugging, you can enable verbose BLE logging by adding the `--debug` flag:


### PR DESCRIPTION
--dest command does not require device ID to be in quotes. In fact, the command fails to match the ID when a user enters it this way.

Modified usage page to reflect this syntax.