### PR TITLE
Update fixed position-related documentation for meshtastic/python#584 changes

### DIFF
--- a/docs/configuration/radio/position.mdx
+++ b/docs/configuration/radio/position.mdx
@@ -168,12 +168,12 @@ meshtastic --set position.fixed_position true
 The device will continue to acquire GPS coordinates according to the `gps_update_interval`, but will use the last saved coordinates as its fixed point.
 :::
 
-```shell title="Set Fixed Position - User Defined"
+```shell title="Set and Enable Fixed Position - User Defined"
 meshtastic --setlat 37.8651 --setlon -119.5383
 ```
 
-```shell title="Unset Fixed Position"
-meshtastic --set position.fixed_position false
+```shell title="Remove and Unset Fixed Position"
+meshtastic --remove-position
 ```
 
 ```shell title="Enable / Disable Smart position broadcast (Enabled by default)"


### PR DESCRIPTION
The linked PR changes the fixed position handling to be more like the apps using the new admin message, so `--setlat/lon/alt` now set that position and also enable the fixed position setting, and `--remove-position` is added which removes the stored position and disables the fixed position setting.

Requires python CLI version 2.3.10, just released about 5 minutes ago, but I figured I could be prompt about updating the docs :)