### PR TITLE
Linux: Add Fedora 42, Remove Fedora 40

### DIFF
--- a/docs/blocks/_linux-install.mdx
+++ b/docs/blocks/_linux-install.mdx
@@ -82,7 +82,7 @@ import { Icon } from "@iconify/react";
     Fedora packages are provided via [Fedora COPR](https://copr.fedorainfracloud.org/coprs/g/meshtastic/beta/).
     [![Copr build status](https://copr.fedorainfracloud.org/coprs/g/meshtastic/beta/package/meshtasticd/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/g/meshtastic/beta/package/meshtasticd/)
 
-    Supported: Fedora `41`, Fedora `40`
+    Supported: Fedora `42`, Fedora `41`
 
     **Install:**
 
@@ -92,18 +92,6 @@ import { Icon } from "@iconify/react";
     # Install meshtasticd
     sudo dnf install meshtasticd
     ```
-
-    <details>
-      <summary>Experimental builds</summary>
-
-      These builds are provided without support, please **do not file issues** relating to Experimental builds.
-
-      Experimental Support: Fedora `42`
-
-      **Install:**
-
-      > Install via the instructions above.
-    </details>
 
   </TabItem>
   <TabItem value="epel" label={<><Icon icon="mdi:redhat" style={{ marginRight: "0.25rem" }} height="1.5rem" /> RedHat (EPEL)</>}>


### PR DESCRIPTION
Small change: Remove Fedora `40` from supported distros (it's EOL), add Fedora `42`.