### PR TITLE
Update iOS offline map instructions

### DIFF
--- a/docs/software/apple/usage.mdx
+++ b/docs/software/apple/usage.mdx
@@ -7,7 +7,15 @@ sidebar_position: 2
 
 ## Offline Maps
 
-The Meshtastic app for iOS, iPadOS and macOS supports the sharing of a .mbtiles file with the app for offline map support.
+### Apple Maps
+
+By default, the Meshtastic app for iOS supports the use of native offline Apple Maps.
+
+To download offline maps, follow the official instructions from Apple for [iPhone](https://support.apple.com/en-gb/105084) or [iPad](https://support.apple.com/en-gb/guide/ipad/ipadc6e7e4d7/ipados). Video instructions are also [available](https://youtube.com/watch?v=L260qixQrYs).
+
+### Legacy Mesh Map
+
+As of version 2.2.10 you can enable legacy mesh maps in the iOS Settings > Meshtastic > Use Legacy Mesh Map. With this, the Meshtastic app supports the sharing of a .mbtiles file with the app for offline map support.
 
 There is an open source cross platform mapping program call [QGIS](https://www.qgis.org/en/site/)
 


### PR DESCRIPTION
There seems to be a lot of confusion ([1](https://meshtastic.discourse.group/t/offline-maps-on-meshtastic/137/37), [2](https://meshtastic.discourse.group/t/offline-map-data/10504/4), [3](https://www.reddit.com/r/meshtastic/comments/17h2e58/ios_app_how_to_force_the_app_to_download_and_only/)) based on the previous instructions for offline maps.

I've gone ahead and updated the instructions with working instructions of the current implementation, and moved the previous instructions under "Legacy Mesh Map".

I'm not 100% sure it was app version 2.2.10 that added the toggle  but going through the commit history this is the earliest known mention of the term.