### PR TITLE
Update device.mdx

### DIFF
--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -191,7 +191,7 @@ meshtastic --set device.role CLIENT
 meshtastic --set device.serial_enabled false
 ```
 
-```shell title="Set `tzdef`"
+```shell title="Set tzdef"
 meshtastic --set device.tzdef UTC0
 ```
 


### PR DESCRIPTION
Removed backticks around the tzdef in title that was breaking the formatting.

![image](https://github.com/user-attachments/assets/322864ba-397c-4539-986f-4bf0c39fc6a6)
