### PR TITLE
Fixing indentation in FAQ

### DIFF
--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -164,9 +164,9 @@ If you use your ham radio license with Meshtastic, consider both the privileges 
     {
       title: "How do I set my ham call sign?",
       content: `
-        - On Android navigate to Radio configuration -> User and set Long name to your Ham Radio callsign, then activate the slider for 'Licensed amateur radio'.
-        - On iPhone navigate to Settings -> User and set Long Name to your Ham Radio callsign, then activate the slider for 'Licensed Operator'.
-        - Instructions for Enabling ham License from the Python CLI can be found [here](/docs/software/python/cli/usage#ham-radio-support).
+- On Android navigate to Radio configuration -> User and set Long name to your Ham Radio callsign, then activate the slider for 'Licensed amateur radio'.
+- On iPhone navigate to Settings -> User and set Long Name to your Ham Radio callsign, then activate the slider for 'Licensed Operator'.
+- Instructions for Enabling ham License from the Python CLI can be found [here](/docs/software/python/cli/usage#ham-radio-support).
       `,
     },
   ],


### PR DESCRIPTION
Previous indentation here caused this documentation to be rendered in a code block. Checked the other FAQ items, look like this was the only one.

![image](https://github.com/user-attachments/assets/4940834b-4687-4e85-ab1a-5e9737e75aff)
