### PR TITLE
Add Heltec Paper 1.1 to indexes

### DIFF
--- a/docs/hardware/devices/heltec-automation/index.mdx
+++ b/docs/hardware/devices/heltec-automation/index.mdx
@@ -10,13 +10,14 @@ sidebar_position: 4
 Inexpensive basic ESP32-based boards.
 
 | Name                                                              | MCU         | Radio  |     WiFi     | BT  | GPS |
-| :---------------------------------------------------------------- | :---------- | :----- | :----------: | :-: | :-: |
+|:------------------------------------------------------------------|:------------|:-------|:------------:|:---:|:---:|
 | [LoRa32 V2.1](./lora32/?heltec=v2.1)                              | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
 | [LoRa32 V3/3.1](./lora32/?heltec=v23)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Stick Lite V3](./lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Tracker v1.0](./lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
 | [Wireless Tracker v1.1](./lora32/?heltec=tracker-v1.1)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
-| [Wireless Paper](./lora32/?heltec=paper)                          | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [Wireless Paper v1.0](./lora32/?heltec=paper-v1.0)                     | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [Wireless Paper v1.1](./lora32/?heltec=paper-v1.1)                     | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 
 ## [Plug & Play Sensors](./sensor/)
 

--- a/docs/hardware/devices/heltec-automation/index.mdx
+++ b/docs/hardware/devices/heltec-automation/index.mdx
@@ -16,8 +16,8 @@ Inexpensive basic ESP32-based boards.
 | [Wireless Stick Lite V3](./lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Tracker v1.0](./lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
 | [Wireless Tracker v1.1](./lora32/?heltec=tracker-v1.1)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
-| [Wireless Paper v1.0](./lora32/?heltec=paper-v1.0)                     | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
-| [Wireless Paper v1.1](./lora32/?heltec=paper-v1.1)                     | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [Wireless Paper v1.0](./lora32/?heltec=paper-v1.0)                | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [Wireless Paper v1.1](./lora32/?heltec=paper-v1.1)                | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 
 ## [Plug & Play Sensors](./sensor/)
 

--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -122,13 +122,14 @@ Standalone device with screen and keyboard
 Inexpensive basic ESP32-based boards.
 
 | Name                                                                                | MCU         | Radio  |     WiFi     | BT  | GPS |
-| :---------------------------------------------------------------------------------- | :---------- | :----- | :----------: | :-: | :-: |
+|:------------------------------------------------------------------------------------|:------------|:-------|:------------:|:---:|:---:|
 | [LoRa32 V2.1](./heltec-automation/lora32/?heltec=v2.1)                              | ESP32       | SX127x | 2.4GHz b/g/n | 4.2 | NO  |
 | [LoRa32 V3/3.1](./heltec-automation/lora32/?heltec=v23)                             | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Stick Lite V3](./heltec-automation/lora32/?heltec=Wireless+Stick+Lite+V3) | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 | [Wireless Tracker v1.0](./heltec-automation/lora32/?heltec=tracker-v1.0)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
 | [Wireless Tracker v1.1](./heltec-automation/lora32/?heltec=tracker-v1.1)            | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | YES |
-| [Wireless Paper](./heltec-automation/lora32/?heltec=paper)                          | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [Wireless Paper v1.0](./heltec-automation/lora32/?heltec=paper-v1.0)                | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
+| [Wireless Paper v1.1](./heltec-automation/lora32/?heltec=paper-v1.1)                | ESP32-S3FN8 | SX1262 | 2.4GHz b/g/n | 5.0 | NO  |
 
 ### [Plug & Play Sensors](./heltec-automation/sensor/)
 


### PR DESCRIPTION
This PR splits the Heltec wireless Paper into 1.0 and 1.1 on the hardware indexes and links to their specific hardware pages.