### PR TITLE
Update harbor-breeze-solar-enclosure.mdx

### DIFF
--- a/docs/community/enclosures/rak/harbor-breeze-solar-enclosure.mdx
+++ b/docs/community/enclosures/rak/harbor-breeze-solar-enclosure.mdx
@@ -50,3 +50,5 @@ Here is a Lowes.com link to the solar light : (https://www.lowes.com/pd/60LM-Sol
 Here is a link to the Meshtastic Starter kit : (https://store.rakwireless.com/products/wisblock-meshtastic-starter-kit)
 
 Here is an amazon link to the sma and antennas (https://www.amazon.com/DIYmalls-915MHz)
+
+Here is a 3d printed base for wall mounting just the solar panel and its pivot on a wall without the light (designed by a fan of this project): https://www.thingiverse.com/thing:6839973


### PR DESCRIPTION
Adding a link to a 3d printed wall mount/base for the solar panel and radio

I designed this mount for the solar panel to allow it to be mounted to my chimney cap without the light or spike housing.  This really cleans up the mounting options.  The wall can be either 90 or 0 degrees, there is plenty of room for the antenna as presented on this page.  Just print the thing, and the panel fits right in just as it does on the lamp housing.