### PR TITLE
Update remote-admin.mdx

### DIFF
--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -115,7 +115,6 @@ Legacy admin is enabled using the Legacy Admin channel option in [Security Confi
    meshtastic --set security.admin_key "PASTEPUBLICKEYHERE"
    ```
 6. You may add up to 3 Admin Keys, enabling control from up to 3 different nodes.
-7. Note: If you retrieve your Public Key via a mobile app or the web client, add `base64:` to the front of your key. It will look like this. `base64:PASTEPUBLICKEYHERE`
 
 #### Setting up Remote Admin Using the Legacy Method
 

--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -115,6 +115,7 @@ Legacy admin is enabled using the Legacy Admin channel option in [Security Confi
    meshtastic --set security.admin_key "PASTEPUBLICKEYHERE"
    ```
 6. You may add up to 3 Admin Keys, enabling control from up to 3 different nodes.
+7. Note: If you retrieve your Public Key via a mobile app or the web client, add `base64:` to the front of your key. It will look like this. `base64:PASTEPUBLICKEYHERE`
 
 #### Setting up Remote Admin Using the Legacy Method
 

--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -112,7 +112,7 @@ Legacy admin is enabled using the Legacy Admin channel option in [Security Confi
 4. Connect to the remote node via USB.
 5. Set the Admin Key on the remote node by running:
    ```bash
-   meshtastic --set security.admin_key "PASTEPUBLICKEYHERE"
+   meshtastic --set security.admin_key "base64:PASTEPUBLICKEYHERE"
    ```
 6. You may add up to 3 Admin Keys, enabling control from up to 3 different nodes.
 


### PR DESCRIPTION
Hello! 

I am proposing the modification to the documentation below. If a user has retrieved their public key to set as the admin key for their node via the web client or one of the mobile apps, it will not include `base64:` at the start of the public key, which appears to be a requirement to actually set it. 

In my experience, not including this leads to an error like is seen below, and some users may encounter problems if they simply try to use their public key as obtained via the apps as mentioned. 

Update CLI command notes to mention to append base64: to the front of the admin key if retrieved from something other than the CLI.

<!-- Add or remove sections as needed -->
## What did you change
I am proposing the modification to the documentation CLI instructions for setting the admin key. If a user has retrieved their public key to set as the admin key for their node via the web client or one of the mobile apps, it will not include `base64:` at the start of the public key, which appears to be a requirement to actually set it. 
<!-- Describe what your changes will do if merged -->
This will allow users to know that they need to typecast their public key to base64, which appears to be a requirement for the CLI. If following the instructions and ONLY using the CLI, the `base64:` will be prepended by default, but will (hopefully) prompt users to do so if not getting their key via the CLI.
## Why did you change it
This is based on my own testing and exploration of enabling remote administration on a node, where failure to prepend the snippet led to the following error below.

```
PS C:\Users\me> python -m meshtastic --set security.admin_key MYKEYWITHOUTPREPENDEDBASE64
Connected to radio
Adding 'MYKEYWITHOUTPREPENDEDBASE64' to the admin_key list
Aborting due to: expected bytes, str found
```

I'll try to update the screenshots below if I can get github to reflect my changes in my version of the repo. For some reason, it shows in this PR but not yet in my repo. Hmm...
## Screenshots
### Before
![image](https://github.com/user-attachments/assets/1f1c9c90-9909-4384-9ffc-5f0694e681b2)


### After
![image](https://github.com/user-attachments/assets/7a7528cd-bccb-41c0-97e0-3d5748685a8f)
