### PR TITLE
network.mdx: logging facility

### DIFF
--- a/docs/configuration/radio/network.mdx
+++ b/docs/configuration/radio/network.mdx
@@ -59,7 +59,7 @@ Contains IP, Gateway, Subnet, and DNS server for a static configuration if selec
 
 ### Rsyslog Server
 
-To configure an rsyslog Server and Port
+To configure an rsyslog Server and Port. Default logging facility is `user`.
 
 ### Protocol Flags
 


### PR DESCRIPTION
## What did you change
network.mdx: about rsyslog logging facility

## Why did you change it
It makes users easier to configure their syslog collector, without the need to dig into the source code https://github.com/meshtastic/firmware/blob/635de2d2296d463fb61fe5a650bd06b94a6559ee/src/mesh/wifi/WiFiAPClient.cpp#L122
