### PR TITLE
Heltec Wireless Tracker Split

### DIFF
--- a/docs/hardware/devices/heltec-automation/index.mdx
+++ b/docs/hardware/devices/heltec-automation/index.mdx
@@ -14,7 +14,8 @@ Inexpensive basic ESP32-based boards.
 | [LoRa32 V2.1](./lora32/?heltec=v2.1)                              | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
 | [LoRa32 V3/3.1](./lora32/?heltec=v23)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Stick Lite V3](./lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
-| [Wireless Tracker](./lora32/?heltec=tracker)                      | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
+| [Wireless Tracker v1.0](./lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
+| [Wireless Tracker v1.1](./lora32/?heltec=tracker-v1.1)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
 | [Wireless Paper](./lora32/?heltec=paper)                          | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 
 ## [Plug & Play Sensors](./sensor/)

--- a/docs/hardware/devices/heltec-automation/lora32/index.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/index.mdx
@@ -16,7 +16,8 @@ values={[
 {label: 'LoRa32 V2.1', value: 'v2.1'},
 {label: 'LoRa32 V3/V3.1', value:'v3'},
 {label: 'Wireless Stick Lite V3', value:'Wireless Stick Lite V3'},
-{label: 'Wireless Tracker', value: 'tracker'},
+{label: 'Wireless Tracker v1.0', value: 'tracker-v1.0'},
+{label: 'Wireless Tracker v1.1', value: 'tracker-v1.1'},
 {label: 'Wireless Paper v1.0', value: 'paper-v1.0'},
 {label: 'Wireless Paper v1.1', value: 'paper-v1.1'}
 ]}>
@@ -165,9 +166,73 @@ Image Source: [Heltec](https://resource.heltec.cn/download/Wireless_Stick_Lite_V
 
 </TabItem>
 
-<TabItem value="tracker">
+<TabItem value="tracker-v1.0">
 
-## Wireless Tracker
+## Wireless Tracker v1.0
+
+:::info
+This device may have issues charging a connected battery if utilizing a USB-C to USB-C cable. It's recommended to use a USB-A to USB-C cable.
+:::
+
+- **MCU:**
+  - ESP32-S3FN8 (WiFi & Bluetooth)
+- **LoRa Transceiver:**
+  - Semtech SX1262
+- **Frequency Options:**
+  - 470 - 510 MHz
+  - 863 - 870 MHz
+  - 902 - 928 MHz
+- **Connectors:**
+  - USB-C
+  - Antenna:
+    - Dedicated 2.4 GHz metal spring antenna for WiFi/Bluetooth
+    - U.FL/IPEX antenna connector for LoRa and GNSS
+
+### Features
+
+- Onboard 0.96-inch LCD display
+- User and Reset Buttons
+
+### Flashing
+
+To flash ESP32-S3 devices like the Wireless Tracker, you typically need to place them in Espressif's firmware download mode. Use the "1200bps reset" button in the web flasher to do this. If this method does not work for any reason, you can follow the manual process below.
+
+:::warning
+
+Do not proceed unless an antenna is connected to avoid possible damage to the device's radio.
+
+:::
+
+The following process will manually place the device into the Espressif Firmware Download mode:
+
+1. Unplug the device.
+2. Press and hold the USER button.
+3. Plug device in.
+4. After 2-3 seconds, release the USER button.
+
+With the device now in the Espressif Firmware Download mode, you can proceed with flashing using one of the supported flashing methods. It's generally recommended to use the [Web Flasher](https://flasher.meshtastic.org/). You can select "Heltec Wireless Tracker" from the device drop-down.
+
+### Pin Map
+
+![HT-Tracker_V1 Pin Map](/img/hardware/HT-Tracker_V1_Pin_Map.webp)
+
+Image Source: [Heltec](https://heltec.org/project/wireless-tracker/)
+
+### Resources
+
+- Firmware file: `firmware-heltec-wireless-tracker-V1-0-X.X.X.xxxxxxx.bin`
+- Purchase Links:
+
+:::note
+
+Heltec revised the Wireless Tracker schematics and released a V1.1, most devices being sold are now [V1.1.](/docs/hardware/devices/heltec-automation/lora32/?heltec=tracker-v1.1#resources-4)
+
+:::
+
+</TabItem>
+<TabItem value="tracker-v1.1">
+
+## Wireless Tracker v1.1
 
 :::info
 This device may have issues charging a connected battery if utilizing a USB-C to USB-C cable. It's recommended to use a USB-A to USB-C cable.

--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -126,7 +126,8 @@ Inexpensive basic ESP32-based boards.
 | [LoRa32 V2.1](./heltec-automation/lora32/?heltec=v2.1)                              | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
 | [LoRa32 V3/3.1](./heltec-automation/lora32/?heltec=v23)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Stick Lite V3](./heltec-automation/lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
-| [Wireless Tracker](./heltec-automation/lora32/?heltec=tracker)                      | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
+| [Wireless Tracker v1.0](./heltec-automation/lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
+| [Wireless Tracker v1.1](./heltec-automation/lora32/?heltec=tracker-v1.1)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
 | [Wireless Paper](./heltec-automation/lora32/?heltec=paper)                          | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 
 ### [Plug & Play Sensors](./heltec-automation/sensor/)


### PR DESCRIPTION
Heltec Wireless Tracker has been separated into **v1.0** and **v1.1** due to different firmware files, and different selections in the flasher. This way people don't get confused. 