### PR TITLE
Update rakwireless links

### DIFF
--- a/docs/development/firmware/nrf52-guide.mdx
+++ b/docs/development/firmware/nrf52-guide.mdx
@@ -9,7 +9,7 @@ This document is a collection of tips and best practices for developing on the n
 
 ## Using the NanoDAP USB debugging probe
 
-This is a mini-HOWTO on installing the appropriate firmware and adapter software, it is loosely based on [this tutorial by RAK](https://docs.rakwireless.com/Product-Categories/Accessories/RAKDAP1-Flash-and-Debug-Tool/Quickstart/#rak4600-evaluation-board).
+This is a mini-HOWTO on installing the appropriate firmware and adapter software, it is loosely based on [this tutorial by RAK](https://docs.rakwireless.com/product-categories/accessories/rakdap1/quickstart/#rak4600-evaluation-board).
 
 ### Required hardware
 

--- a/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/drag-n-drop.mdx
@@ -53,7 +53,7 @@ After flashing the Meshtastic firmware to the device, you can proceed with the i
 
 :::info
 
-Before flashing confirm that you have [RAK4631](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/) and not a [RAK4631-R](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631-R/) If this is not the case, fear not. The hardware is identical but requires changing the bootloader. Instructions on how to do this are located [here](/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r).
+Before flashing confirm that you have [RAK4631](https://docs.rakwireless.com/product-categories/wisblock/rak4631/overview) and not a [RAK4631-R](https://docs.rakwireless.com/product-categories/wisblock/rak4631-r/overview) If this is not the case, fear not. The hardware is identical but requires changing the bootloader. Instructions on how to do this are located [here](/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r).
 
 :::
 

--- a/docs/hardware/devices/rak-wireless/wisblock/base-boards.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/base-boards.mdx
@@ -64,7 +64,7 @@ The RAK5005 (without the -O) is not compatible.
 - JST ZHR-2 connector for 5v solar panel.
   - Minimum input voltage to charge is 4.4v, maximum 5.5v.
 
-Further information on the RAK5005-O can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK5005-O/Overview/#product-description).
+Further information on the RAK5005-O can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak5005-o/overview/#product-description).
 
 <img
   alt="RAK4631 5005"
@@ -94,7 +94,7 @@ Further information on the RAK5005-O can be found on the [RAK Documentation Cent
 - **Screen Support**
   - OLED screen support (OLED screen sold separately)
 
-Further information on the RAK19007 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK19007/Overview/#product-description).
+Further information on the RAK19007 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak19007/overview/#product-description).
 
 ### Connectors Diagram
 
@@ -142,7 +142,7 @@ Further information on the RAK19007 can be found on the [RAK Documentation Cente
 - **Screen Support**
   - OLED screen support (OLED screen sold separately)
 
-Further information on the RAK19003 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK19003/Overview/#product-description)
+Further information on the RAK19003 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak19003/overview/#product-description)
 
 ### Connectors Diagram
 
@@ -198,7 +198,7 @@ Further information on the RAK19003 can be found on the [RAK Documentation Cente
 - **Screen Support**
   - OLED screen support (OLED screen sold separately)
 
-Further information on the RAK19001 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK19001/Overview/#product-description).
+Further information on the RAK19001 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak19001/overview/#product-description).
 
 ### Connectors Diagram
 

--- a/docs/hardware/devices/rak-wireless/wisblock/core-modules.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/core-modules.mdx
@@ -49,13 +49,13 @@ Please be aware of the difference between the RAK4631 (Arduino bootloader) and t
 ### Resources
 
 - Firmware file: `firmware-rak4631-X.X.X.xxxxxxx.uf2`
-- Further information on the RAK4631 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Overview/#product-description).
+- Further information on the RAK4631 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak4631/overview/#product-description).
 - Purchase Links:
   - US
     - [Rokland - US915 Mhz](https://store.rokland.com/products/rak-wireless-rak4631-nordic-nrf52840-ble-core-module-for-lorawan-with-lora-sx1262)
   - International
     - [RAKwireless Store](https://store.rakwireless.com/products/rak4631-lpwan-node?variant=37505443856582)
-    - [RAKwireless Aliexpress](https://www.aliexpress.us/item/3256801470104151.html)
+    - [RAKwireless AliExpress](https://www.aliexpress.us/item/3256801470104151.html)
 
 <img
   alt="RAK4631 Core Module"
@@ -146,13 +146,13 @@ If the device does not enter download mode, double-check the BOOT to GND connect
 ### Resources
 
 - Firmware file: `firmware-rak11200-X.X.X.xxxxxxx.bin`
-- Further information on the RAK11200 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK11200/Overview/#product-description).
+- Further information on the RAK11200 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak11200/overview/#product-description).
 - Purchase Links:
   - US
     - [Rokland](https://store.rokland.com/products/rakwireless-rak11200-wifi-and-ble-espressif-esp32-wrover-pid-110023)
   - International
     - [RAKwireless Store](https://store.rakwireless.com/products/wiscore-esp32-module-rak11200)
-    - [RAKwireless Aliexpress](https://www.aliexpress.us/item/3256802312474717.html)
+    - [RAKwireless AliExpress](https://www.aliexpress.us/item/3256802312474717.html)
 
 <img
   alt="RAK4631 5005 11200"
@@ -193,14 +193,14 @@ If the device does not enter download mode, double-check the BOOT to GND connect
 ### Resources
 
 - Firmware file: `firmware-rak11310-X.X.X.xxxxxxx.uf2`
-- Further information on the RAK11310 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK11310/Overview/#product-description).
+- Further information on the RAK11310 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak11310/overview/#product-description).
 - Purchase Links:
   - US
     - [Rokland](https://store.rokland.com/products/rak-raspberry-pi-rp2040-core-module-for-lorawan-with-lora-sx1262-us915-mhz-rak11310-pid-116003)
   - International
     - [RAKwireless WisMesh RP2040 Starter Kit](https://store.rakwireless.com/products/wisblock-rp2040-starter-kit-for-meshtastic)
     - [RAKwireless Store](https://store.rakwireless.com/products/rak11310-wisblock-lpwan-module)
-    - [RAKwireless Aliexpress](https://www.aliexpress.us/item/3256803225175784.html)
+    - [RAKwireless AliExpress](https://www.aliexpress.us/item/3256803225175784.html)
 
 </TabItem>	
 </Tabs>

--- a/docs/hardware/devices/rak-wireless/wisblock/index.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/index.mdx
@@ -23,7 +23,7 @@ Please see the RAK documentation for the correct way to connect your hardware to
 ## Resources
 
 - Design and build Meshtastic devices quick and easy by selecting the right modules with the [RAKwireless Meshtastic Designer tool](http://meshtastic-designer.rakwireless.com?utm_source=website_partner&utm_medium=referral&utm_campaign=rak_meshtastic_collab).
-- RAK's Wisblock [Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock)
+- RAK's Wisblock [Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/)
 - RAK's [GitHub Page](https://github.com/RAKWireless/WisBlock) for the WisBlock
 - RAK's [WisBlock IO Pin Mapping Tool](https://docs.rakwireless.com/Knowledge-Hub/Pin-Mapper/).
 - This tool helps properly map your WisBlock modules by identifying the compatible pins and their possible conflicts. Be sure to reference the RAK4631 [variant.h](https://github.com/meshtastic/firmware/blob/master/variants/rak4631/variant.h) to cross-reference potential conflicts to Meshtastic's firmware pin definitions.

--- a/docs/hardware/devices/rak-wireless/wisblock/peripherals.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/peripherals.mdx
@@ -78,8 +78,8 @@ The RAK1910 is supported on the following base boards & slots:
 ### Resources
 
 - RAK Documentation Center
-  - [RAK12500](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK12500/Overview/#product-description)
-  - [RAK1910](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1910/Overview/#product-description)
+  - [RAK12500](https://docs.rakwireless.com/product-categories/wisblock/rak12500/overview/#product-description)
+  - [RAK1910](https://docs.rakwireless.com/product-categories/wisblock/rak1910/overview/#product-description)
 - Purchase Links:
   - US
     - [Rokland RAK1910](https://store.rokland.com/products/rak-wireless-rak1910-wisblock-gnss-location-module)
@@ -99,7 +99,7 @@ The [RAK18001 Buzzer Module](https://store.rakwireless.com/products/wisblock-buz
 
 #### Resources
 
-- [RAK Documentation Center RAK18001](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK18001/Overview/#product-description)
+- [RAK Documentation Center RAK18001](https://docs.rakwireless.com/product-categories/wisblock/rak18001/overview/#product-description)
 - Purchase Links:
   - International
     - [RAKwireless](https://store.rakwireless.com/products/wisblock-buzzer-module-rak18001)
@@ -147,7 +147,7 @@ There is development activity in progress to get sensors such as this added to t
 
 ### Resources
 
-- [RAK Documentation Center RAK13002](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK13002/Overview)
+- [RAK Documentation Center RAK13002](https://docs.rakwireless.com/product-categories/wisblock/rak13002/overview/)
 - Purchase Links:
   - US
     - [muzi ᴡᴏʀᴋꜱ](https://muzi.works/products/rak-io-module)
@@ -188,9 +188,9 @@ The [RAK1906 Environment Sensor](https://store.rakwireless.com/products/rak1906-
 #### Resources
 
 - RAK Documentation Center
-  - [RAK1901](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1901/Overview/#product-description)
-  - [RAK1902](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1902/Overview/#product-description)
-  - [RAK1906](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1906/Overview/#product-description)
+  - [RAK1901](https://docs.rakwireless.com/product-categories/wisblock/rak1901/overview/#product-description)
+  - [RAK1902](https://docs.rakwireless.com/product-categories/wisblock/rak1902/overview/#product-description)
+  - [RAK1906](https://docs.rakwireless.com/product-categories/wisblock/rak1906/overview/#product-description)
 - Purchase Links:
   - US
     - [Rokland RAK1901](https://store.rokland.com/products/rak-wireless-rak1901-temperature-and-humidity-sensor-sensirion-shtc3-pid-100001)
@@ -210,7 +210,7 @@ The [RAK12002 WisBlock RTC Module](https://store.rakwireless.com/products/rtc-mo
 
 ### Resources
 
-- [RAK Documentation Center RAK12002](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK12002/Overview/)
+- [RAK Documentation Center RAK12002](https://docs.rakwireless.com/product-categories/wisblock/rak12002/overview/)
 - Purchase Links:
   - US
     - [Rokland](https://store.rokland.com/products/rak-wireless-rak12002-rtc-module-micro-crystal-rv-3028-c7-pid-100032)

--- a/docs/hardware/devices/rak-wireless/wisblock/screens.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/screens.mdx
@@ -34,7 +34,7 @@ If pin ordering on the OLED board are swapped, there are some tricks to allow ei
 
 ### Resources
 
-- [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1921/Overview/#product-description)
+- [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak1921/overview/#product-description)
 - Purchase Links:
 - US
   - [Rokland](https://store.rokland.com/products/rak-wireless-wisblock-oled-display-rak1921-pid-110004)
@@ -60,7 +60,7 @@ Please note only the white-black display is supported at this time, the white-bl
 ### Resources
 
 - Firmware for 5005 with RAK14000 e-paper: [`firmware-rak4631_eink-X.X.X.xxxxxxx.uf2`](/downloads)
-- [RAK Documentation Center](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK14000/Overview/#product-description)
+- [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisblock/rak14000/overview/#product-description)
 - Purchase Links:
   - US
     - [muzi ᴡᴏʀᴋꜱ](https://muzi.works/products/rak-oled-display-ssd1306)


### PR DESCRIPTION
## What did you change
* Changed all rakwireless links to lower case links.
* Renamed link text "RAKwireless Aliexpress" into "RAKwireless AliExpress"

## Why did you change it
* The upper case links result in 404 errors (but still show the page content mostly)
* The lower case links are the default in the docs menu on left of each page: https://docs.rakwireless.com/