### PR TITLE
OK to MQTT is in LoRa config

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -79,14 +79,6 @@ The precision to use for the position in the map report. Defaults to a maximum d
 
 How often we should publish the map report to the MQTT server in seconds. Defaults to 900 seconds (15 minutes).
 
-### OK to MQTT
-
-Acceptable values: `true`, `false`
-
-Default is `false`. When set to `true`, this configuration indicates that the user approves the packet to be uploaded to MQTT. If set to `false`, remote nodes are requested not to forward packets to MQTT.
-
-**Important:** This is not a cryptographic solution but a polite request that is enforced in the official firmware.
-
 ## MQTT Module Config Client Availability
 
 <Tabs
@@ -145,7 +137,6 @@ The following configuration options are available in the Python CLI:
 |          mqtt.root           |     `string`      |                       |
 | mqtt.proxy_to_client_enabled |  `true`, `false`  |        `false`        |
 |  mqtt.map_reporting_enabled  |  `true`, `false`  |        `false`        |
-|    mqtt.config_ok_to_mqtt    |  `true`, `false`  |        `false`        |
 
 :::tip
 

--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -115,6 +115,14 @@ For testing it is useful sometimes to force a node to never listen to particular
 
 Setting this to option to 'true' means the device will ignore any messages it receives via LoRa that came via MQTT somewhere along the path towards the device. Note this only works when your device and the MQTT node are running at least firmware version 2.2.19.
 
+### OK to MQTT
+
+Acceptable values: `true`, `false`
+
+Default is `false`. When set to `true`, this configuration indicates that the user approves their packets to be uploaded to MQTT. If set to `false`, nodes receiving your packets are requested not to forward packets to MQTT.
+
+**Important:** This is not a cryptographic solution but a polite request that is enforced in the official firmware.
+
 ### Override Duty Cycle Limit
 
 Setting this option to 'true' means the device will ignore the hourly duty cycle limit in Europe. This means that you might violate regulations if the device transmits too much. By default, this option is set to 'false,' which means the device will stop sending data when it reaches the hourly limit and will start again when it is allowed to do so.
@@ -185,6 +193,7 @@ LoRa config commands are available in the python CLI. Example commands are below
 |       lora.tx_enabled       |                                                                      `false`, `true`                                                                      |   `true`    |
 |      lora.channel_num       |                                                                `0`, `1` to `NUM_CHANNELS`                                                                 |     `0`     |
 |      lora.ignore_mqtt       |                                                                      `false`, `true`                                                                      |   `false`   |
+|    lora.config_ok_to_mqtt   |                                                                      `true`, `false`                                                                      |   `false`   |
 |  lora.override_duty_cycle   |                                                                      `false`, `true`                                                                      |   `false`   |
 | lora.sx126x_rx_boosted_gain |                                                                      `false`, `true`                                                                      |   `false`   |
 |   lora.override_frequency   |                             Any supported frequency the LoRA radio is capable of. Please respect local rules and regulations                              |     `0`     |


### PR DESCRIPTION
The "OK to MQTT" setting was on the MQTT config page, but it is in the LoRa config.