### PR TITLE
Add description of how Presets map to meshes

### DIFF
--- a/docs/about/overview/index.mdx
+++ b/docs/about/overview/index.mdx
@@ -15,3 +15,14 @@ When a receiving radio captures a packet, it checks to see if it has heard that 
 For each message a radio rebroadcasts, it marks the "hop limit" down by one. When a radio receives a packet with a hop limit of zero, it will not rebroadcast the message.
 
 The radio will store a small amount of packets (around 30) in its memory for when it's not connected to a client app. If it's full, it will replace the oldest packets with newly incoming text messages only.
+
+## What is a mesh?
+
+At the radio level a Meshtastic mesh is a set of nodes that share the same LoRa spreading factor, center frequency, and bandwidth. A node can only be in one radio mesh; it will not see or respond to messages from nodes using different values for these settings. For a mesh to form, nodes need to share the same values. 
+
+These values are grouped into "presets" that can be easily chosen in the LoRa configuration section. Presets make it easy for nodes to configure the same radio parameters.
+
+Sitting on top of this radio mesh are Channels. A logical mesh is formed by a Channel with a particular name and encryption key. The default channel in a radio mesh is Channel 0 with a blank "name" and an ecryption key of AQ==. 
+
+Nodes can belong to many Channels in their radio mesh. You can even create your own Channel for use by your group of friends. Only nodes that have configured a Channel with the same Channel name and encryption key will be able to read and display the messages on that Channel. However, all nodes in the radio mesh will receive and retransmit messages (depending on their Role) without regard to the Channel settings for the message.
+

--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -71,7 +71,7 @@ Maximum number of hops. This can't be greater than 7. Default is 3 which should 
 
 If zero, then use default max legal continuous power (i.e. something that won't burn out the radio hardware)
 
-In most cases you should use zero here. Units are in dBm.
+In most cases you should use zero here. (In Apple apps the value shown is the dBm. Larger is better.) Units are in dBm.
 
 ### Bandwidth
 


### PR DESCRIPTION
## What did you change
Added a section to describe how radio presets actually define the mesh.

## Why did you change it
There was discussion on Discord in #docs where some people misunderstood the concept. They thought nodes using different Presets could forward messages for each other; they cannot. After a bit of discussion, someone suggested adding this to the docs, so I did. 

I considered adding this to the Radio page, but it seemed more logical to add it to Overview because the discussion also mentions Channels.
