### PR TITLE
Remove Unused BaseCSS Bandaid

### DIFF
--- a/src/components/BaseCSS.tsx
+++ b/src/components/BaseCSS.tsx
@@ -1,7 +1,0 @@
-// class .markdown needs to be called or it is removed from the build
-
-const BaseCSS = () => {
-  return <div className="markdown">Shid Fard</div>;
-};
-
-export default BaseCSS;


### PR DESCRIPTION
I created this file to preserve some formatting that disappeared in a cleanup effort.  I have no idea why this worked in the first place, and it seems to no longer have any effect.