### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -22,9 +22,15 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 ## Australia
 
+- [Meshtastic Australia - Facebook](https://www.facebook.com/groups/1169993994163108)
+
 ### Australian Capital Territory
 
 - [Canberra Meshtastic Community - Discord](https://discord.gg/4QgFsuaC3Z)
+
+### New South Wales 
+
+- [Meshtastic Sydney - Facebook](https://www.facebook.com/groups/1041534027106861)
 
 ### Tasmania
 


### PR DESCRIPTION
Added Australia FB group
Added Australian state New South Wales
Added Sydney facebook group under New South Wales

<!-- Add or remove sections as needed -->
## What did you change
Updated and added some Australia information

## Why did you change it
Moderator of the Meshtastic Sydney FB group and wanting to help grow the community

