### PR TITLE
Update comments.mdx Changed words for clarity

### DIFF
--- a/docs/about/overview/encryption/comments.mdx
+++ b/docs/about/overview/encryption/comments.mdx
@@ -42,7 +42,7 @@ Always keep in mind [xkcd's note on encryption](https://xkcd.com/538).
 
 If you are reviewing our implementation, this is a brief statement of our method.
 
-- We do all crypto at the SubPacket (payload) level only, so that all Meshtastic nodes will route for others - even those channels which are encrypted with a different key.
+- We do all crypto at the SubPacket (payload) level only, so that all Meshtastic nodes will route for others - even those channels which are encrypted with a key the node does not possess.
 - Mostly based on reading [Wikipedia](<https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_(CTR)>) and using the modes the ESP32 provides support for in hardware.
 - We use AES256-CTR as a stream cypher (with zero padding on the last BLOCK) because it is well supported with hardware acceleration.
 - Our AES key is 128 or 256 bits, shared as part of the 'Channel' specification.


### PR DESCRIPTION
## What did you change
"different key" to "a key the node does not possess"

## Why did you change it
The original text used the phrase "a different key" as in different from the key used to encrypt the packet. I think that is less clear. The nodes have several different keys, one for each channel. The new wording is meant to make that clear without changing the meaning of the text.

## changed text
### Before
encrypted with a different key

### After
encrypted with a key the node does not posses.