### PR TITLE
Add Seeed T1000-E

### DIFF
--- a/docs/hardware/devices/Seeed Card Tracker/index.mdx
+++ b/docs/hardware/devices/Seeed Card Tracker/index.mdx
@@ -1,0 +1,39 @@
+---
+id: seeed-T1000E
+title: SenseCAP Card Tracker T1000-E for Meshtastic
+sidebar_label: Seeed Card Tracker
+sidebar_position: 16
+---
+
+A 'credit card' sized ready-to-use product. Internal antenna and battery, waterproof housing.
+
+- **MCU**
+  - Nordic nRF52840 (WiFi & Bluetooth)
+- **LoRa Transceiver**
+  - Semtech LR1110
+- **Frequency options**
+  - not stated, but tested at 868Mhz and 915Mhz. 
+- **Navigation Module**
+  - Mediatek AG333
+- **Connectors**
+  - magnetic four pin
+
+
+### Features
+
+- Temperature sensor
+- Lux sensor (light intensity)
+- 3-Axis Accelerometer
+- 700mAh battery
+- single button
+- housing: IP65, credit card size (6.5mm thick)
+
+### Resources
+
+- Firmware file: `firmware-tracker-t1000-e-X.X.X.xxxxxxx.bin`
+- Purchase Links:
+  - International
+    - [Seeed Studio](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html)
+- [Seeed wiki product](https://wiki.seeedstudio.com/sensecap_t1000_e/)
+- [Seeed wiki for T1000 family](https://wiki.seeedstudio.com/SenseCAP_T1000_tracker/Introduction/)
+


### PR DESCRIPTION
First documentation about the SenseCAP Card Tracker T1000-E.
Data from Seeed websites, verified personally where possible.