### PR TITLE
Update linux-native-hardware.mdx

### DIFF
--- a/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
+++ b/docs/hardware/devices/linux-native-hardware/linux-native-hardware.mdx
@@ -33,7 +33,7 @@ Before proceeding with the setup, ensure the device meets the following requirem
 
 #### SPI
 
-- Raspberry Pi: Zero, Zero 2, 3, 4, Pi 400, and Pi 5 on Raspbian `bookworm`.
+- Raspberry Pi: Zero 2, 3, 4, Pi 400, and Pi 5 on Raspbian `bookworm`.
 - Luckfox Pico: [femtofox](https://github.com/noon92/femtofox/tree/main) on Ubuntu 22.04 `jammy`.
 
 #### USB (CH341)


### PR DESCRIPTION
Update pi compatibility list.


## What did you change
Removed Pi Zero from compatibility list.

## Why did you change it
The new installation instructions and repo are incompatible with the cpu architecture of the pi 1/zero/zero w and will lead to a a segfault if attempted.
