### PR TITLE
Update _lora-regions.mdx: add Brazil, Argentina to ANZ

### DIFF
--- a/docs/blocks/_lora-regions.mdx
+++ b/docs/blocks/_lora-regions.mdx
@@ -1,24 +1,24 @@
-| Region Code |                    Description                     |
-|:-----------:|:--------------------------------------------------:|
-|   `UNSET`   |                       Unset                        |
-|    `US`     |                   United States                    |
-|  `EU_433`   |               European Union 433MHz                |
-|  `EU_868`   |               European Union 868MHz                |
-|    `CN`     |                       China                        |
-|    `JP`     |                       Japan                        |
-|    `ANZ`    | Australia, New Zealand, Brazil, Argentina, Chile   |
-|    `KR`     |                       Korea                        |
-|    `TW`     |                      Taiwan                        |
-|    `RU`     |                      Russia                        |
-|    `IN`     |                       India                        |
-|  `NZ_865`   |                New Zealand 865MHz                  |
-|    `TH`     |                     Thailand                       |
-|  `UA_433`   |                  Ukraine 433MHz                    |
-|  `UA_868`   |                  Ukraine 868MHz                    |
-|  `MY_433`   |                  Malaysia 433MHz                   |
-|  `MY_919`   |                  Malaysia 919MHz                   |
-|  `SG_923`   |                 Singapore 923MHz                   |
-|  `LORA_24`  |                2.4 GHz band worldwide              |
+| Region Code |                    Description            |
+|:-----------:|:-----------------------------------------:|
+|   `UNSET`   |                       Unset               |
+|    `US`     |                   United States           |
+|  `EU_433`   |               European Union 433MHz       |
+|  `EU_868`   |               European Union 868MHz       |
+|    `CN`     |                       China               |
+|    `JP`     |                       Japan               |
+|    `ANZ`    | Australia, New Zealand, Brazil, Argentina |
+|    `KR`     |                       Korea               |
+|    `TW`     |                      Taiwan               |
+|    `RU`     |                      Russia               |
+|    `IN`     |                       India               |
+|  `NZ_865`   |                New Zealand 865MHz         |
+|    `TH`     |                     Thailand              |
+|  `UA_433`   |                  Ukraine 433MHz           |
+|  `UA_868`   |                  Ukraine 868MHz           |
+|  `MY_433`   |                  Malaysia 433MHz          |
+|  `MY_919`   |                  Malaysia 919MHz          |
+|  `SG_923`   |                 Singapore 923MHz          |
+|  `LORA_24`  |                2.4 GHz band worldwide     |
 
 
 :::info

--- a/docs/blocks/_lora-regions.mdx
+++ b/docs/blocks/_lora-regions.mdx
@@ -1,24 +1,25 @@
-| Region Code |       Description       |
-|:-----------:|:-----------------------:|
-|   `UNSET`   |          Unset          |
-|    `US`     |      United States      |
-|  `EU_433`   |  European Union 433MHz  |
-|  `EU_868`   |  European Union 868MHz  |
-|    `CN`     |          China          |
-|    `JP`     |          Japan          |
-|    `ANZ`    | Australia & New Zealand |
-|    `KR`     |          Korea          |
-|    `TW`     |         Taiwan          |
-|    `RU`     |         Russia          |
-|    `IN`     |          India          |
-|  `NZ_865`   |   New Zealand 865MHz    |
-|    `TH`     |        Thailand         |
-|  `UA_433`   |     Ukraine 433MHz      |
-|  `UA_868`   |     Ukraine 868MHz      |
-|  `MY_433`   |     Malaysia 433MHz     |
-|  `MY_919`   |     Malaysia 919MHz     |
-|  `SG_923`   |    Singapore 923MHz     |
-|  `LORA_24`  | 2.4 GHz band worldwide  |
+| Region Code |                    Description                     |
+|:-----------:|:--------------------------------------------------:|
+|   `UNSET`   |                       Unset                        |
+|    `US`     |                   United States                    |
+|  `EU_433`   |               European Union 433MHz                |
+|  `EU_868`   |               European Union 868MHz                |
+|    `CN`     |                       China                        |
+|    `JP`     |                       Japan                        |
+|    `ANZ`    | Australia, New Zealand, Brazil, Argentina, Chile   |
+|    `KR`     |                       Korea                        |
+|    `TW`     |                      Taiwan                        |
+|    `RU`     |                      Russia                        |
+|    `IN`     |                       India                        |
+|  `NZ_865`   |                New Zealand 865MHz                  |
+|    `TH`     |                     Thailand                       |
+|  `UA_433`   |                  Ukraine 433MHz                    |
+|  `UA_868`   |                  Ukraine 868MHz                    |
+|  `MY_433`   |                  Malaysia 433MHz                   |
+|  `MY_919`   |                  Malaysia 919MHz                   |
+|  `SG_923`   |                 Singapore 923MHz                   |
+|  `LORA_24`  |                2.4 GHz band worldwide              |
+
 
 :::info
 EU_433 and EU_868 have to adhere to an hourly duty cycle limitation of 10%. Your device will stop transmitting if you reach it, until it is allowed again.


### PR DESCRIPTION
<img width="779" alt="image" src="https://github.com/meshtastic/meshtastic/assets/1467605/e58d008e-0cc3-4c04-84b7-8733353ffa4c">


Source: https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country/

* `AU915-928`: Brazil, Argentina