### PR TITLE
Added hint thas ios app does only support connection via bluetooth.

### DIFF
--- a/docs/software/apple/usage.mdx
+++ b/docs/software/apple/usage.mdx
@@ -4,6 +4,9 @@ title: Apple Application Usage
 sidebar_label: Usage
 sidebar_position: 2
 ---
+## Connection Options
+
+This app can only connect to the node via Bluetooth and [not Wi-Fi](https://github.com/meshtastic/Meshtastic-Apple/issues/550). If you enable Wi-Fi you have to use the [other clients](https://meshtastic.org/docs/software/).
 
 ## Offline Maps
 


### PR DESCRIPTION
## What did you change
I added information in the documentation that the iOS app does only support bt to connect to the node.

## Why did you change it
I myself added my node to my wifi and was puzzled, that the app does not find the node.

Wifi connection on the iOS app is not supportet and not planned and even seems to be [not possible](https://github.com/meshtastic/Meshtastic-Apple/issues/296#issuecomment-2859097558).