### PR TITLE
Use Internet Archive for Meshtastic Discource group links

### DIFF
--- a/docs/about/overview/range-test.mdx
+++ b/docs/about/overview/range-test.mdx
@@ -62,7 +62,7 @@ Default Very Long Slow
 
 - **Range:** 254km (158 miles)
 - **Record Holders:** _kboxlabs_
-- **Source:** [Meshtastic Discourse](https://meshtastic.discourse.group/t/practical-range-test-results/692/137)
+- **Source:** [Meshtastic Discourse (archive)](https://web.archive.org/web/20250102052417/https://meshtastic.discourse.group/t/practical-range-test-results/692/137)
 
 <h5 id="modem-settings-254">Modem Settings</h5>
 
@@ -95,7 +95,7 @@ Default Long_Fast
 
 - **Range:** 166km (103 miles)
 - **Record Holder:** _PuzzledPancake_
-- **Source:** [Meshtastic Discourse](https://meshtastic.discourse.group/t/practical-range-test-results/692/44)
+- **Source:** [Meshtastic Discourse (archive)](https://web.archive.org/web/20250102052417/https://meshtastic.discourse.group/t/practical-range-test-results/692/44)
 
 <h5 id="modem-settings-166">Modem Settings</h5>
 
@@ -132,7 +132,7 @@ Default Long_Fast
 
 - **Range:** 206km (128 miles)
 - **Record Holders:** _StarWatcher, CVR, rook, kboxlabs_
-- **Source:** [Meshtastic Discourse](https://meshtastic.discourse.group/t/practical-range-test-results/692/130)
+- **Source:** [Meshtastic Discourse (archive)](https://web.archive.org/web/20250102052417/https://meshtastic.discourse.group/t/practical-range-test-results/692/130)
 
 <h5 id="modem-settings-206">Modem Settings</h5>
 


### PR DESCRIPTION
## What did you change
Use links of the Internet Archive to make Meshtastic Discource group links available

## Why did you change it
Meshtastic Discource group web page is unavailable