### PR TITLE
remove unused Mapbox reference from Meshtastic privacy policy

### DIFF
--- a/docs/legal/privacy.mdx
+++ b/docs/legal/privacy.mdx
@@ -9,8 +9,6 @@ We don't collect any personal identifying information. We never capture username
 
 If you opt-in to analytics on the Android app (thank you - that helps us know what things we need to improve), we will receive anonymized information about user behavior. This includes crash reports, screens used in the app, etc... Analytics is provided by [Firebase Crashlytics](https://firebase.google.com/products/crashlytics).
 
-Maps provided by Mapbox require analytics to work. For more information about what they collect, please see the [Mapbox privacy policy](https://www.mapbox.com/legal/privacy).
-
 The search engine for this website is provided by Algolia, please see their [privacy policy](https://www.algolia.com/policies/privacy) for details of what information they collect.
 
 This is an open-source project run by hobbyists, and we try to be completely transparent. If you have questions on this policy, please post on the forum, and we'll reply/clarify/correct.


### PR DESCRIPTION
Since 2.0 Mapbox is no longer used and this reference can be removed.