### PR TITLE
resolve gps_update_interval documentation conflict

### DIFF
--- a/docs/configuration/radio/position.mdx
+++ b/docs/configuration/radio/position.mdx
@@ -155,7 +155,7 @@ meshtastic --set position.fixed_position true --setlat 37.8651 --setlon -119.538
 
 :::
 
-```shell title="Set GPS update interval (Default of 0 is 30 seconds)"
+```shell title="Set GPS update interval (Default of 0 is 2 Minutes)"
 meshtastic --set position.gps_update_interval 0
 meshtastic --set position.gps_update_interval 45
 ```


### PR DESCRIPTION
The documentation states that the default value for the gps_update_interval is both 2 Minutes and 30 Seconds.  It appears the correct value is 2 Minutes, so this change makes that consistent throughout this page.