### PR TITLE
Broken links replace with Archive & an invalid invite removed from local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -95,7 +95,6 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 ### Ontario
 
 - [Mesht Ontario](https://t.me/meshtOnt)
-- [Greater Ottawa Meshtastic Enthusiasts Discord](https://discord.gg/njcQ4BnKDU)
 
 ### Prince Edward Island
 
@@ -212,11 +211,11 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 - [Meshtastic Türkiye Community - Telegram](https://t.me/trmesh)
 - [Meshtastic Türkiye Community - Discord](https://discord.gg/7TGnZSSA)
-- [Meshtastic Türkiye Community - Web](https://trmesh.org)
+- ~~Meshtastic Türkiye Community - Web~~ - [Archived](https://web.archive.org/web/20241207225721/http://trmesh.org/)
 
 ## Ukraine
 
-- [WiKi Meshtastic UA](https://wikimesh.pp.ua)
+- ~~WiKi Meshtastic UA~~ - [Archived](https://web.archive.org/web/20241012101501/https://wikimesh.pp.ua/uk/home)
 
 ## United States
 
@@ -247,7 +246,7 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 - [MontereyBayMesh](https://mrymesh.net/)
 - [San Diego Mesh](https://discord.gg/k8RputgWgD)
 - [Antelope Valley Mesh](https://www.avmesh.org/)
-- [AltaMesh](https://altamesh.net/)
+- ~~AltaMesh~~ - [Archived](https://web.archive.org/web/20250122193410/https://altamesh.net/)
 - [Central Valley](https://centralvalleymesh.net/)
 - [Sac Valley Mesh](http://www.sacvalleymesh.com)
 - [Inter-Canyon Mesh - Orange County Canyons](https://icmesh.com)
@@ -348,13 +347,13 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 - [Austin Mesh](https://austinmesh.org/)
 - [Cypress, Texas Meshtastic Club](https://discord.gg/KzuwNRwE6q)
-- [DFW / North Texas Mesh](https://ntxmesh.net)
+- ~~DFW / North Texas Mesh~~ - [Archived](https://web.archive.org/web/20250122194857/https://ntxmesh.net/)
 
 ### Virginia
 
 - [MadisonMesh](https://madisonmesh.com/)
 - [Albemarle Mesh](https://albemarlemesh.com/)
-- [Shenandoah Valley Mesh](https://svmesh.org)
+- ~~Shenandoah Valley Mesh~~ - [Archived](https://web.archive.org/web/20250216025925/https://svmesh.org/)
 
 ### Wisconsin
 


### PR DESCRIPTION
## What did you change

Broken links replace with Archive & an invalid invite removed.

Invalid discord invite removed :
Greater Ottawa Meshtastic Enthusiasts Discord - https://discord.gg/njcQ4BnKDU

Linked replace with Archive : 
Name : Meshtastic Türkiye Community - Web
Link : https://trmesh.org
Reason : DNS not found
Archive : https://web.archive.org/web/20241207225721/http://trmesh.org/

Name : WiKi Meshtastic UA
Link : https://wikimesh.pp.ua
Reason : DNS not found
Archive : https://web.archive.org/web/20241012101501/https://wikimesh.pp.ua/uk/home

Name : AltaMesh
Link : https://altamesh.net
Reason : Host not found
Archive : https://web.archive.org/web/20250122193410/https://altamesh.net/

Name : DFW / North Texas Mesh
Link : https://ntxmesh.net
Reason : Host not found
Archive : https://web.archive.org/web/20250122194857/https://ntxmesh.net/

Name : Shenandoah Valley Mesh
Link : https://svmesh.org
Reason : Host not found
Archive : https://web.archive.org/web/20250216025925/https://svmesh.org/