### PR TITLE
Fixed Temp units

### DIFF
--- a/docs/software/integrations/mqtt/home-assistant.mdx
+++ b/docs/software/integrations/mqtt/home-assistant.mdx
@@ -113,7 +113,7 @@ sensor:
         {{ this.state }}
       {% endif %}
     device_class: "temperature"
-    unit_of_measurement: "F"
+    unit_of_measurement: "°F"
 # With device_class: "temperature" set, make sure to use the configured unit for temperature in your HA instance.
 # If you don't, then non-temperature messages will change the value of this sensor by reinterpreting the current state with the wrong unit, unless you account for it.
 # For Celsius use:    {{ (value_json.payload.temperature | float) | round(1) }} 


### PR DESCRIPTION
Without the degree symbol Home Assistant doesn't recognize the units properly

<!-- Add or remove sections as needed -->
Added the degree symbol to properly represent the units of degrees Fahrenheit 
<!-- Describe what your changes will do if merged -->
Make the example more accurate as with the proper units HA will automatically convert on request as well.

## Why did you change it
It bothered me when I used the example and other people may not realize 


