### PR TITLE
Updates to Linux Native Devices documentation

### DIFF
--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -169,7 +169,6 @@ ExecStart=/usr/sbin/meshtasticd
 Restart=always
 User=root
 Group=root
-StandardOutput=file:/var/log/meshtasticd.log
 StandardError=file:/var/log/meshtasticd.log
 Type=simple
 
@@ -208,45 +207,12 @@ This will give you a detailed view of the service status and any potential error
 
 By following these steps, you set up a systemd service for meshtasticd that will start automatically at boot and restart if it crashes. You can manage it using the standard systemctl commands (start, stop, restart, status, etc.).
 
-#### Setup Log Rotation
-To setup log rotation within the Linux Native Device and do a daily restart of the Meshtastic Daemon you can implement the below.
+#### View Logs of Mesthastic
+To view the log output of the meshtasticd service, use the below command to read them out of the system journal.
 
-Create a logrotate configuration file for the meshtasticd log. Create a file named /etc/logrotate.d/meshtasticd:
 ```shell
-sudo nano /etc/logrotate.d/meshtasticd
+journalctl -u meshtasticd -b
 ```
-
-Add the following content to the file:
-```plaintext
-/var/log/meshtasticd.log {
-    daily
-    missingok
-    rotate 7
-    compress
-    delaycompress
-    notifempty
-    create 0640 root root
-    sharedscripts
-    postrotate
-        systemctl restart meshtasticd > /dev/null 2>&1 || true
-    endscript
-}
-```
-
-##### Test log rotation:
-
-Test the logrotate configuration to ensure it works as expected:
-```shell
-sudo logrotate -d /etc/logrotate.d/meshtasticd
-```
-
-If everything looks good, force a rotation to see it in action:
-```shell
-sudo logrotate -f /etc/logrotate.d/meshtasticd
-```
-
-By following these steps, you will have meshtasticd output directed to a log file with automatic log rotation configured, ensuring that your logs are managed and disk space is conserved.
-
 
 #### Installation of drivers
 

--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -62,7 +62,7 @@ For devices requiring SPI or I2C:
 
 ```shell
 sudo raspi-config nonint set_config_var dtparam=spi on /boot/firmware/config.txt # Enable SPI
-sudo raspi-config nonint set_config_var dtparam=i2c_arm on /boot/firmware/config.txt # Enalbe i2c_arm
+sudo raspi-config nonint set_config_var dtparam=i2c_arm on /boot/firmware/config.txt # Enable i2c_arm
 
 # Ensure dtoverlay=spi0-0cs is set in /boot/firmware/config.txt without altering dtoverlay=vc4-kms-v3d or dtparam=uart0
 sudo sed -i -e '/^\s*#\?\s*dtoverlay\s*=\s*vc4-kms-v3d/! s/^\s*#\?\s*(dtoverlay|dtparam\s*=\s*uart0)\s*=.*/dtoverlay=spi0-0cs/' /boot/firmware/config.txt

--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -58,7 +58,22 @@ sudo apt install ./meshtasticd_{version}arm64.deb
 
 For devices requiring SPI or I2C:
 
-- SPI support can be enabled in `/boot/config.txt` or `/boot/firmware/config.txt`:
+- This can be done by running the below commands on a Raspberry Pi (2-5)
+
+```bash
+sudo raspi-config nonint set_config_var dtparam=spi on /boot/firmware/config.txt # Enable SPI
+sudo raspi-config nonint set_config_var dtparam=i2c_arm on /boot/firmware/config.txt # Enalbe i2c_arm
+
+# Ensure dtoverlay=spi0-0cs is set in /boot/firmware/config.txt without altering dtoverlay=vc4-kms-v3d or dtparam=uart0
+sudo sed -i -e '/^\s*#\?\s*dtoverlay\s*=\s*vc4-kms-v3d/! s/^\s*#\?\s*(dtoverlay|dtparam\s*=\s*uart0)\s*=.*/dtoverlay=spi0-0cs/' /boot/firmware/config.txt
+
+# Insert dtoverlay=spi0-0cs after dtparam=spi=on if not already present
+if ! sudo grep -q '^\s*dtoverlay=spi0-0cs' /boot/firmware/config.txt; then
+    sudo sed -i '/^\s*dtparam=spi=on/a dtoverlay=spi0-0cs' /boot/firmware/config.txt
+fi
+```
+
+- Or this can be accomplished by manually enabling SPI support in `/boot/firmware/config.txt`:
 
 ```plaintext
 dtparam=spi=on
@@ -102,7 +117,14 @@ Webserver:
 
 ### GPS Support
 
