### PR TITLE
Update index.mdx to reflect removal of support

### DIFF
--- a/docs/hardware/devices/heltec-automation/sensor/index.mdx
+++ b/docs/hardware/devices/heltec-automation/sensor/index.mdx
@@ -19,6 +19,10 @@ values={[
 
 ## Heltec Capsule Sensor Rev. 3.0
 
+:::info
+https://github.com/meshtastic/firmware/releases/tag/v2.5.15.79da236 removed support for the Heltec Wireless Capsule Sensor V3.
+:::
+
 - **MCU:**
   - ESP32-S3FN8 (WiFi & Bluetooth)
 - **LoRa Transceiver:**


### PR DESCRIPTION
Include info that 2.5.15.79da236 Beta removed support for these units in https://github.com/meshtastic/firmware/pull/5436 .

## What did you change
Add information at top of page noting removal of support.

## Why did you change it
https://github.com/meshtastic/firmware/pull/5436 included in release https://github.com/meshtastic/firmware/releases/tag/v2.5.15.79da236 has removed the wireless capsule support, but appears documentation has not been updated to warn people off purchasing unsupported units.