### PR TITLE
Remove Heltec V2 from docs

### DIFF
--- a/docs/community/enclosures/heltec-v3.mdx
+++ b/docs/community/enclosures/heltec-v3.mdx
@@ -2,7 +2,7 @@
 id: heltec-enclosures
 title: Heltec LoRa 32 Enclosures
 description: Enclosures
-sidebar_label: Heltec V2
+sidebar_label: Heltec V3
 sidebar_position: 5
 ---
 
@@ -10,7 +10,7 @@ import Tropho from "/img/enclosures/3dp-tropho-heltec32.webp";
 
 ## Created by tropho/TonyG
 
-### Heltec LoRa32 v2.1+ Case
+### Heltec LoRa32 v3 Case
 
 Download from [Printables](https://www.printables.com/model/118750-heltec-lora-32-case-for-meshtastic) or purchase an already printed case below.
 

--- a/docs/hardware/devices/heltec-automation/index.mdx
+++ b/docs/hardware/devices/heltec-automation/index.mdx
@@ -10,9 +10,8 @@ sidebar_position: 4
 Inexpensive basic ESP32-based boards.
 
 | Name                                                              | MCU         | Radio  |     WiFi     | BT  | GPS |
-| :---------------------------------------------------------------- | :---------- | :----- | :----------: | :-: | :-: |
-| [LoRa32 V2.1](./lora32/?heltec=v2.1)                              | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
-| [LoRa32 V3/3.1](./lora32/?heltec=v23)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+|:------------------------------------------------------------------|:------------|:-------|:------------:|:---:|:---:|
+| [LoRa32 V3/3.1](./lora32/?heltec=v3)                              | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Stick Lite V3](./lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Tracker v1.0](./lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
 | [Wireless Tracker v1.1](./lora32/?heltec=tracker-v1.1)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |

--- a/docs/hardware/devices/heltec-automation/lora32/index.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/index.mdx
@@ -13,7 +13,6 @@ groupId="heltec"
 queryString="heltec"
 defaultValue="v3"
 values={[
-{label: 'LoRa32 V2.1', value: 'v2.1'},
 {label: 'LoRa32 V3/V3.1', value:'v3'},
 {label: 'Wireless Stick Lite V3', value:'Wireless Stick Lite V3'},
 {label: 'Wireless Tracker v1.0', value: 'tracker-v1.0'},
@@ -21,38 +20,6 @@ values={[
 {label: 'Wireless Paper v1.0', value: 'paper-v1.0'},
 {label: 'Wireless Paper v1.1', value: 'paper-v1.1'}
 ]}>
-<TabItem value="v2.1">
-
-## V2.1
-
-:::warning
-Not recommended because of design issues! Support is being phased out. Use V3 in new projects.
-:::
-
-- **MCU:**
-  - ESP32 (WiFi & Bluetooth)
-- **LoRa Transceiver:**
-  - Semtech SX127x
-- **Frequency Options:**
-  - 433 MHz
-  - 868 MHz
-  - 915 MHz
-- **Connectors:**
-  - Micro USB
-  - Antenna:
-    - U.FL/IPEX antenna connector for LoRa
-
-### Features
-
-- Built in 0.96 inch OLED display
-- User and Reset Buttons
-- No GPS
-
-### Resources
-
-- Firmware file: `firmware-heltec-v2.1-X.X.X.xxxxxxx.bin`
-
-</TabItem>
 
 <TabItem value="v3">
 

--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -122,8 +122,7 @@ Standalone device with screen and keyboard
 Inexpensive basic ESP32-based boards.
 
 | Name                                                                                | MCU         | Radio  |     WiFi     | BT  | GPS |
-| :---------------------------------------------------------------------------------- | :---------- | :----- | :----------: | :-: | :-: |
-| [LoRa32 V2.1](./heltec-automation/lora32/?heltec=v2.1)                              | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
+|:------------------------------------------------------------------------------------|:------------|:-------|:------------:|:---:|:---:|
 | [LoRa32 V3/3.1](./heltec-automation/lora32/?heltec=v23)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Stick Lite V3](./heltec-automation/lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Tracker v1.0](./heltec-automation/lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |

--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -15,7 +15,7 @@ Meshtastic firmware can be installed on a wide range of development boards. The 
 While all the boards listed on this page will run Meshtastic and mesh with each other, some current community favorites are:
 
 - RAK Meshtastic Start Kit: [RAK19007](/docs/hardware/devices/rak-wireless/wisblock/base-board/?rakbase=RAK19007)+[RAK4631](/docs/hardware/devices/rak-wireless/wisblock/core-module/?rakcore=RAK4631)
-- [HELTEC LoRa V3](/docs/hardware/devices/heltec-automation/lora32/?heltec=v23)
+- [HELTEC LoRa V3](/docs/hardware/devices/heltec-automation/lora32/?heltec=v3)
 - [Nano G2 Ultra](/docs/hardware/devices/b-and-q-consulting/nano/?nano-series=g2)
 - [Station G2](/docs/hardware/devices/b-and-q-consulting/station-series/?station-series=g2)
 - [LILYGO LoRa T3-S3](/docs/hardware/devices/lilygo/lora/?t-lora=S3-v1)
@@ -123,7 +123,7 @@ Inexpensive basic ESP32-based boards.
 
 | Name                                                                                | MCU         | Radio  |     WiFi     | BT  | GPS |
 |:------------------------------------------------------------------------------------|:------------|:-------|:------------:|:---:|:---:|
-| [LoRa32 V3/3.1](./heltec-automation/lora32/?heltec=v23)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [LoRa32 V3/3.1](./heltec-automation/lora32/?heltec=v3)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Stick Lite V3](./heltec-automation/lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Tracker v1.0](./heltec-automation/lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
 | [Wireless Tracker v1.1](./heltec-automation/lora32/?heltec=tracker-v1.1)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |


### PR DESCRIPTION
Out with the old

Heltec V2 is no longer a supported board. 