### PR TITLE
Remove duplicate Seeed Wio-WM1110

### DIFF
--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -228,15 +228,6 @@ All-in-one development device with LoRa, WiFi, BT, touchscreen, accelerometer, g
 | :------------------- | :--------------- | :----- | :--: | :-: | :-: |
 | [unPhone](./unPhone) | ESP32-S3-WROOM-1 | RF950W | YES  | 5.0 | NO  |
 
-### [Seeed Wio-WM1110](./seeed-studio/wm1110)
-
-nRF52840-based development boards with GPS, and multiple ports to attach sensors.
-
-| Name                                                                      | MCU      | Radio  | WiFi | BT  | GPS |
-| :------------------------------------------------------------------------ | :------- | :----- | :--: | :-: | :-: |
-| [Seeed Wio-WM1110 Dev Kit](./seeed-studio/wm1110?wm1110=wio-sdk-wm1110)   | nRF52840 | LR1110 | YES  | 5.3 | YES |
-| [Seeed Wio Tracker 1110](./seeed-studio/wm1110?wm1110=wio-tracker-wm1110) | nRF52840 | LR1110 | YES  | 5.3 | YES |
-
 ## [Chatter](./chatter)
 
 DIY kit with ESP32, LoRa chip, and optional GPS. Designed for STEM education.


### PR DESCRIPTION
## What did you change
Removed a duplicate entry that is incorrectly placed under unPhone as discussed in [this](https://github.com/meshtastic/meshtastic/issues/1590) issue.

## Why did you change it
Improves the clarity of the documentation.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/3470b121-d650-4552-9b47-1106a1f2c792)

### After
![image](https://github.com/user-attachments/assets/d28649d5-c84d-49a5-98fb-58bc449bc022)

