### PR TITLE
typo: correct `py -V`

### DIFF
--- a/docs/software/python-cli/installation.mdx
+++ b/docs/software/python-cli/installation.mdx
@@ -163,7 +163,7 @@ values={[
 - Check that your computer has Python 3 installed.
   - Use the command
     ```powershell
-    py -V
+    python -V
     ```
   - If this does not return a version, install [python](https://www.python.org)
 


### PR DESCRIPTION
## What did you change
correct `py -V` to `python -V` for Windows

## Why did you change it
`py -V` is meaningless