### PR TITLE
Mention device may be in dfu after full erase

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
@@ -16,7 +16,7 @@ import Link from "@docusaurus/Link";
 You may now use the [Meshtastic Web Flasher](https://flasher.meshtastic.org) to download and copy firmware to your nRF52 or RP2040-based devices. Alternatively, follow the instructions below to download and install firmware.
 :::
 
-If you have just performed a [Factory Erase](/docs/getting-started/flashing-firmware/nrf52/nrf52-erase/), your device may automatically startup in bootloader mode, and you may skip to "Copy the appropriate firmware..."
+If you have just performed a [Factory Erase](/docs/getting-started/flashing-firmware/nrf52/nrf52-erase/), your device may automatically startup in bootloader mode, and you may skip to "Copy the appropriate firmware..." for your respective device below:
 
 ### nRF52
 

--- a/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
@@ -16,6 +16,8 @@ import Link from "@docusaurus/Link";
 You may now use the [Meshtastic Web Flasher](https://flasher.meshtastic.org) to download and copy firmware to your nRF52 or RP2040-based devices. Alternatively, follow the instructions below to download and install firmware.
 :::
 
+If you have just performed a [Factory Erase](/docs/getting-started/flashing-firmware/nrf52/nrf52-erase/), your device may automatically startup in bootloader mode, and you may skip to "Copy the appropriate firmware..."
+
 ### nRF52
 
 1. Download and unzip the latest firmware from [Meshtastic Downloads](https://meshtastic.org/downloads).


### PR DESCRIPTION
This PR adds a note to the drag-n-drop firmware install page mentioning that your device may already be in DFU if you've just performed a factory erase.  This allows you to skip several steps.
