### PR TITLE
RAK19001 supports GPS modules on slot F, document that

### DIFF
--- a/docs/hardware/devices/rak/peripherals.mdx
+++ b/docs/hardware/devices/rak/peripherals.mdx
@@ -34,6 +34,7 @@ The RAK12500 is supported on the following base boards & slots:
 
 - RAK19007 on slot A
 - RAK19003 on slot C
+- RAK19001 on slot F
 
 ### RAK1910
 
@@ -47,6 +48,7 @@ The RAK1910 is supported on the following base boards & slots:
 - RAK5005-0 on slot A
 - RAK19007 on slot A
 - RAK19003 on slot C
+- RAK19001 on slot F
 
 ### Resources
 - RAK Documentation Center


### PR DESCRIPTION
For a rak12500, user figured out this worked earlier: https://discord.com/channels/867578229534359593/1202456506587418664/1232564486624247869

Since the rak1910 communicates using the same process/UART number as far as I'm aware, that should be the same for that