### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -246,7 +246,6 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 ### Arizona
 
-- [Tucson Meshtastic Community](https://discord.gg/7MzbMMd2kg)
 - [Arizona Meshtastic Community](https://azmsh.net)
 
 ### Arkansas


### PR DESCRIPTION
## What did you change
Removed Tucson Meshtastic Community link from Arizona

## Why did you change it
Discord is no longer maintained, all members have moved to the larger Arizona Meshtastic Community Discord.
