### PR TITLE
Suggest against SX1276 devices

### DIFF
--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -24,7 +24,7 @@ Please do your research and choose the board that meets your needs (or maybe alr
 
 :::info
 
-- The Semtech SX1262 transceiver is newer than the SX1276 and provides increased receive and transmit performance.
+- Devices using the previous-generation Semtech SX1276 are no longer recommended due to poor performance .
 - nRF52-based devices use a fraction of the power compared to ESP32-based devices and are therefore generally preferred for solar and handset applications.
 - ESP32-based devices require more power to operate but are typically lower-cost alternatives that do perform well when using house power, or for handsets that only require a day or two of runtime, and for applications that require WiFi connectivity.
 

--- a/docs/hardware/devices/index.mdx
+++ b/docs/hardware/devices/index.mdx
@@ -24,7 +24,7 @@ Please do your research and choose the board that meets your needs (or maybe alr
 
 :::info
 
-- Devices using the previous-generation Semtech SX1276 are no longer recommended due to poor performance .
+- Devices using the previous-generation Semtech SX1276 are no longer recommended due to their inferior performance.
 - nRF52-based devices use a fraction of the power compared to ESP32-based devices and are therefore generally preferred for solar and handset applications.
 - ESP32-based devices require more power to operate but are typically lower-cost alternatives that do perform well when using house power, or for handsets that only require a day or two of runtime, and for applications that require WiFi connectivity.
 


### PR DESCRIPTION
## What did you change

I updated the docs to make the wording firmer, clarifying that at this point Semtech SX1276 devices are a generation out of date.

## Why did you change it

I noticed that maintainers were actively advising people not to buy devices using SX1276, which prompted me to realize that the wording wasn't as direct as it should be on the docs.

## Screenshots
### Before


### After
