### PR TITLE
fix(docs): Correct rotary encoder event commands in Canned Message Module Documentation

### DIFF
--- a/docs/configuration/module/canned-message.mdx
+++ b/docs/configuration/module/canned-message.mdx
@@ -316,9 +316,9 @@ Replace each `GPIO` (x3) below with the GPIO numbers from your hardware setup.
 meshtastic --set canned_message.inputbroker_pin_a GPIO
 meshtastic --set canned_message.inputbroker_pin_b GPIO
 meshtastic --set canned_message.inputbroker_pin_press GPIO
-meshtastic --set canned_message.inputbroker_event_cw KEY_UP
-meshtastic --set canned_message.inputbroker_event_ccw KEY_DOWN
-meshtastic --set canned_message.inputbroker_event_press KEY_SELECT
+meshtastic --set canned_message.inputbroker_event_cw UP
+meshtastic --set canned_message.inputbroker_event_ccw DOWN
+meshtastic --set canned_message.inputbroker_event_press SELECT
 meshtastic --set canned_message.rotary1_enabled True
 ```
 

--- a/docs/configuration/module/canned-message.mdx
+++ b/docs/configuration/module/canned-message.mdx
@@ -192,17 +192,17 @@ meshtastic --set canned_message.inputbroker_pin_press 0
 ```
 
 ```shell title="Set/Unset Input Broker CW Event"
-meshtastic --set canned_message.inputbroker_event_cw KEY_UP
+meshtastic --set canned_message.inputbroker_event_cw UP
 meshtastic --set canned_message.inputbroker_event_cw ""
 ```
 
 ```shell title="Set/Unset Input Broker CCW Event"
-meshtastic --set canned_message.inputbroker_event_ccw KEY_DOWN
+meshtastic --set canned_message.inputbroker_event_ccw DOWN
 meshtastic --set canned_message.inputbroker_event_ccw ""
 ```
 
 ```shell title="Set/Unset Input Broker Press Event"
-meshtastic --set canned_message.inputbroker_event_press KEY_SELECT
+meshtastic --set canned_message.inputbroker_event_press SELECT
 meshtastic --set canned_message.inputbroker_event_press ""
 ```
 


### PR DESCRIPTION
This pull request fixes an issue in the Canned Message Module documentation where incorrect example commands were provided for configuring rotary encoder events. Specifically, the values `KEY_UP`, `KEY_DOWN`, and `KEY_SELECT` were mistakenly used in the example commands instead of the correct enum values: `UP`, `DOWN`, and `SELECT`.  

### Changes Made:
- Replaced all instances of `KEY_UP`, `KEY_DOWN`, and `KEY_SELECT` with the correct enums `UP`, `DOWN`, and `SELECT` in the example command section.

### Why This Fix is Needed:

Using incorrect values such as `KEY_UP` results in errors like:

```shell
canned_message.inputbroker_event_cw does not have an enum called KEY_UP, so you can not set it.
Choices in sorted order are:
    BACK
    CANCEL
    DOWN
    LEFT
    NONE
    RIGHT
    SELECT
    UP
LocalConfig and LocalModuleConfig do not have attribute canned_message.inputbroker_event_cw.
```
