### PR TITLE
Update mac cli install to use pipx

### DIFF
--- a/docs/software/python-cli/installation.mdx
+++ b/docs/software/python-cli/installation.mdx
@@ -172,13 +172,15 @@ To install the Meshtastic CLI, select the tab for your operating system and foll
     ```
   - If this does not return a version, install [pip](https://pip.pypa.io/en/stable/installing)
 
-- Install pytap2
+- Install pipx
   ```shell
-  sudo pip3 install --upgrade pytap2
+  brew install pipx
+  pipx ensurepath
   ```
+
 - Install meshtastic:
   ```shell
-  sudo pip3 install --upgrade "meshtastic[cli]"
+  pipx install "meshtastic[cli]"
   ```
   (the `[cli]` suffix installs a few optional dependencies that match older versions of the CLI)
 


### PR DESCRIPTION
This PR updates the mac os CLI installation instructions to use pipx
## Screenshots
### Before

<img width="741" alt="Screenshot 2025-03-14 at 7 39 06 PM" src="https://github.com/user-attachments/assets/1753d356-88df-4e43-bb51-a73efad0f36d" />

### After
<img width="739" alt="Screenshot 2025-03-14 at 7 38 48 PM" src="https://github.com/user-attachments/assets/5d834309-0565-4fc3-a3ea-a5ee8345850c" />