-Enabling UART for GPS hats requires modifications in `/boot/firmware/config.txt`:
+- You can enable UART by running the below commands (which additionally will disable serial console tty)
+
+```shell
+sudo raspi-config nonint do_serial_hw 0 # Enable Serial Port (enable_uart=1)
+sudo raspi-config nonint do_serial_cons 1 # Disable Serial Console
+```
+
+- Or you can manually enable UART for GPS hats by making modifications in `/boot/firmware/config.txt`:
 
 ```plaintext
 # Needed for all Pi device.
@@ -114,12 +136,119 @@ dtoverlay=uart0
 
 - The correct port for UART GPS on the Pi 5 after a reboot is `/dev/ttyAMA0`.
 - The correct port for UART GPS on earlier Pi versions after a reboot is `/dev/ttyS0`.
+- You may need to disable the serial console on a Pi and then reboot
+```shell
+sudo raspi-config nonint do_serial_cons 1 # Disable Serial Console
+```
 
 ### Persistence
 
 - The persistent .proto db files of the portduino version of meshtasticd are stored under: `/root/.portduino/default/prefs/`.
 
 ### Advanced Setup and Troubleshooting
+
+#### Creating and Enabling a Systemctl Script (non .deb installs)
+
+To Setup the device to start and stop meshtasticd as as service using systemctl you can setup the service unit using the instructions below.
+
+Create the service unit file:
+
+Create a new file in the /etc/systemd/system/ directory with a name like meshtasticd.service.
+```shell
+sudo nano /etc/systemd/system/meshtasticd.service
+```
+Add the following content to the file:
+
+```plaintext
+[Unit]
+Description=Meshtastic Daemon
+After=network.target
+
+[Service]
+ExecStart=/usr/sbin/meshtasticd
+Restart=always
+User=root
+Group=root
+StandardOutput=file:/var/log/meshtasticd.log
+StandardError=file:/var/log/meshtasticd.log
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload systemd to recognize the new service:
+```shell
+sudo systemctl daemon-reload
+```
+
+Enable the service to start on boot:
+```shell
+sudo systemctl enable meshtasticd
+```
+
+##### Starting and Stopping the Service
+
+Start the service:
+```shell
+sudo systemctl start meshtasticd
+```
+
+Check the status of the service:
+```shell
+sudo systemctl status meshtasticd
+```
+
+Stop the service:
+```shell
+sudo systemctl stop meshtasticd
+```
+
+This will give you a detailed view of the service status and any potential errors.
+
+By following these steps, you set up a systemd service for meshtasticd that will start automatically at boot and restart if it crashes. You can manage it using the standard systemctl commands (start, stop, restart, status, etc.).
+
+#### Setup Log Rotation
+To setup log rotation within the Linux Native Device and do a daily restart of the Meshtastic Daemon you can implement the below.
+
+Create a logrotate configuration file for the meshtasticd log. Create a file named /etc/logrotate.d/meshtasticd:
+```shell
+sudo nano /etc/logrotate.d/meshtasticd
+```
+
+Add the following content to the file:
+```plaintext
+/var/log/meshtasticd.log {
+    daily
+    missingok
+    rotate 7
+    compress
+    delaycompress
+    notifempty
+    create 0640 root root
+    sharedscripts
+    postrotate
+        systemctl restart meshtasticd > /dev/null 2>&1 || true
+    endscript
+}
+```
+
+##### Test log rotation:
+
+Test the logrotate configuration to ensure it works as expected:
+```shell
+sudo logrotate -d /etc/logrotate.d/meshtasticd
+```
+
+If everything looks good, force a rotation to see it in action:
+```shell
+sudo logrotate -f /etc/logrotate.d/meshtasticd
+```
+
+By following these steps, you will have meshtasticd output directed to a log file with automatic log rotation configured, ensuring that your logs are managed and disk space is conserved.
+
+
+#### Installation of drivers
 
 - Installation of drivers for CH341 is required for Ubuntu 22.04 and other systems for SPI/I2C/GPIO support.
 

--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -60,7 +60,7 @@ For devices requiring SPI or I2C:
 
 - This can be done by running the below commands on a Raspberry Pi (2-5)
 
-```bash
+```shell
 sudo raspi-config nonint set_config_var dtparam=spi on /boot/firmware/config.txt # Enable SPI
 sudo raspi-config nonint set_config_var dtparam=i2c_arm on /boot/firmware/config.txt # Enalbe i2c_arm
 

--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -149,7 +149,7 @@ sudo raspi-config nonint do_serial_cons 1 # Disable Serial Console
 
 #### Creating and Enabling a Systemctl Script (non .deb installs)
 
-To Setup the device to start and stop meshtasticd as as service using systemctl you can setup the service unit using the instructions below.
+To configure the device to start and stop meshtasticd as as service using systemctl you can setup the service unit using the instructions below.
 
 Create the service unit file:
 

--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -169,7 +169,6 @@ ExecStart=/usr/sbin/meshtasticd
 Restart=always
 User=root
 Group=root
-StandardError=file:/var/log/meshtasticd.log
 Type=simple
 
 [Install]


### PR DESCRIPTION
Update of Linux Native Agent documentation to satisfy https://github.com/meshtastic/meshtastic/issues/1259
This should also allow us to close the issue on the firmware https://github.com/meshtastic/firmware/issues/3909 as GPSFan wanted it left open until documentation was updated.

Added commands to setup config.txt and cmdline.txt correctly using mostly raspi-config commands instead of manual edits, but left manual method documentation in tact.

Also expanded on some Advanced Functions (eg, those with manual builds/non .deb releases) to create a service script and logrotate.