### PR TITLE
Add Chile US frequency as the official

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -23,6 +23,9 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 - Server invitation links must be set to never expire.
 :::
 
+## Chile
+- [Meshtastic Chilean Community](https://links.meshtastic.cl)
+
 ## Argentina
 
 - [Meshtastic Argentina Community](https://github.com/Meshtastic-Argentina/)

--- a/docs/configuration/region-by-country.mdx
+++ b/docs/configuration/region-by-country.mdx
@@ -36,6 +36,7 @@ If you'd like to contribute information for your country, click the "Edit this p
 | Croatia        | EU_868<br />EU_433 |                                                                                                                                  |
 | Cyprus         | EU_868<br />EU_433 |                                                                                                                                  |
 | Czech Republic | EU_868<br />EU_433 |                                                                                                                                  |
+| Chile          | US                 | [Chilean Regulation](https://www.bcn.cl/leychile/navegar?idNorma=1109333&idParte=9841504&idVersion=&r_c=6)                    |
 
 ### D
 


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## Included Chile in the list of countries with it's respective frequency zone (US) and url to national RF regulation
<!-- Describe what your changes will do if merged -->
This fork adds Chile to the list in LoRa Region by country

## Why did you change it
We are recently planning and creating the network for Chile and we need to appear on the official wiki so the new users know what frequency to use.

We are also building our wiki (wiki.meshtastic.cl and we have our own mqtt server mqtt.meshtastic.cl)

## Screenshots
### Before

![image](https://github.com/user-attachments/assets/02c32053-8987-4e07-a82e-d3c780253473)



### After
![image](https://github.com/user-attachments/assets/50effafa-8bea-4b4e-9688-ad6fb3519524)
