### PR TITLE
Update index.mdx under community, software

### DIFF
--- a/docs/community/software/index.mdx
+++ b/docs/community/software/index.mdx
@@ -10,6 +10,9 @@ The Meshtastic ecosystem is highly extensible, and a number of community project
 Current community projects:
 
 - [Meshtasticator (Simulator)](/docs/community/software/community-meshtasticator) - Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software.
+
 - [Meshtastic Web API](/docs/community/software/meshtastic-web-api) - Meshtastic Web API provides a RESTful interface to interact with a Meshtastic node via a serial connection.
+
+- [Mesh-Metrics](https://github.com/cordelster/mesh-metrics) - A script that uses meshtastic-cli to pole repeaters for their telemetry and formats for ingestion by prometheus_node_exporter with a Grafana dashbord for visualization and alerting.
 
 Support for these projects should be sought from their respective authors.

--- a/docs/community/software/index.mdx
+++ b/docs/community/software/index.mdx
@@ -9,9 +9,9 @@ The Meshtastic ecosystem is highly extensible, and a number of community project
 
 Current community projects:
 
-- [Meshtasticator (Simulator)](/docs/community/software/community-meshtasticator) - Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software.
+- [Meshtasticator (Simulator)](/docs/community/software/community/meshtasticator) - Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software.
 
-- [Meshtastic Web API](/docs/community/software/meshtastic-web-api) - Meshtastic Web API provides a RESTful interface to interact with a Meshtastic node via a serial connection.
+- [Meshtastic Web API](/docs/community/software/community/meshtastic-web-api) - Meshtastic Web API provides a RESTful interface to interact with a Meshtastic node via a serial connection.
 
 - [Mesh-Metrics](https://github.com/cordelster/mesh-metrics) - A script that uses meshtastic-cli to pole repeaters for their telemetry and formats for ingestion by prometheus_node_exporter with a Grafana dashbord for visualization and alerting.
 

--- a/docs/community/software/index.mdx
+++ b/docs/community/software/index.mdx
@@ -9,9 +9,9 @@ The Meshtastic ecosystem is highly extensible, and a number of community project
 
 Current community projects:
 
-- [Meshtasticator (Simulator)](/docs/community/software/community/meshtasticator) - Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software.
+- [Meshtasticator (Simulator)](/docs/community/software/community/meshtasticator.mdx) - Meshtasticator is a discrete-event and interactive simulator that mimics the radio section of the device software.
 
-- [Meshtastic Web API](/docs/community/software/community/meshtastic-web-api) - Meshtastic Web API provides a RESTful interface to interact with a Meshtastic node via a serial connection.
+- [Meshtastic Web API](/docs/community/software/community/meshtastic-web-api.mdx) - Meshtastic Web API provides a RESTful interface to interact with a Meshtastic node via a serial connection.
 
 - [Mesh-Metrics](https://github.com/cordelster/mesh-metrics) - A script that uses meshtastic-cli to pole repeaters for their telemetry and formats for ingestion by prometheus_node_exporter with a Grafana dashbord for visualization and alerting.
 


### PR DESCRIPTION
Add github link for mesh-metrics. script polls list of repeaters via meshtastic-cli and outputs telemetry formatted for node_exporter ingestion. Grafana dashboard supports selection of multiple metrics end points for segregation of differing mesh networks.