### PR TITLE
Remove Non-Compliant Community Groups

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -75,14 +75,10 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 - [Israel Meshtastic Club](https://t.me/+yUGsbNw3zp41MGFk)
 
 ## Italy
-- [Meshtastic Italia](https://t.me/meshtastic_italia)
 - [Mesh_ITA Discord Server](https://discord.gg/ETFmtyzbFT)
 
 ## Lithuania
 - [Meshtastic Lietuva](https://www.facebook.com/groups/1122509422249414)
-
-## The Netherlands
-- [Meshtastic Netherlands](https://t.me/meshtastic_nl)
 
 ## Poland
 - [Meshtastic Poland Matrix Space](https://matrix.to/#/#meshtasticpl:matrix.org)
@@ -98,11 +94,6 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 ## Ukraine
 - [WiKi Meshtastic UA](https://wikimesh.pp.ua)
-
-## United Kingdom
-- [UK Meshtastic Kent / South East](https://www.facebook.com/groups/ukmeshtastickent/)
-- [UK Meshtastic Brighton](https://www.facebook.com/groups/3696312513946679/)
-- [UK Meshtastic North East England](https://www.facebook.com/groups/meshtasticnortheastengland/)
 
 ## United States
 - [Midwest Mesh](https://discord.gg/wYwD56K439)
@@ -127,9 +118,6 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 ### Hawaii
 - [Hawaii Meshnet](https://www.hawaiimesh.net/)
-
-### Illinois
-- [Chicagoland Meshtastic](https://chicagolandmesh.org/)
 
 ### Kansas
 - [SecKC Amateur Radio Club of Kansas City and Surrounding Cities for Amateur Radio](https://ks3ckc.radio/home)


### PR DESCRIPTION
This PR removes listings for local community groups not in compliance with our trademark and logo usage guidelines. Despite notification in April via #1211 and an extended grace period, these groups have not made the required adjustments. While we appreciate their enthusiasm, maintaining consistent branding is crucial for our project's identity. We remain open to re-listing these groups if they choose to comply in the future. https://meshtastic.org/docs/legal/licensing-and-trademark/#social-media

### Groups Affected

- Chicagoland Meshtastic https://chicagolandmesh.org/
- Meshtastic Italia https://t.me/meshtastic_italia
- UK Meshtastic Kent / South East https://www.facebook.com/groups/ukmeshtastickent/
- UK Meshtastic Brighton https://www.facebook.com/groups/3696312513946679/
- UK Meshtastic North East England https://www.facebook.com/groups/meshtasticnortheastengland/
- Meshtastic Netherlands https://t.me/meshtastic_nl