### PR TITLE
Add required library install to Native Software Install

### DIFF
--- a/docs/blocks/_native-libraries.mdx
+++ b/docs/blocks/_native-libraries.mdx
@@ -1,0 +1,9 @@
+- Necessary system libraries should be installed before building or installing Meshtasticd.
+
+```shell
+sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev
+```
+- And optionally for web server support
+```shell
+sudo apt install openssl libssl-dev libulfius-dev liborcania-dev
+```

--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -6,6 +6,8 @@ sidebar_position: 11
 description: Set up and configure Meshtastic on Linux-native devices using the meshtasticd binary.
 ---
 
+import NativeLibraries from "@site/docs/blocks/_native-libraries.mdx";
+
 This page outlines the setup of Meshtastic on Linux-native devices, utilizing portduino to run the Meshtastic firmware under Linux.
 
 ## Prerequisites and Hardware Compatibility
@@ -37,15 +39,7 @@ UART HATs and SX1302/SX1303 chip-based HATs are not supported. Only hats that us
 
 ### Installing Meshtasticd
 
-- Necessary system libraries should be installed before building or installing Meshtastic.
-
-```shell
-sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev
-```
-- And optionally for web server support
-```shell
-sudo apt install openssl libssl-dev libulfius-dev liborcania-dev
-```
+<NativeLibraries />
 
 - The .deb Package is available as [part of the release](https://github.com/meshtastic/firmware/releases/latest), installing the binary, a systemd service, and a config file. It is compiled for Debian Bookworm and incompatible with Bullseye.
 ```shell

--- a/docs/software/linux-native.mdx
+++ b/docs/software/linux-native.mdx
@@ -5,6 +5,8 @@ sidebar_label: Linux Native
 sidebar_position: 5
 ---
 
+import NativeLibraries from "@site/docs/blocks/_native-libraries.mdx";
+
 The device software can also run on a native Linux machine thanks to the [Portduino framework](https://github.com/geeksville/framework-portduino).
 
 The application either simulates some of the interfaces, or uses the real hardware of your machine.
@@ -16,6 +18,8 @@ For instructions on how to use it, see the [interactive simulator](https://githu
 
 The easiest way of building the native application is using Visual Studio Code with the PlatformIO extension.
 See the instructions for creating such a building environment [here](/docs/development/firmware/build).
+
+<NativeLibraries />
 
 Then after opening the firmware repository in Visual Studio Code, simply click on the PlatformIO extension in the left bar, select native and click on 'Build'.
 This will generate the binary file 'program' which you can find in `.pio/build/native/`.


### PR DESCRIPTION
This PR
- Adds the required libraries installation instructions to the Linux Native Application install under software.
- These instructions are copied from the Meshtasticd install instructions under hardware.
- Since the instructions are the same, I've created a reusable block to include on both pages.

Previews:
[Hardware - Linux Native](https://sandbox-git-native-prereq-block-pdxlocs-projects.vercel.app/docs/hardware/devices/linux-native-hardware/#installation)
[Software - Linux Native](https://sandbox-git-native-prereq-block-pdxlocs-projects.vercel.app/docs/software/linux-native/#usage-with-a-linux-machine)