### PR TITLE
Add `mtnme.sh` to local groups.

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -192,6 +192,7 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 ## United States
 
 - [Midwest Mesh](https://discord.gg/wYwD56K439)
+- [Mountain Mesh (North GA / East TN)](https://mtnme.sh)
 
 ### Arizona
 


### PR DESCRIPTION
Adds [MtnMe.sh](https://mtnme.sh) group.

Attributed to the "United States" section because we cover North GA and East TN.