### PR TITLE
Adding Iowa Mesh

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -261,6 +261,10 @@ To be listed here, your group must be in compliance with our [Trademark Guidline
 
 - [Chicagoland Mesh](https://chicagolandmesh.org)
 
+### Iowa
+
+- [Iowa Mesh](https://iowamesh.org)
+
 ### Kansas
 
 - [SecKC Amateur Radio Club of Kansas City and Surrounding Cities for Amateur Radio](https://ks3ckc.radio/home)


### PR DESCRIPTION
## What did you change
- Added Iowa section to local-groups.md
- Added Iowa Mesh link to the Iowa section

## Why did you change it
- To connect Meshtastic users in Iowa and participate in the Iowa community mesh.