### PR TITLE
Clarify HA Send Message Instructions

### DIFF
--- a/docs/software/integrations/mqtt/home-assistant.mdx
+++ b/docs/software/integrations/mqtt/home-assistant.mdx
@@ -321,7 +321,11 @@ First, create an input text helper entity. The preferred way to configure an inp
 
 ### Create a Send Message Automation
 
-This automation will check the send box for changes.  After typing a message, either hit enter or click off the box and the automation will send a text string in JSON to the mqtt broker. Make sure to publish to a channel called "mqtt" and to update the device ID and `from` field in the example below. A field `channel` can be added to transmit on a different channel index than the primary, or a `to` field can be added with a node number to send a DM.
+This automation will check the send box for changes.  After typing a message, either hit enter or click off the box and the automation will send a text string in JSON to the mqtt broker.
+
+To make this work, ensure that your node has a Meshtastic channel configured called "mqtt" with downlink enabled. The PSK doesn't matter. This channel allows the node to listen to messages on the msh/US/2/json/mqtt/ topic.
+
+Now make sure to publish to the same "mqtt" topic and to update the device ID and `from` field in the example below. A field `channel` can be added to transmit on a different channel index than the primary, or a `to` field can be added with a node number to send a DM.
 
 ```yaml
 - alias: Meshtastic - Send Automation


### PR DESCRIPTION
When injecting json from Home Assistant you must have a channel called MQTT.  While this is [documented on another page](https://meshtastic.org/docs/software/integrations/mqtt/#json-downlink-to-instruct-a-node-to-send-a-message), this detail could easily be missed when following the HA Integration instructions.

This PR adds this information to the "create a send box entity" instructions.