### PR TITLE
meshtasticd: Add libuv to build guide

### DIFF
--- a/docs/blocks/_native-libraries.mdx
+++ b/docs/blocks/_native-libraries.mdx
@@ -7,7 +7,7 @@ The following libraries must be installed before building `meshtasticd`:
   <TabItem value="debian" label={<><Icon icon="mdi:debian" style={{ marginRight: "0.25rem" }} height="1.5rem" /> Debian</>} default>
   ```shell
   # Base dependencies
-  sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev
+  sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev libuv1-dev
   # Optional dependencies for web server support
   sudo apt install openssl libssl-dev libulfius-dev liborcania-dev
   ```
@@ -18,7 +18,7 @@ The following libraries must be installed before building `meshtasticd`:
   # Enable the Meshtastic build tools COPR repository
   sudo dnf copr enable @meshtastic/build-tools
   # Base dependencies
-  sudo dnf install gcc-c++ pkgconfig(yaml-cpp) pkgconfig(libgpiod) pkgconfig(bluez) pkgconfig(libusb-1.0) libi2c-devel
+  sudo dnf install gcc-c++ pkgconfig(yaml-cpp) pkgconfig(libgpiod) pkgconfig(bluez) pkgconfig(libusb-1.0) libi2c-devel pkgconfig(libuv)
   # Optional dependencies for web server support
   sudo dnf install pkgconfig(openssl) pkgconfig(liborcania) pkgconfig(libyder) pkgconfig(libulfius)
   ```


### PR DESCRIPTION
Adds `libuv` to the Linux building guide per https://github.com/meshtastic/firmware/pull/6342