### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -279,7 +279,7 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 - [Austin Mesh](https://austinmesh.org/)
 - [Cypress, Texas Meshtastic Club](https://discord.gg/KzuwNRwE6q)
-- [DFW / North Texas Mesh](https://discord.gg/jyzYRTtyMD)
+- [DFW / North Texas Mesh](https://ntxmesh.net)
 
 ### Virginia
 


### PR DESCRIPTION

## What did you change

Changed NTX Mesh community link from discord invite to community website.

## Why did you change it
To better communicate our resource as a community, while providing discord invite from the community website instead.

## Screenshots
### Before


### After
