### PR TITLE
Make frequency slot calc use default slot instead of 0

### DIFF
--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -352,16 +352,6 @@ export const FrequencyCalculator = (): JSX.Element => {
 
       setNumChannels(calculatedNumChannels);
 
-      // Reset the channel to 0 when modemPreset or region changes
-      const defaultChannel = 0;
-      setChannel(defaultChannel);
-
-      // Recalculate the frequency for the default channel
-      const newChannelFrequency =
-        selectedRegion.freqStart +
-        selectedModemPreset.bw / 2000 +
-        defaultChannel * (selectedModemPreset.bw / 1000);
-      setChannelFrequency(newChannelFrequency);
 
       // Calculate the default slot using the new channel name logic
       const channelName = getChannelName(modemPreset); // Use the full name
@@ -370,6 +360,17 @@ export const FrequencyCalculator = (): JSX.Element => {
         calculatedNumChannels,
       );
       setDefaultSlot(defaultSlot);
+
+      // Reset the channel to the default when modemPreset or region changes
+      setChannel(defaultSlot);
+
+      // Recalculate the frequency for the default channel
+      const newChannelFrequency =
+        selectedRegion.freqStart +
+        selectedModemPreset.bw / 2000 +
+        defaultChannel * (selectedModemPreset.bw / 1000);
+      setChannelFrequency(newChannelFrequency);
+
     }
   }, [modemPreset, region]);
 


### PR DESCRIPTION
## What did you change
Make Radio Settings doc's Frequency Slot Calculator tool set the "Frequency Slot" to the value of the "Default Frequency Slot" when changing Modem Preset or Region, rather than the first (1).

## Why did you change it
The default frequency slot is the one that will be used most often, so it makes more sense to initialize the frequency slot to the default rather than making the user manually select the default frequency slot from the list. This lead to a bit of confusion in this discord chat:
https://discord.com/channels/1215670460264742922/1379994081744257215/1380265051059130379

