### PR TITLE
Correct fixed_pin setting name

### DIFF
--- a/docs/configuration/radio/bluetooth.mdx
+++ b/docs/configuration/radio/bluetooth.mdx
@@ -123,7 +123,7 @@ All Bluetooth config options are available in the python CLI. Example commands a
 | :------------------: | :---------------------------------: | :----------: |
 | `bluetooth.enabled`  |           `true`, `false`           |    `true`    |
 |   `bluetooth.mode`   | `RANDOM_PIN`, `FIXED_PIN`, `NO_PIN` | `RANDOM_PIN` |
-| `bluetooth.fixedPin` |        `integer` (6 digits)         |   `123456`   |
+| `bluetooth.fixed_pin` |        `integer` (6 digits)         |   `123456`   |
 
 :::tip
 


### PR DESCRIPTION
Table of values shows fixedPin instead of actual fixed_pin.

<!-- Add or remove sections as needed -->
## CLI setting table
<!-- Describe what your changes will do if merged -->

## Why did you change it
Setting name for CLI value was incorrect.  The rest of the document correctly used "fixed_pin" while this used the incorrect "fixedPin".

