### PR TITLE
Remove pages and json strings from crowdin translation

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,11 +4,11 @@ preserve_hierarchy: true
 "base_url": "https://meshtastic.crowdin.com"
 files:
   # JSON translation files
-  - source: /i18n/en/**/*
-    translation: /i18n/%two_letters_code%/**/%original_file_name%
+  # - source: /i18n/en/**/*
+  #  translation: /i18n/%two_letters_code%/**/%original_file_name%
   # Docs Markdown files
   - source: /docs/**/*
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
   # Pages Markdown files
-  - source: /pages/**/*
-    translation: /i18n/%two_letters_code%/docusaurus-plugin-content-pages/**/%original_file_name%
+  # - source: /pages/**/*
+  #  translation: /i18n/%two_letters_code%/docusaurus-plugin-content-pages/**/%original_file_name%


### PR DESCRIPTION
We're currently focusing on documentation and have not enabled translation of website pages and jsons string. Remove these so that the job doesn't report errors.