### PR TITLE
Add CincyMesh to Kentucky

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -204,6 +204,10 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 - [SecKC Amateur Radio Club of Kansas City and Surrounding Cities for Amateur Radio](https://ks3ckc.radio/home)
 
+### Kentucky
+
+- [Cincy Mesh](https://www.cincymesh.org)
+
 ### Massachusetts
 
 - [Boston Meshnet](https://github.com/Darachnid/Boston-Meshnet)


### PR DESCRIPTION
Half of the greater cincy area is in Kentucky as a border-city, so it properly belongs in both categories. Very minor PR adjusting this.

As an example,  several of the nodes on their website's map are in KY.

https://www.cincymesh.org/guidelines

The river in the middle is the border.

![image](https://github.com/user-attachments/assets/ae5b859a-aff1-4876-b7fc-3b38fdaad592)
