### PR TITLE
Add Meshtastic Serbia

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -192,6 +192,10 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 - [Comunidade Meshtastic Portugal](https://t.me/comunidademeshtasticpt)
 
+## Serbia
+
+- [Meshtastic Srbija](https://meshserbia.com/)
+
 ## Slovenia
 
 - [MeshNet.si](https://meshnet.si)


### PR DESCRIPTION
## What did you change

Added the Serbian Meshtastic Community website to the Local Groups

I'm pretty sure that the website complies with the Submission Requirements; however, if it doesn't please let me know so I can forward this information to them. 

The website officially stated (translated by me):

> Meshtastic Serbia is an informal community of enthusiasts founded with the aim of bringing together all users of the Meshtastic network in Serbia and it's surrounding regions. The gathering and exchange of knowledge takes place through the publicly available Meshtastic channel, as well as on the active Telegram group of the community.

> The network is maintained and developed by a community of volunteers — individuals who work out of enthusiasm, without monetary compensation.

> It is important to emphasize that Meshtastic Serbia is not officially connected or approved by the Meshtastic® project.
## Screenshots

### Before

![Screenshot before](https://github.com/user-attachments/assets/e2560bb6-05cd-486c-b26c-a51618a9abb6)

### After

![Screenshot after](https://github.com/user-attachments/assets/3559e12f-fb93-40db-8250-d80712713fb9)
