### PR TITLE
Center images within markdown content

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -272,4 +272,5 @@ p {
 
 .markdown img {
   margin-bottom: 0;
+  display: block;
 }


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
1. Set `.markdown img` (all images inside of markdown files` to `block` display. By default, images are inline-block meaning they cannot take advantage of `margin: auto`

## Why did you change it
1. We want to begin centering all images within the markdown content. [See conversation ](https://github.com/meshtastic/meshtastic/pull/1752#discussion_r1996944827)

## Screenshots
### Before

<img width="880" alt="Screenshot 2025-03-17 at 9 44 47 PM" src="https://github.com/user-attachments/assets/e489612c-97ed-4a75-b81c-1516a857e730" />

### After
<img width="899" alt="Screenshot 2025-03-17 at 9 44 34 PM" src="https://github.com/user-attachments/assets/15adfab4-2501-4fe5-ac16-a27de2d2068a" />

