### PR TITLE
Remove "Control" from Community Apps

### DIFF
--- a/docs/community/software/index.mdx
+++ b/docs/community/software/index.mdx
@@ -14,8 +14,6 @@ Current community projects:
 - [Node-RED Messages Node](/docs/community/software/community-node-red-messages) - Node-RED node to send and receive packets / text messages from a device connected via HTTP.
 - [Telemetry Harbor - Grafana](/docs/community/software/telemetry-harbor) - A cloud-based solution for collecting, storing, and visualizing Meshtastic telemetry data using grafana.
 - [Connect](https://github.com/pdxlocations/connect) - A standalone Python client for communicating with Meshtastic devices via MQTT
-- [Contact](https://github.com/pdxlocations/contact) - A terminal-based chat client for Meshtastic devices, built using the Python curses library.
-- [Control](https://github.com/pdxlocations/control) - A terminal-based node configuration client for Meshtastic devices, built on the Meshtastic Python library.
-
+- [Contact](https://github.com/pdxlocations/contact) - A terminal-based Python chat and configuration client for Meshtastic devices.
 
 Support for these projects should be sought from their respective authors.


### PR DESCRIPTION
I'm no longer supporting "Control" as a separate app as it is also built into "Contact"
