### PR TITLE
Update radio-settings.mdx / explain frequency slots

### DIFF
--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -55,7 +55,7 @@ The maximum output power for North America is +30 dBm ERP ([Effective Radiated P
 
 The band range is from 902 to 928 MHz.
 
-There are 104 frequency slots defined with the standard radio preset `LongFast`. After factory reset the radio will be set to frequency slot 20 with a center frequency of 906.875 MHz.
+There are a number of Frequency Slots defined for use in North America. The number of Slots depends upon the bandwidth setting. Bandwidth is one of the settings in a Radio Preset. For instance, the standard Radio Preset is LongFast and that offers 104 Frequency Slots. After factory reset the radio will be set to the default Preset of LongFast with Frequency Slot 20 -  a center frequency of 906.875 MHz.
 
 ## Data Rates
 


### PR DESCRIPTION

## What did you change
Clarified that the connection between number of Frequency Slots and Presets depends on the LoRa bandwidth selected. Bandwidth is part of the Presets.

## Why did you change it
Previous text left the reader to wonder if all Presets have 104 slots (they do not, some have less, some more). 

