### PR TITLE
Note how to install the web client via CLI

### DIFF
--- a/docs/getting-started/flashing-firmware/esp32/cli-script.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/cli-script.mdx
@@ -348,6 +348,8 @@ device-update.bat -f firmware-BOARD-VERSION-update.bin
   </TabItem>
 </Tabs>
 
+To also install an on-device copy of the [Web Client](/docs/software/web-client/), include the `--web` option in the command.
+
 ## Connect and Configure Device
 
 After flashing the Meshtastic firmware to the device, you can proceed with the initial configuration.


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->

I added some documentation for flashing the web client via CLI.

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->

I tried to install the web client on my device with `./device-install.sh -f littlefswebui-2.5.20.4c97351.bin`, which is very wrong but attempts to work anyway.

Also, if you're not using Google Chrome, you won't have the web flasher available with the checkbox to install the web UI, and you also probably want the web UI hosted off the device, since you won't have anything but the network method of talking to the device from a browser, and connecting the cloud-hosted web UI to the device over the network at a different origin requires a special SSL certificate acceptance dance. So anyone not on Chrome is going to be using the CLI flasher *and* probably will want the on-device web UI.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/9ecd19c2-6114-4ec8-a59f-4eb2b7108160)


### After
![image](https://github.com/user-attachments/assets/64bde256-1d19-447e-ad33-60d1bcd52d3a)

