### PR TITLE
Added Meshtastic Argentina telegram group link

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -25,7 +25,8 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 ## Argentina
 
-- [Meshtastic Argentina Community](https://github.com/Meshtastic-Argentina/)
+- [Meshtastic Argentina Community - Telegram](https://t.me/meshtastic_argentina)
+- [Meshtastic Argentina Community - GitHub](https://github.com/Meshtastic-Argentina/)
 
 ## Australia
 
@@ -303,7 +304,6 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 - [Boston Meshnet](https://github.com/Darachnid/Boston-Meshnet)
 - [Pioneer Valley Meshtastic Network](https://pvmesh.org)
 - [SouthCoast Mesh](https://southcoastmesh.com)
-- [Greater Boston Mesh](https://discord.gg/MUVASVEEES)
 
 ### Michigan
 


### PR DESCRIPTION
## What did you change
Added Meshtastic Argentina telegram group link
## Why did you change it
The telegram group with 3400+ members, is the main communication channel for organizing public mesh networks in Argentina.
