### PR TITLE
fix: update the factory erase documentation

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/nrf52-erase.mdx
@@ -20,7 +20,7 @@ Alternatively, follow the instructions below.
 
 To reset the flash storage on your nRF52 board:
 
-1. Download and unzip the latest firmware from [Meshtastic Downloads](https://meshtastic.org/downloads).
+1. Download and unzip the latest Alpha firmware from [Meshtastic Downloads](https://meshtastic.org/downloads).
 2. Connect your device to your computer with a USB data cable.
 3. Double click the reset button on your device (this will put it into bootloader mode)
 4. Notice a new drive will be mounted on your computer (Windows, Mac, or Linux)


### PR DESCRIPTION
This PR updates documentation which was not completely correct. Alternatively, the referenced `uf2` files should be made available in the Stable zip, but that's beyond the scope of this PR which is intended to correct the documentation only.