### PR TITLE
Fix typo in example node unique_id

### DIFF
--- a/docs/software/integrations/mqtt/home-assistant.mdx
+++ b/docs/software/integrations/mqtt/home-assistant.mdx
@@ -43,7 +43,7 @@ sensor:
 # Node #1 
 
   - name: "Node 1 Battery Voltage"
-    unique_id: "node_1__battery_voltage"
+    unique_id: "node_1_battery_voltage"
     state_topic: "msh/US/2/json/LongFast/!67ea9400"
     state_class: measurement
     value_template: >-


### PR DESCRIPTION
## What did you change

Typo in documentation.