### PR TITLE
Add meshcn of China community to local groups list

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -96,6 +96,11 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 - [Mesht Saskatchewan](https://t.me/MeshtSaska)
 
+## China
+
+- [Meshtastic 中国社区](https://meshcn.net)
+
+
 ## Denmark
 
 - [Danske Meshtastic Brugere](https://discord.gg/EXWWwDmfBN)


### PR DESCRIPTION
This change will add the Chinese community to local groups list - `local-groups.mdx`. The URL of China's Meshtastic community is https://meshcn.net .

<!-- Add or remove sections as needed -->
## What did you change
- Add meshcn of China community to local groups list

## Why did you change it
- We just established the Chinese community in China. It has more than 40 people in less than two weeks. 
