### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -261,3 +261,7 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 ### Wisconsin
 
 - [Meshconsin](https://meshconsin.org)
+
+### Washington
+
+- [Puget Mesh]()https://PugetMesh.org


### PR DESCRIPTION
## What did you change
Added Washington State section and Puget Mesh group link.

## Why did you change it
There was no section for Washington state, and no link to the PugetMesh group which is in Washington state. 