### PR TITLE
fix link to android usage instead of python

### DIFF
--- a/docs/getting-started/initial-config.mdx
+++ b/docs/getting-started/initial-config.mdx
@@ -74,7 +74,7 @@ values={[
 
 #### Android
 
-1. Follow the [installation](/docs/software/android/installation) and [usage](/docs/software/python/cli/usage) instructions for [Meshtastic Android](/docs/category/android-app).
+1. Follow the [installation](/docs/software/android/installation) and [usage](/docs/software/android/usage/) instructions for [Meshtastic Android](/docs/category/android-app).
 2. Open the app, connect to the device from your phone over USB Serial or Bluetooth.
 3. Once paired, Click "UNSET" next to the device name.
 4. Select the region from the list according to your regional location.


### PR DESCRIPTION
The link for android usage went to python cli page, this PR changes it to the android usage page.

<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->

## Screenshots
### Before


### After
