### PR TITLE
Improve the timezone documentation

### DIFF
--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -89,7 +89,7 @@ Disabling this will disable the SerialConsole by not initializing the StreamAPI.
 
 The `tzdef` setting allows the local offset to be defined for the device. It uses the TZ Database format to display the correct local time on the device display and in its logs.
 
-To set the timezone, use the POSIX TZ Database string for the relevant region. Here is a list of [supported timezones](https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv).
+To set the timezone, use the POSIX TZ Database string for the relevant region. Here is a list of [supported timezones](https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv). If your timezone is `America/Los_Angeles`, then you must input `PST8PDT,M3.2.0,M11.1.0` as the timezone.
 
 ## Debug Log
 


### PR DESCRIPTION
The current document is confusing if one should enter the TZ name or the "code" corresponding to the zone.