### PR TITLE
Add XIAO nRF52840 hardware page

### DIFF
--- a/docs/hardware/devices/seeed-studio/esp32-sx1262-kit/index.mdx
+++ b/docs/hardware/devices/seeed-studio/esp32-sx1262-kit/index.mdx
@@ -5,6 +5,11 @@ sidebar_label: XIAO ESP32S3 & Wio-SX1262 Kit
 sidebar_position: 2
 ---
 
+:::warning[Note]
+The Wio-SX1262 module shipped with this kit does not have the same pin configuration as the one shipped with the XIAO nRF52840 kit.
+If you want to use a Wio-SX1262 module from a different Seeed kit with a XIAO ESP32S3, you may need to flash custom firmware with the correct pin definitions.
+:::
+
 A thumb-sized LoRa dev kit, supporting WiFi, BLE, and LoRa, it includes a built-in power management chip and can be extended via IIC, UART, and other GPIO interfaces, with compatibility for Arduino development.
 
 ### Specifications
@@ -25,6 +30,12 @@ A thumb-sized LoRa dev kit, supporting WiFi, BLE, and LoRa, it includes a built-
 
 - **Thumb-sized Compact Design**: 21 x 18mm, adopting the classic form factor of XIAO.
 - **Grove Connectors**: 400+ Grove-compatible GPIOs for flexible expansion options.
+- **L76K GNSS Module available**: A Seeed L76K GNSS Module is available with the same form factor as the XIAO ESP32S3 & Wio-SX1262 Kit.
+
+:::info[Note]
+When using the Seeed L76K GNSS Module together with this kit, the L76K `RST` pin is shared with the Wio-SX1262 `RST` pin.
+In order to use these modules together, you must cut the pin so that is not connected to the L76K GNSS Module.
+:::
 
 ### Resources
 

--- a/docs/hardware/devices/seeed-studio/nrf52840-sx1262-kit/index.mdx
+++ b/docs/hardware/devices/seeed-studio/nrf52840-sx1262-kit/index.mdx
@@ -1,0 +1,41 @@
+---
+id: xiao-nrf52840-kit
+title: XIAO nRF52840 & Wio-SX1262 Kit
+sidebar_label: XIAO nRF52840 & Wio-SX1262 Kit
+sidebar_position: 3
+---
+
+:::warning[Note]
+The Wio-SX1262 module shipped with this kit does not have the same pin configuration as the one shipped with the XIAO ESP32S3 kit.
+If you want to use a Wio-SX1262 module from a different Seeed kit with a XIAO nRF52840, you may need to flash custom firmware with the correct pin definitions.
+:::
+
+A thumb-sized LoRa dev kit, supporting BLE, and LoRa, it includes a built-in power management chip and can be extended via IIC, UART, and other GPIO interfaces, with compatibility for Arduino development.
+
+### Specifications
+
+- **MCU**
+  - XIAO nRF52840 (Bluetooth)
+- **LoRa Transceiver**
+  - Semtech SX1262
+- **Frequency options**
+  - 862-930 MHz
+- **Connectors**
+  - USB-C
+  - Antenna
+    - U.FL/IPEX antenna connector for LoRa
+
+### Features
+
+- **Thumb-sized Compact Design**: 21 x 18mm, adopting the classic form factor of XIAO.
+- **L76K GNSS Module available**: A compatible Seeed L76K GNSS Module is available with the same form factor as the XIAO nRF52840 & Wio-SX1262 Kit.
+
+### Resources
+
+- Purchase Links:
+  - International
+    - [Seeed Studio Online Store](https://www.seeedstudio.com/XIAO-nRF52840-Wio-SX1262-Kit-for-Meshtastic-p-6400.html)
+
+  {/* While DigiKey has the article, they do not seem to stock them. Yet?
+    - Distributor
+      - [DigiKey](https://www.digikey.com/en/products/detail/seeed-technology-co-ltd/102010710/26553900) */}

--- a/docs/hardware/devices/seeed-studio/wm1110/index.mdx
+++ b/docs/hardware/devices/seeed-studio/wm1110/index.mdx
@@ -2,7 +2,7 @@
 id: seeed-wm1110
 title: Seeed Wio-WM1100
 sidebar_label: Wio-WM1100
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 import Tabs from "@theme/Tabs";


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
Add XIAO nRF52840 hardware page similar to the ESP32 one, but with a notice about pin-incompatibility between ESP32 and nRF versions of the WIO LoRa module.

Modify XIAO ESP32 hardware page to include note on WIO module pin-incompatibility and workaround for L76K GNSS module from Seeed.

## Why did you change it
Discussions on Discord and Facebook groups relating to differences between ESP32 and nRF52840 versions and L67K GNSS module usage.

This is also related to [firmware PR#6717](https://github.com/meshtastic/firmware/pull/6717)

## Screenshots
### Before
--

### After
Incompatibility warning
<img width="977" alt="Screenshot 2025-05-07 at 20 42 19" src="https://github.com/user-attachments/assets/4695b57f-9276-428b-9ada-e7fa4d2ce782" />

New page
<img width="951" alt="Screenshot 2025-05-07 at 20 42 43" src="https://github.com/user-attachments/assets/68b76bda-a4d9-4cf6-a550-9715860e0eed" />

