### PR TITLE
Fix copy button for codeblocks in Safari

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,10 @@ import typography from "@tailwindcss/typography";
 import type { Config } from "tailwindcss";
 
 export default {
+  corePlugins: {
+    preflight: false,
+    container: false,
+  },
   content: ["./src/**/*.{js,jsx,ts,tsx,md,mdx}", "./docs/**/*.{md,mdx}"],
   darkMode: ["class", '[data-theme="dark"]'],
   theme: {


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->
Added some tailwindcss configuration that was missing from the existing `tailwind.config.js` file.

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->
Codeblocks were not successfully copying on Safari, adding this has fixed it.