### PR TITLE
Add Greater Boston Mesh discord

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -303,6 +303,7 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 - [Boston Meshnet](https://github.com/Darachnid/Boston-Meshnet)
 - [Pioneer Valley Meshtastic Network](https://pvmesh.org)
 - [SouthCoast Mesh](https://southcoastmesh.com)
+- [Greater Boston Mesh](https://discord.gg/MUVASVEEES)
 
 ### Michigan
 


### PR DESCRIPTION
We have created a new Discord server to support discussion and coordination around the Meshtastic net in the greater Boston area. This is intended to serve an overlapping purpose with the Boston Meshnet Facebook group (the primary online community space for the area currently; linked from the Boston Meshnet Github page on line 303) and specifically reach folks who do not use Facebook.

<img width="882" alt="Screen Shot 2025-06-08 at 10 25 52 PM" src="https://github.com/user-attachments/assets/33c2d621-39f5-47d6-bd8f-398a54c60a79" />

## Screenshots
### Before
<img width="405" alt="Screen Shot 2025-06-08 at 10 27 59 PM" src="https://github.com/user-attachments/assets/748db1c1-2117-4493-9e23-bb48f5bde558" />

### After
<img width="434" alt="Screen Shot 2025-06-08 at 10 27 22 PM" src="https://github.com/user-attachments/assets/b26552e3-603a-47ec-a19b-4ef5a2512e72" />
