### PR TITLE
Update remote-admin.mdx

### DIFF
--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -6,6 +6,10 @@ sidebar_position: 3
 description: An advanced feature which allows remote administration of a device through a secure channel on the Mesh instead of via Bluetooth, Serial, or IPv4.
 ---
 
+:::warning Out of Date
+This page is out of date for firmware 2.5+ and will not work.
+:::
+
 :::caution Disclaimer
 This is an advanced feature that few users should need. Keep in mind that it is possible (if you are not careful) to assign settings to a remote node that cause it to completely drop off of your mesh. We advise network admins have a test node to test settings with before applying changes to a remote node to prevent this.
 :::


### PR DESCRIPTION
## What did you change
I added a warning banner for version 2.5+ users that the content of the page will not work. 

## Why did you change it
2.5+ users can still follow the documentation and expect the same result. However, they will not. Bad documentation is worse than no documentation. Warning users about this page being out of date until it is updated. The content is otherwise unchanged to benefit users with older nodes.