### PR TITLE
Add note about ROUTER_CLIENT deprecation and link to tips

### DIFF
--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -27,6 +27,12 @@ The device config options are: Role, Serial Output, and Debug Log. Device config
 | REPEATER       | Infrastructure node for extending network coverage by relaying messages with minimal overhead. Not visible in Nodes list. | Best positioned in strategic locations to maximize the network's overall coverage. Device is not shown in topology.                    |
 | ROUTER         | Infrastructure node for extending network coverage by relaying messages. Visible in Nodes list.                           | Best positioned in strategic locations to maximize the network's overall coverage. Device is shown in topology.                        |
 
+:::tip
+Still not sure which role to use? Check out the [role configuration tips](/docs/configuration/tips/#roles)
+:::
+
+Looking for ROUTER_CLIENT? This role was deprecated in firmware 2.3.15. Learn more in the [2.3.15 release notes](https://github.com/meshtastic/firmware/releases/tag/v2.3.15.deb7c27)
+
 ### Role Comparison
 
 This table shows the **default** values after selecting a preset. As always, individual settings can be adjusted after choosing a preset.


### PR DESCRIPTION
## What
1. Adds a new `tip` admonition linking to the config tips docs for roles, since I didn't see any others
2. Adds a note about router client deprecation with a link to the firmware version release notes

## Why
1. Our config tips are helpful, we should link to them!
2. We are likely to get questions about this, it will be helpful to have docs to deflect some questions. I have set myself a reminder for 60 days to come back in and remove this since it won't be needed long term.

## Screenshots
<img width="883" alt="Screenshot 2024-07-09 at 10 23 54 AM" src="https://github.com/meshtastic/meshtastic/assets/5215365/8f3432f3-64b2-46ef-9886-32ded6ba2e7e">
