### PR TITLE
Update index.mdx Description of Channel 0 name was not accurate

### DIFF
--- a/docs/about/overview/index.mdx
+++ b/docs/about/overview/index.mdx
@@ -22,7 +22,7 @@ At the radio level a Meshtastic mesh is a set of nodes that share the same LoRa 
 
 These values are grouped into "presets" that can be easily chosen in the LoRa configuration section. Presets make it easy for nodes to configure the same radio parameters.
 
-Sitting on top of this radio mesh are Channels. A logical mesh is formed by a Channel with a particular name and encryption key. The default channel in a radio mesh is Channel 0 with a blank "name" and an ecryption key of AQ==. 
+Sitting on top of this radio mesh are Channels. A logical mesh is formed by a Channel with a particular name and encryption key. The default channel in a radio mesh is Channel 0. With default settings, the default name of Channel 0 is the CamelCase abbreviation of the radio preset (preset Long Fast would be LongFast) with an ecryption key of AQ==. Note that some control applications leave the Channel 0 name blank and allow the firmware to apply the CamelCase name. 
 
 Nodes can belong to a maximum of 8 Channels in the radio mesh. A custom Channel can be created for use by a specific group. Only nodes configured with the same Channel name and encryption key will be able to read and display messages on that Channel. However, all nodes in the radio mesh will receive and may retransmit messages (depending on their Role) regardless of the Channel settings for the message.
 


### PR DESCRIPTION

## What did you change
The default channel in a radio mesh is Channel 0 with a blank "name" and an encryption key of AQ==.

## Why did you change it
The actual channel 0 name when using the default preset is LongFast, not blank. It is blank in the iOS app (I don't know what it is in Android) and the firmware changes that to LongFast. 

This is a confusing topic for sure, but I think for people new to Meshtastic we should spend some extra words and begin to reveal some of the language that they will find in the rest of the documentation. It is important for newbies to see that the app (web/phone/serial) they use is distinctly different from the node. Particularly true when people are reading the "I want to know more about the technical details" part of the docs.
