### PR TITLE
Adding a 50 byte warning  the SX1262

### DIFF
--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -23,7 +23,8 @@ Before proceeding with the setup, ensure the device meets the following requirem
 ### Hardware Compatibility
 
 :::caution Warning
-UART HATs and SX1302/SX1303 chip-based HATs are not supported. Only hats that use a SPI radio can work with Meshtastic.
+- UART HATs and SX1302/SX1303 chip-based HATs are not supported. Only hats that use a SPI radio can work with Meshtastic.
+- Waveshare SX1262 LoRaWAN Node Module Expansion Board for Raspberry Pi has partial support in Meshtastic. While it can receive messages and monitor the mesh network, sending messages is currently limited to a maximum of 50 bytes(characters) due to hardware constraints. Please note that the user interface does not enforce this limit, so users should be mindful of it when composing messages. 
 :::
 
 - Tested radios include the Waveshare SX126X (SPI version), Adafruit RFM9x, and Elecrow Lora RFM95 IOT.


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
I added a warning about the SX1262 to the Linux Devices docs. 
<!-- Describe what your changes will do if merged -->
Adds a line item in the Linux Devices documentation  warning regarding the SX1262.

## Why did you change it
I did some more testing using my local Raspberry Pi Zero W and found that I could successfully send 50 bytes (chars) to my other nodes. This was not documented so I went ahead and did it.

## Screenshots
https://meshtastic-716k6ztk1-phils-projects-7050c4fc.vercel.app/docs/hardware/devices/linux-native-hardware/

### Before
![Screenshot 2024-12-20 at 6 13 54 AM](https://github.com/user-attachments/assets/f104b9a1-ecb9-4fdb-9725-c7793e424883)


### After
![Screenshot 2024-12-20 at 6 14 19 AM](https://github.com/user-attachments/assets/03b07465-8955-40fb-a3be-bf8a70f4a5be)
