### PR TITLE
Update position.mdx: position.gps_mode capitalization

### DIFF
--- a/docs/configuration/radio/position.mdx
+++ b/docs/configuration/radio/position.mdx
@@ -19,9 +19,9 @@ The position config uses an admin message to send a `Config.Position` protobuf. 
 
 Configures whether the GPS functionality is enabled, disabled, or not present on the node.
 
-Acceptable values: `Disabled`, `Enabled`, and `Not_Present`.
+Acceptable values: `DISABLED`, `ENABLED`, and `NOT_PRESENT`.
 
-Generally, depending on the device and its configuration, this value will default to either `Enabled` or `Not Present`.
+Generally, depending on the device and its configuration, this value will default to either `ENABLED` or `NOT_PRESENT`.
 
 ### GPS Update Interval
 
@@ -163,7 +163,7 @@ All Position config commands are available in the python CLI. Example commands a
 
 |                    Setting                     |                                                             Acceptable Values                                                             |           Default            |
 | :--------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------: |
-|               position.gps_mode                |                                                   `enabled`, `disabled`, `not_present`                                                    |  `Enabled` or `Not Present`  |
+|               position.gps_mode                |                                                   `ENABLED`, `DISABLED`, `NOT_PRESENT`                                                    |  `ENABLED` or `NOT_PRESENT`  |
 |          position.gps_update_interval          |                                                            `integer` (seconds)                                                            |   Default `0` is 2 Minutes   |
 |            position.fixed_position             |                                                              `true`, `false`                                                              |           `false`            |
 |   position.position_broadcast_smart_enabled    |                                                              `true`, `false`                                                              |            `true`            |


### PR DESCRIPTION
## What did you change

Update position.mdx: position.gps_mode parameters to be in all caps.

## Why did you change it

Meshtastic Python CLI only accepts case-sensitive arguments for position.gps_mode and they must be in all caps, or it will refuse the setting with "position.gps_mode does not have an enum called not_present, so you can not set it."

## Screenshots

N/A, refer to text diff.