### PR TITLE
Community Groups now alphabetical and fix UK typo

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -37,6 +37,7 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 ### New Brunswick
 - [Mesht New Brunswick](https://t.me/MeshtNB)
+
 ### Newfoundland
 - [Mesht Newfoundland](https://t.me/MeshtNewfoundland)
 
@@ -57,9 +58,40 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 ### Saskatchewan
 - [Mesht Saskatchewan](https://t.me/MeshtSaska)
-## 
-## United States
 
+## Finland
+- [Mesh Finland Discord](https://discord.com/invite/GHnaVAjqed)
+- [Mesh Finland Website](https://mesh-finland.github.io)
+
+## Germany
+- [Meshtastic Users D-A-CH](https://t.me/meshtasticgermany) for technical chat
+
+## India
+- [India Bir Paragliding](https://bircom.in)
+
+## Italy
+- [Meshtastic Italia](https://t.me/meshtastic_italia)
+- [Mesh_ITA Discord Server](https://discord.gg/ETFmtyzbFT)
+
+## Lithuania
+- [Meshtastic Lietuva](https://www.facebook.com/groups/1122509422249414)
+
+## The Netherlands
+- [Meshtastic Netherlands](https://t.me/meshtastic_nl)
+
+## Poland
+- [Meshtastic Poland Matrix Space](https://matrix.to/#/#meshtasticpl:matrix.org)
+
+## Taiwan
+- [Meshtastic Taiwan Community 臺灣鏈網 - Facebook](https://www.facebook.com/groups/413628121046386)
+- [Meshtastic Taiwan Community 臺灣鏈網 - Discord](https://discord.gg/2vZkuckp8E)
+
+## United Kingdom
+- [UK Meshtastic Kent / South East](https://www.facebook.com/groups/ukmeshtastickent/)
+- [UK Meshtastic Brighton](https://www.facebook.com/groups/3696312513946679/)
+- [UK Meshtastic North East England](https://www.facebook.com/groups/meshtasticnortheastengland/)
+
+## United States
 ### Arkansas
 - [Fort Smith Mesh](https://discord.com/invite/nwsvcXeqMX)
 
@@ -97,40 +129,3 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 ### Texas
 - [Austin Mesh](https://austinmesh.org/)
-
-## Finland
-- [Mesh Finland Discord](https://discord.com/invite/GHnaVAjqed)
-- [Mesh Finland Website](https://mesh-finland.github.io)
-
-## Germany
-- [Meshtastic Users D-A-CH](https://t.me/meshtasticgermany) for technical chat
-
-## India
-- [India Bir Paragliding](https://bircom.in)
-
-## Italy
-- [Meshtastic Italia](https://t.me/meshtastic_italia)
-- [Mesh_ITA Discord Server](https://discord.gg/ETFmtyzbFT)
-
-## Lithuania
-- [Meshtastic Lietuva](https://www.facebook.com/groups/1122509422249414)
-
-## Poland
-- [Meshtastic Poland Matrix Space](https://matrix.to/#/#meshtasticpl:matrix.org)
-
-## United Kingdon
-- [UK Meshtastic Kent / South East](https://www.facebook.com/groups/ukmeshtastickent/)
-- [UK Meshtastic Brighton](https://www.facebook.com/groups/3696312513946679/)
-- [UK Meshtastic North East England](https://www.facebook.com/groups/meshtasticnortheastengland/)
-
-## The Netherlands
-- [Meshtastic Netherlands](https://t.me/meshtastic_nl)
-
-## Taiwan
-- [Meshtastic Taiwan Community 臺灣鏈網 - Facebook](https://www.facebook.com/groups/413628121046386)
-- [Meshtastic Taiwan Community 臺灣鏈網 - Discord](https://discord.gg/2vZkuckp8E)
-
-
-
-
-


### PR DESCRIPTION
This PR:
1. Properly alphabetizes the Community Groups List
2. Fixed a misspelled United Kingdom

[preview link](https://sandbox-git-words-are-hard-pdxlocs-projects.vercel.app/docs/community/local-groups/)