### PR TITLE
added NCMesh URL to community page

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -301,6 +301,8 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 ### North Carolina
 
+- [NC Mesh](https://www.ncmesh.net)
+
 ### Ohio
 
 - [Cincy Mesh](https://www.cincymesh.org)


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
Added link to North Carolina mesh (NCMesh.net) to the community page
<!-- Describe what your changes will do if merged -->
Should only update 2 lines in the main docs/community page
## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->
NCMesh was missing from the documentation page and is a large, active meshtastic community.