### PR TITLE
Update key restore command

### DIFF
--- a/docs/configuration/radio/security.mdx
+++ b/docs/configuration/radio/security.mdx
@@ -173,5 +173,5 @@ Suggested backup methods:
 
 To restore your keys you may:
 
-1.  Use the Meshtastic CLI to run `meshtastic --config config_backup.yaml` - This is the fastest way to get your entire node back to where you left it!
+1.  Use the Meshtastic CLI to run `meshtastic --configure config_backup.yaml` - This is the fastest way to get your entire node back to where you left it!
 2.  Manually paste or retype the keys into the client app from your saved location.


### PR DESCRIPTION
Changed --config to --configure to match python module help text.  This matches the current 2.6.0 python module.

![image](https://github.com/user-attachments/assets/53188e23-bb6e-4f29-ba9c-49bcf4a95171)
