### PR TITLE
Update g1 station to indicate unsupported status

### DIFF
--- a/docs/hardware/devices/b-and-q-consulting/station-series/index.mdx
+++ b/docs/hardware/devices/b-and-q-consulting/station-series/index.mdx
@@ -25,7 +25,7 @@ values={[
 
 :::info
 
-The Station G1 has been discontinued and replaced by the upgraded Station G2. The Station G1 remains a supported device.
+The Station G1 has been discontinued and replaced by the upgraded Station G2. The Station G1 is no longer a supported device.
 
 :::
 


### PR DESCRIPTION
station-g1 is not located in bin/device-install.sh or in boards list on https://github.com/meshtastic/firmware/tree/9799f10e6363703bf64490044dbac813f0ddf2ea/boards changed the language on the page to indicate it is no longer supported.

<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->
"The Station G1 remains a supported device." changed to The Station G1 is no longer a supported device.
## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->
started with this rabbit hole seeking a solution to the problem of installing the most recent firmware on the station-g1: https://github.com/meshtastic/firmware/issues/6929 and realized that the station G1 is not listed on the boards or in the device-install.sh script file

## Screenshots
### Before


### After
