### PR TITLE
Update tips.mdx

### DIFF
--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -59,7 +59,7 @@ Alternatively, if you wish to only share your location with trusted parties, you
 
 1. Ensure you have not changed the LoRa [Modem Preset](/docs/configuration/radio/lora#modem-preset) from the default `unset` / `LONG_FAST`.
 2. On your PRIMARY channel, set anything you'd like for the channel's name and choose a random PSK.
-3. Enable a SECONDARY channel named "LongFast" with PSK "AQ==".
+3. Enable a SECONDARY channel with an empty name with the Meshtastic default PSK "AQ==".  Note:  Older versions of Meshtastic used the channel name: "LongFast".
 4. If your LoRa frequency slot is set to the default (`0`), the radio's transmit frequency will be automatically changed based on your PRIMARY channel's name. In this case, you will have to manually set it back to your region's default (in LoRa settings) in order to interface with users on the default slot:
 
 ### Default Primary Frequency Slots by Region
@@ -68,7 +68,7 @@ Alternatively, if you wish to only share your location with trusted parties, you
 | :-: | :----: | :----: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :----: | :-: | :----: | :----: | :----: | :----: | :----: | :-----: |
 | 20  |   4    |   1    | 36  | 20  | 20  | 12  | 16  |  2  |  4  |   4    | 16  |   6    |   2    |   4    |   16   |   4    |    6    |
 
-To quickly test this configuration, find and scan your region's QR from [this repository](https://github.com/meshtastic/meshtastic/tree/master/static/img/configuration/qr-private-primary-example/). Remember to generate a new PSK for your private channel before sharing with your trusted nodes.
+To quickly test this configuration, find and scan your region's QR from [this repository](https://github.com/meshtastic/meshtastic/tree/master/static/img/configuration/qr-private-primary-example/).  The channel configuration will create a private primary channel, a default Meshtastic secondary channel & set the radio frequency to the specific region. Remember to generate a new PSK for your private channel (and name if desired) before sharing with your trusted nodes.
 
 ## Rebroadcast "Public" Traffic
 


### PR DESCRIPTION
## What did you change
Updated the documentation to match the current Meshtastic behavior where the name of the secondary default channel should be empty.  Added descriptive behavior for the QR code examples that create the private primary channel and secondary default channel.

## Why did you change it
New to Meshtastic and was trying to follow the instructions but it wasn't working for me.  When using the QR code, the secondary channel name was empty.

## Screenshots
### Before


### After
