### PR TITLE
doc fix: add I2C pin numbers for heltec wireless tracker v1.1

### DIFF
--- a/docs/hardware/devices/heltec-automation/lora32/index.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/index.mdx
@@ -259,6 +259,11 @@ The following process will manually place the device into the Espressif Firmware
 
 With the device now in the Espressif Firmware Download mode, you can proceed with flashing using one of the supported flashing methods. It's generally recommended to use the [Web Flasher](https://flasher.meshtastic.org/). You can select "Heltec Wireless Tracker" from the device drop-down.
 
+### Meshtastic I2C Definitions
+
+- SDA: GPIO41
+- SCL: GPIO42
+
 ### Pin Map
 
 ![HT-Tracker_V1 Pin Map](/img/hardware/HT-Tracker_V1_Pin_Map.webp)


### PR DESCRIPTION
added I2C pin numbers for heltec wireless tracker v1.1