### PR TITLE
shutdown after losing power - check power detection status note

### DIFF
--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -30,6 +30,9 @@ When activated, this feature disables Bluetooth, Serial, WiFi, and the device's 
 
 Automatically shut down a device after a defined time period if power is lost.
 
+Before setting this, ensure your board correctly detects when it is connected to external power (the "🔌" icon in the app). Otherwise, your device could shut down even when power is present.
+Many devices detect power status correctly, however for some devices, you will need to modify the ADC Multiplier (below).
+
 ### ADC Multiplier Override
 
 Ratio of voltage divider for battery pin e.g. 3.20 (R1=100k, R2=220k)


### PR DESCRIPTION
As described in meshtastic/firmware#3743 , some users were discovering that their devices unexpectedly powered down after setting "Shutdown on battery delay", despite their devices being connected to USB.

This was due to the devices not correctly detecting that they were connected to USB. This can be resolved by altering the ADC_MULTIPLIER per existing instructions.

This commit adds a note to encourage users to check the power status before enabling "Shutdown on battery delay".

fixes meshtastic/firmware#3743