### PR TITLE
docs: Telegram link for Meshtastic enthusiasts in Colombia

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -113,6 +113,9 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 - [Meshtastic 中国社区](https://meshcn.net)
 
+## Colombia
+
+- [Telegram Group](https://t.me/meshtasticco)
 
 ## Denmark
 


### PR DESCRIPTION
Added link to the Colombian Meshtastic enthusiast Telegram group to help local community members connect and collaborate.

