### PR TITLE
Add Central Ohio Mesh to Local Groups Page.

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -259,6 +259,7 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 - [Cincy Mesh](https://www.cincymesh.org)
 - [Dayton Mesh](https://daytonmesh.org/)
+- [Central Ohio Mesh](https://meshcolumb.us/)
 
 ### Oklahoma
 


### PR DESCRIPTION
## What did you change
Update local-groups.mdx. Adds a link to the Central Ohio Mesh community group site at meshcolumb.us.

## Why did you change it
Improves discoverability of the Columbus area LUG.