### PR TITLE
Update Apple OTA Firmware flashing instructions with recommended settings for the nRF DFU app to prevent update failures

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/ota.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/ota.mdx
@@ -45,6 +45,16 @@ OTA firmware updates are available for Android using an older release of the mor
 
 OTA firmware updates are available on iOS & iPadOS using the nRF Device Firmware Update App available through the [Apple App Store](https://apps.apple.com/us/app/nrf-device-firmware-update/id1624454660)
 
+:::caution
+
+To ensure successful OTA DFU firmware flashing on iOS, change the following settings in the nRF DFU App:
+- Packet receipt notification: On
+- Number of Packets: 10
+
+Failure to change these settings may cause the OTA firmware update to fail. Failure will result in the the Meshtastic firmware not booting and will require the firmware to be re-flashed via USB.
+
+:::
+
 1. Download the firmware release you wish to install from the [Meshtastic Download Page](/downloads), [Meshtastic GitHub](https://github.com/meshtastic/firmware/releases), or via the iOS or iPadOS app.
 2. Unzip the firmware folder
 3. Open the nRF DFU App and select the correct device firmware file (will end with -ota.zip)


### PR DESCRIPTION
Updated the Apple OTA Firmware flashing documentation to include a caution notice with instructions to change settings in the nRF Device Firmware Update app to prevent failure.

## What did you change
Modified the Apple section of the nRF52/RP2040 over-the-air Firmware update documentation to include a caution. This caution includes suggested settings to prevent firmware update failure when using the nRF Device Firmware Update app. It also mentions that re-flashing the firmware via USB will be required in case of a failed OTA flash.

## Why did you change it
I changed it because going on the roof is no fun.

