### PR TITLE
Add Libraries to Linux Native

### DIFF
--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -40,7 +40,7 @@ UART HATs and SX1302/SX1303 chip-based HATs are not supported. Only hats that us
 - Necessary system libraries should be installed before building or installing Meshtastic.
 
 ```shell
-sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev
+sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev
 ```
 - And optionally for web server support
 ```shell


### PR DESCRIPTION
Added `libusb-1.0-0-dev` & `libi2c-dev` to recommended library install.
based on https://github.com/meshtastic/firmware/blob/175ff218f1e8830b501dab26f8f2aa9e40d55051/.github/workflows/build_native.yml#L17