### PR TITLE
Fix FreqSlot Calc

### DIFF
--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -1,4 +1,4 @@
-import { Protobuf, Types } from "@meshtastic/js";
+import { Protobuf, type Types } from "@meshtastic/js";
 import { useEffect, useState } from "react";
 
 interface Region {
@@ -279,23 +279,32 @@ const modemPresets = new Map<
       sf: 12,
     },
   ],
-  [
-    Protobuf.Config.Config_LoRaConfig_ModemPreset.VERY_LONG_SLOW,
-    {
-      bw: 62.5,
-      cr: 8,
-      sf: 12,
-    },
-  ],
 ]);
 
-// Helper function to format the channel name (e.g., LONG_FAST -> LongFast)
-const formatChannelName = (name: string): string => {
-  return name
-    .toLowerCase()
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join("");
+// Helper function to get the formatted channel name based on the modem preset
+const getChannelName = (
+  preset: Protobuf.Config.Config_LoRaConfig_ModemPreset,
+): string => {
+  switch (preset) {
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.SHORT_TURBO:
+      return "ShortTurbo";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.SHORT_SLOW:
+      return "ShortSlow";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.SHORT_FAST:
+      return "ShortFast";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.MEDIUM_SLOW:
+      return "MediumSlow";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.MEDIUM_FAST:
+      return "MediumFast";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.LONG_SLOW:
+      return "LongSlow";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.LONG_FAST:
+      return "LongFast";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.LONG_MODERATE:
+      return "LongMod";
+    default:
+      return "Invalid";
+  }
 };
 
 // Helper function to calculate hash
@@ -325,46 +334,58 @@ export const FrequencyCalculator = (): JSX.Element => {
     useState<Protobuf.Config.Config_LoRaConfig_RegionCode>(
       Protobuf.Config.Config_LoRaConfig_RegionCode.US,
     );
-  const [channel, setChannel] = useState<Types.ChannelNumber>(
-    Types.ChannelNumber.Primary,
-  );
+  const [channel, setChannel] = useState<Types.ChannelNumber>(0);
   const [numChannels, setNumChannels] = useState<number>(0);
   const [channelFrequency, setChannelFrequency] = useState<number>(0);
   const [defaultSlot, setDefaultSlot] = useState<number>(0);
 
+  // Recalculate values when modemPreset or region changes
   useEffect(() => {
     const selectedRegion = RegionData.get(region);
     const selectedModemPreset = modemPresets.get(modemPreset);
-    const calculatedNumChannels = Math.floor(
-      (selectedRegion.freqEnd - selectedRegion.freqStart) /
-        (selectedRegion.spacing + selectedModemPreset.bw / 1000),
-    );
 
-    setNumChannels(calculatedNumChannels);
+    if (selectedRegion && selectedModemPreset) {
+      const calculatedNumChannels = Math.floor(
+        (selectedRegion.freqEnd - selectedRegion.freqStart) /
+          (selectedRegion.spacing + selectedModemPreset.bw / 1000),
+      );
 
-    let updatedChannel = channel;
-    if (updatedChannel >= calculatedNumChannels) {
-      updatedChannel = 0;
-    }
+      setNumChannels(calculatedNumChannels);
 
-    setChannel(updatedChannel);
+      // Reset the channel to 0 when modemPreset or region changes
+      const defaultChannel = 0;
+      setChannel(defaultChannel);
 
-    setChannelFrequency(
-      selectedRegion.freqStart +
+      // Recalculate the frequency for the default channel
+      const newChannelFrequency =
+        selectedRegion.freqStart +
         selectedModemPreset.bw / 2000 +
-        updatedChannel * (selectedModemPreset.bw / 1000),
-    );
+        defaultChannel * (selectedModemPreset.bw / 1000);
+      setChannelFrequency(newChannelFrequency);
 
-    // Calculate the default slot
-    const channelName = formatChannelName(
-      Protobuf.Config.Config_LoRaConfig_ModemPreset[modemPreset],
-    ); // Example: LONG_FAST -> LongFast
-    const defaultSlot = determineFrequencySlot(
-      channelName,
-      calculatedNumChannels,
-    );
-    setDefaultSlot(defaultSlot);
-  }, [modemPreset, region, channel]);
+      // Calculate the default slot using the new channel name logic
+      const channelName = getChannelName(modemPreset); // Use the full name
+      const defaultSlot = determineFrequencySlot(
+        channelName,
+        calculatedNumChannels,
+      );
+      setDefaultSlot(defaultSlot);
+    }
+  }, [modemPreset, region]);
+
+  // Recalculate the frequency of the selected slot when the channel changes
+  useEffect(() => {
+    const selectedRegion = RegionData.get(region);
+    const selectedModemPreset = modemPresets.get(modemPreset);
+
+    if (selectedRegion && selectedModemPreset) {
+      const newChannelFrequency =
+        selectedRegion.freqStart +
+        selectedModemPreset.bw / 2000 +
+        channel * (selectedModemPreset.bw / 1000);
+      setChannelFrequency(newChannelFrequency);
+    }
+  }, [channel, modemPreset, region]);
 
   return (
     <div class="flex flex-col border-l-[5px] shadow-md my-4 border-accent rounded-lg p-4 bg-secondary gap-2">


### PR DESCRIPTION
## What did you change
The formatting of the channel name to do the hash was wrong, 
also getting rid of very long slow since it's deprecated. 

## Why did you change it
Because copilot failed me and @ianmcorvidae called me out. I figured it should. 

I've tested this manually with a heltec v3 setting random combinations and verified that the frequency is still correct, as well as doing random modem_preset and regions and they seem to be matching what the firmware does based on this testing. 

Is it the right/proper way to do this? Most assuredly not. But does it work? It would seem it does. Someone actually experienced and smarter than me (or rather copilot 😅) is welcome to PR a replacement. 