### PR TITLE
Add initial documentation for Health Telemetry

### DIFF
--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -149,7 +149,7 @@ All telemetry module config options are available in the python CLI. Example com
 |   telemetry.air_quality_enabled           |   `true`, `false`   |                `false`                    |
 |   telemetry.air_quality_interval          | `integer` (seconds) | Default `0` is 30 minutes(`1800` seconds). |
 |   telemetry.health_measurement_enabled    |   `true`, `false`   |                `false`                    |
-|   telemetry.health_update_in              | `integer` (seconds) | Default `0` is 30 minutes(`1800` seconds). |
+|   telemetry.health_update_interval           | `integer` (seconds) | Default `0` is 30 minutes(`1800` seconds). |
 |   telemetry.health_screen_enabled         |   `true`, `false`   |                `false`                    |
 
 

--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -2,15 +2,15 @@
 id: telemetry
 title: Telemetry Module Configuration
 sidebar_label: Telemetry
-description: This module allows sharing of Device, Environment, and Air Quality metrics from your Meshtastic device.
+description: This module allows sharing of Device, Environment, Health, and Air Quality metrics from your Meshtastic device.
 ---
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-The Telemetry Module provides three types of data over the mesh: Device metrics (Battery Level, Voltage, Channel Utilization and Airtime) from your Meshtastic device, Environment Metrics from attached I2C sensors, and Air Quality Metrics from attached I2C particle sensors.
+The Telemetry Module provides four types of data over the mesh: Device metrics (Battery Level, Voltage, Channel Utilization and Airtime) from your Meshtastic device, Environment Metrics, Air Quality Metrics, and Health metrics (Heart rate, Oxygen Saturation and body temperature).
 
-Supported sensors connected to the I2C bus of the device will be automatically detected at startup. Environment Telemetry and Air Quality must be enabled for them to be instrumented and their readings sent over the mesh.
+Supported sensors connected to the I2C bus of the device will be automatically detected at startup. The Environment Telemetry, Air Quality, and Health Telemetry modules must be enabled for them to be instrumented and their readings sent over the mesh.
 
 <object data="https://www.youtube.com/embed/6jj1s-fsPlc?autohide=1&autoplay=0" width="100%" height="400"></object>
 
@@ -32,6 +32,9 @@ Supported sensors connected to the I2C bus of the device will be automatically d
 |  SHT31  |          0x44          |                   Temperature and humidity                    |
 | PMSA003I|          0x12          |     Concentration units by size and particle counts by size   |
 | DFROBOT_LARK |    0x42           | Temperature, barometric pressure, humidity, wind direction, wind speed |
+| MAX30102 |        0x57           | Heart Rate, Oxygen Saturation, and body temperature           |
+| MLX90614 |        0x5A           | Body temperature                                              |
+
 
 ## Module Config Values
 
@@ -74,6 +77,18 @@ Default is `false`.
 ### Air Quality Interval
 
 This option is used to configure the interval (in seconds) that should be used to send air quality metrics from an attached supported sensor over the mesh network.
+
+Default is `1800` seconds (30 minutes).
+
+### Health Telemetry Enabled
+
+This option is used to enable/disable the sending of health data from an attached supported sensor over the mesh network.
+
+Default is `false`.
+
+### Health Telemetry Interval
+
+This option is used to configure the interval (in seconds) that should be used to send health data from an attached supported sensor over the mesh network.
 
 Default is `1800` seconds (30 minutes).
 
@@ -133,6 +148,10 @@ All telemetry module config options are available in the python CLI. Example com
 |   telemetry.environment_update_interval   | `integer` (seconds) | Default `0` is 30 minutes(`1800` seconds). |
 |   telemetry.air_quality_enabled           |   `true`, `false`   |                `false`                    |
 |   telemetry.air_quality_interval          | `integer` (seconds) | Default `0` is 30 minutes(`1800` seconds). |
+|   telemetry.health_measurement_enabled    |   `true`, `false`   |                `false`                    |
+|   telemetry.health_update_in              | `integer` (seconds) | Default `0` is 30 minutes(`1800` seconds). |
+|   telemetry.health_screen_enabled         |   `true`, `false`   |                `false`                    |
+
 
 :::tip
 


### PR DESCRIPTION
The health telemetry module, implemented by https://github.com/meshtastic/firmware/pull/4927 , allows heart rate, oxygen saturation, and body temperature measurements to be shared over the mesh.

The first users are likely to be cows, rather than humans :)

Fixes https://github.com/meshtastic/firmware/issues/4738