### PR TITLE
Update Local Groups

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -277,7 +277,6 @@ us on [Discord](https://discord.com/invite/ktMAKGBnBs) to add your group.
 
 - [Cincy Mesh](https://www.cincymesh.org)
 - [Dayton Mesh](https://daytonmesh.org/)
-- [Central Ohio (Columbus Metro Area) Mesh](https://meshcolumb.us/)
 
 ### Oklahoma
 


### PR DESCRIPTION
Removes Central Ohio Mesh -- Logo being used is not in compliance with https://meshtastic.org/docs/legal/licensing-and-trademark/#social-media Group has been contacted, link can be re-added once in compliance. 
