### PR TITLE
Remove Incorrect Apple PKC Admin Step?

### DIFF
--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -74,13 +74,12 @@ Legacy admin is enabled using the Legacy Admin channel option in [Security Confi
 #### Setting up Remote Admin Using the PKC Method
 
 1. Connect to the node that will be used to administer the remote node.
-2. Go to Settings > App Settings on this node and enable **Administration**.
+2. Go to **Settings > App Settings** on this node and enable **Administration**.
 3. Navigate to **Settings > Radio Configuration > [Security](/docs/configuration/radio/security/#public-key)** to find its public key.
 4. Copy the public key to use for configuring the remote node.
 5. Connect to the remote node.
 6. In **Settings > Radio Configuration > Security**, add the public key of the local node as an Admin Key.
 7. Up to 3 Admin Keys may be supplied, allowing up to 3 controlling nodes.
-8. On the remote node, go to **Settings > App Settings** and enable **Administration**.
 
 #### Setting up Remote Admin using the Legacy method
 


### PR DESCRIPTION
This PR removes the instruction #8 on https://meshtastic.org/docs/configuration/remote-admin/#apple:
`On the remote node, got to Settings > App Settings and enable Administration.`

I believe this setting is client-side only and this step doesn't do anything.

![image](https://github.com/user-attachments/assets/962c0401-2e18-49c8-aad2-8011df66cbc0)