### PR TITLE
Added Maine heading and Maine Mesh local group

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -280,6 +280,10 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 - [SecKC Amateur Radio Club of Kansas City and Surrounding Cities for Amateur Radio](https://ks3ckc.radio/home)
 
+### Maine
+
+- [Maine Mesh](https://github.com/JFRHorton/MaineMesh)
+
 ### Massachusetts
 
 - [Boston Meshnet](https://github.com/Darachnid/Boston-Meshnet)


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
Added heading for Maine to US Local Groups, and a link to the Maine Mesh project GitHub, to the local-groups.mdx page

## Why did you change it
Added link to aid coordinating network in Maine, prepping for a number of presentations at our local radio club.
Initially inquired about process on Discord 'docs' channel.
