### PR TITLE
docs: clarify which keys config_ok_to_mqtt applies to

### DIFF
--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -119,7 +119,7 @@ Setting this to option to 'true' means the device will ignore any messages it re
 
 Acceptable values: `true`, `false`
 
-Default is `false`. When set to `true`, this configuration indicates that the user approves their packets to be uploaded to MQTT. If set to `false`, nodes receiving your packets are requested not to forward packets to MQTT.
+Default is `false`. When set to `true`, this configuration indicates that the user approves their packets to be uploaded to MQTT. If set to `false`, nodes receiving your packets are requested not to forward packets to MQTT. This configuration only applies to Channels configured with the `defaultpsk` and `eventpsk` keys set in the Meshtastic Firmware; Channels with custom keys ignore this setting.
 
 **Important:** This is not a cryptographic solution but a polite request that is enforced in the official firmware.
 


### PR DESCRIPTION
`config_ok_to_mqtt` [only applies to the `defaultpsk` and `eventpsk`](https://github.com/meshtastic/firmware/blob/1c54388bb897ac2a5617fc9a85e1b045265826e3/src/mqtt/MQTT.cpp#L547-L548).

This might be a little verbose because I state what it does apply to and consequences for other keys, but sometimes being that explicit helps. I'm not tied to it. 