### PR TITLE
Canned messages via InkHUD menu

### DIFF
--- a/docs/software/inkhud/index.mdx
+++ b/docs/software/inkhud/index.mdx
@@ -78,12 +78,22 @@ Only wanted a quick peek at the clock? Long-press a second time to close the men
   style={{maxHeight: '256px', width: 'auto'}}
 />
 
-### Send Ping
+### Send
+
+#### Ping
 
 Manually announces the device to other nodes on the mesh. 
 
 This is optional, as nodes are discovered automatically, 
 however sending a ping manually may speed up this process is some situations.
+
+#### Canned Messages
+
+Send predefined text messages to the mesh network from the device without using the phone app. 
+To enable this feature, [set a list of predefined messages](https://meshtastic.org/docs/configuration/module/canned-message/#messages).
+No further configuration is required.
+
+To send, select your predefined message in the `Send` menu, then select a destination. The list of possible destinations will include your channels, and nodes marked favorite.
 
 ### Options
 


### PR DESCRIPTION
## What did you change
Add information on configuring / using canned messages via InkHUD's on-screen menu.

## Why did you change it
https://github.com/meshtastic/firmware/pull/7096 (applicable as of 2.7.1)