### PR TITLE
Update telemetry.mdx

### DIFF
--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -43,6 +43,7 @@ Supported sensors connected to the I2C bus of the device will be automatically d
 | DFROBOT_LARK |          0x42          | Temperature, barometric pressure, humidity, wind direction, wind speed |
 |   MAX30102   |          0x57          |          Heart Rate, Oxygen Saturation, and body temperature           |
 |   MLX90614   |          0x5A          |                            Body temperature                            |
+|   NAU7802    |          0x2A          |               24-Bit differential ADC for Wheatstone bridge            |
 
 ## Module Config Values
 


### PR DESCRIPTION
Added line for NAU7802 Wheatstone bridge sensor

## What did you change
I added a line in the table for NAU7802 - Wheatstone bridge sensor

## Why did you change it
It was missing but supported in firmware.
