### PR TITLE
Add Argentina Community telegram group link

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -25,7 +25,8 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 ## Argentina
 
-- [Meshtastic Argentina Community](https://github.com/Meshtastic-Argentina/)
+- [Meshtastic Argentina Community - Telegram](https://t.me/meshtastic_argentina)
+- [Meshtastic Argentina Community - GitHub](https://github.com/Meshtastic-Argentina/)
 
 ## Australia
 


### PR DESCRIPTION
The telegram group is the main communication channel for organizing public mesh networks in Argentina.
![image](https://github.com/user-attachments/assets/fccf96ff-2abd-4304-b556-5f1d8116c18a)

## What did you change
Add new link to Argentina Meshtastic Community in Telegram.

## Why did you change it
It was missing.
