### PR TITLE
docs: --noproto needs a physical connection

### DIFF
--- a/docs/software/python-cli/index.mdx
+++ b/docs/software/python-cli/index.mdx
@@ -541,7 +541,7 @@ meshtastic --ble-scan
 
 ### --noproto
 
-Don't start the API, just function as a dumb serial terminal. Useful for debugging because it doesn't count as a client. Depends on a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
+Don't start the API, just function as a dumb serial terminal. Useful for debugging because it doesn't count as a client. Depends on a physically cabled serial connection. It will connect but not display information over a network (--host) or Bluetooth (--ble) connection.
 
 ```shell title="Usage"
 meshtastic --noproto

--- a/docs/software/python-cli/index.mdx
+++ b/docs/software/python-cli/index.mdx
@@ -541,11 +541,7 @@ meshtastic --ble-scan
 
 ### --noproto
 
-Don't start the API, just function as a dumb serial terminal. Probably not very helpful from the command line. Used more for testing/internal needs.
-
-:::note
-The `--noproto` command depends on a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
-:::
+Don't start the API, just function as a dumb serial terminal. Useful for debugging because it doesn't count as a client. Depends on a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
 
 ```shell title="Usage"
 meshtastic --noproto

--- a/docs/software/python-cli/index.mdx
+++ b/docs/software/python-cli/index.mdx
@@ -543,6 +543,10 @@ meshtastic --ble-scan
 
 Don't start the API, just function as a dumb serial terminal. Probably not very helpful from the command line. Used more for testing/internal needs.
 
+:::note
+The `--noproto` command depends on a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
+:::
+
 ```shell title="Usage"
 meshtastic --noproto
 ```

--- a/docs/software/python-cli/usage.mdx
+++ b/docs/software/python-cli/usage.mdx
@@ -16,6 +16,10 @@ The `meshtastic` command is not run within python but is a script run from your 
 
 The `--noproto` command in the Meshtastic Python CLI is used to disable the API and function merely as a "dumb serial terminal."  This mode of operation allows both the API and device functionalities to remain accessible for regular use, while simultaneously providing a window into the raw serial output. This feature can be particularly useful for debugging, development, or understanding the low-level communication between devices.
 
+:::note
+The `--noproto` command depends on a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
+:::
+
 ```shellsession title="Example Usage"
 user@host % meshtastic --noproto
 # You should see results similar to this:

--- a/docs/software/python-cli/usage.mdx
+++ b/docs/software/python-cli/usage.mdx
@@ -14,11 +14,7 @@ The `meshtastic` command is not run within python but is a script run from your 
 
 ## Viewing Serial Output
 
-The `--noproto` command in the Meshtastic Python CLI is used to disable the API and function merely as a "dumb serial terminal."  This mode of operation allows both the API and device functionalities to remain accessible for regular use, while simultaneously providing a window into the raw serial output. This feature can be particularly useful for debugging, development, or understanding the low-level communication between devices.
-
-:::note
-The `--noproto` command depends on a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
-:::
+The `--noproto` command in the Meshtastic Python CLI is used to disable the API and function merely as a "dumb serial terminal."  This mode of operation allows both the API and device functionalities to remain accessible for regular use, while simultaneously providing a window into the raw serial output. This feature can be particularly useful for debugging, development, or understanding the low-level communication between devices.Requires a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
 
 ```shellsession title="Example Usage"
 user@host % meshtastic --noproto

--- a/docs/software/python-cli/usage.mdx
+++ b/docs/software/python-cli/usage.mdx
@@ -14,7 +14,7 @@ The `meshtastic` command is not run within python but is a script run from your 
 
 ## Viewing Serial Output
 
-The `--noproto` command in the Meshtastic Python CLI is used to disable the API and function merely as a "dumb serial terminal."  This mode of operation allows both the API and device functionalities to remain accessible for regular use, while simultaneously providing a window into the raw serial output. This feature can be particularly useful for debugging, development, or understanding the low-level communication between devices.Requires a physically cabled serial connection. It will connect but not display information over a network (`--host`) or Bluetooth (`--ble`) connection.
+The `--noproto` command in the Meshtastic Python CLI is used to disable the API and function merely as a "dumb serial terminal."  This mode of operation allows both the API and device functionalities to remain accessible for regular use, while simultaneously providing a window into the raw serial output. This feature can be particularly useful for debugging, development, or understanding the low-level communication between devices. Depends on a physically cabled serial connection. It will connect but not display information over a network (--host) or Bluetooth (--ble) connection.
 
 ```shellsession title="Example Usage"
 user@host % meshtastic --noproto


### PR DESCRIPTION
I noticed today that if I attempt to use the python cli's `--noproto` with a network or BLE connection, the CLI will connect but never display any information. @ianmcorvidae (mian on Discord) confirmed this was the case in [this Discord conversation](https://discord.com/channels/867578229534359593/871553765105348668/1292593285990187200). 

This PR updates the docs with this caveat/context.