### PR TITLE
Only build en locale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         run: pnpm install
 
       - name: Build Package
-        run: pnpm run build
+        run: pnpm run build --locale en


### PR DESCRIPTION
We don't currently have content for other locales we are translating, so let's speed up the build process by only building en.