### PR TITLE
Revert "Update local-groups.mdx"

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -85,9 +85,6 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 ### Texas
 - [Austin Mesh](https://austinmesh.org/)
 
-## Italy
-- [Meshtastic Italia](https://t.me/meshtastic_italia)
-
 ## Lithuania
 - [Meshtastic Lietuva](https://www.facebook.com/groups/1122509422249414)
 


### PR DESCRIPTION
Reverts meshtastic/meshtastic#1179

I perhaps merged this too quickly as the group does not comply with trademark usage guidelines
https://meshtastic.org/docs/legal/licensing-and-trademark/#social-media