### PR TITLE
Update index.mdx added Foreign Mesh to Terms

### DIFF
--- a/docs/terms/index.mdx
+++ b/docs/terms/index.mdx
@@ -37,6 +37,9 @@ Firmware | [Guide](https://meshtastic.org/docs/getting-started/flashing-firmware
 Flash/Flashing | [Guide](https://meshtastic.org/docs/getting-started/flashing-firmware/)
 : The process of updating or installing firmware on a Meshtastic device. This is typically done using a computer to load new firmware versions or custom software to enhance or modify device functionality.
 
+Foreign Mesh
+: A Foreign Mesh is one in which the receiving node does not share any Channels with the transmitting node. When a node receives a message it is unable to decrypt, then the message is said to come from a Foreign Mesh.
+
 GPIO
 : General Purpose Input/Output. An uncommitted digital signal pin on a device
 


### PR DESCRIPTION
based on comment in discord from b8b8

## What did you change
Added term Foreign Mesh to the definitions page

## Why did you change it
The term Foreign Mesh is used in the documentation but never defined.

## Screenshots

### After
<img width="1038" alt="Screenshot 2025-04-26 at 3 40 43 PM" src="https://github.com/user-attachments/assets/5f3ed59c-b342-4396-8102-917fc9e93ca9" />

