### PR TITLE
Add SouthCoast Mesh to Local Groups -> United States -> Massachusetts

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -278,6 +278,7 @@ To be listed here, your group must be in compliance with our [Trademark Guidline
 ### Massachusetts
 
 - [Boston Meshnet](https://github.com/Darachnid/Boston-Meshnet)
+- [SouthCoast Mesh](https://southcoastmesh.com)
 
 ### Michigan
 


### PR DESCRIPTION
## What did you change

Adds our local user group to the local groups page.

## Why did you change it
We changed it because we wanted to appear in the official list of groups
