### PR TITLE
Added links to German Meshtastic Groups

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -65,6 +65,8 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 ## Germany
 - [Meshtastic Users D-A-CH](https://t.me/meshtasticgermany) for technical chat
+- [Meshtastic Users Germany - Facebook](https://www.facebook.com/share/o6CZ9E35UmDKjp9U/)
+- [Mesh Hessen](https://t.me/Mesh_Hessen)
 
 ## India
 - [India Bir Paragliding](https://bircom.in)


### PR DESCRIPTION
Added 'Meshtastic Germany' Facebook group and 'Mesh Hessen' Telegram group links