### PR TITLE
Add how to include the web client when flashing from VSCode

### DIFF
--- a/docs/development/firmware/building.mdx
+++ b/docs/development/firmware/building.mdx
@@ -47,7 +47,7 @@ Meshtastic uses [PlatformIO](https://platformio.org), a development environment 
 
 1. Navigate to the [web client releases GitHub page](https://github.com/meshtastic/web/releases) and download the latest `build.tar` into your firmware folder.
 2. Extract the files with `tar -xf build.tar -C data/static`
-3. You man remove the tar file with `rm build.tar`
+3. You may remove the tar file with `rm build.tar`
 4. From the PlatformIO Window in VSCode choose:
    - Project Tasks: Platform -> Erase Flash
    - Project Tasks: General -> Upload

--- a/docs/development/firmware/building.mdx
+++ b/docs/development/firmware/building.mdx
@@ -43,6 +43,16 @@ Meshtastic uses [PlatformIO](https://platformio.org), a development environment 
 4. To build the firmware, simply run `PlatformIO: Build` from your command palette.
 5. Finally, flash the firmware to your device by running `PlatformIO: Upload`
 
+## Build and Upload with Web Client
+
+1. Navigate to the [web client releases GitHub page](https://github.com/meshtastic/web/releases) and download the latest `build.tar` into your firmware folder.
+2. Extract the files with `tar -xf build.tar -C data`
+3. You man remove the tar file with `rm build.tar`
+4. From the PlatformIO Window in VSCode choose:
+   - Project Tasks: Platform -> Erase Flash
+   - Project Tasks: General -> Upload
+   - Project Tasks: Platform -> Upload Filesystem Image
+
 ## Adding Custom Hardware
 
 The build system is modular. Adding a new board variant for an already supported architecture is straightforward.

--- a/docs/development/firmware/building.mdx
+++ b/docs/development/firmware/building.mdx
@@ -46,7 +46,7 @@ Meshtastic uses [PlatformIO](https://platformio.org), a development environment 
 ## Build and Upload with Web Client
 
 1. Navigate to the [web client releases GitHub page](https://github.com/meshtastic/web/releases) and download the latest `build.tar` into your firmware folder.
-2. Extract the files with `tar -xf build.tar -C data`
+2. Extract the files with `tar -xf build.tar -C data/static`
 3. You man remove the tar file with `rm build.tar`
 4. From the PlatformIO Window in VSCode choose:
    - Project Tasks: Platform -> Erase Flash


### PR DESCRIPTION
This PR adds instructions on how to include the web client when flashing custom firmware from VSCode.
