### PR TITLE
Update mqtt.mdx

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -78,7 +78,7 @@ The precision to use for the position in the map report. Defaults to a maximum d
 
 #### Map Report Publish Interval
 
-How often we should publish the map report to the MQTT server in seconds. Defaults to 900 seconds (15 minutes).
+How often we should publish the map report to the MQTT server in seconds. Defaults to 3600 seconds (1 hour), which is also the minimum value.
 
 ## MQTT Module Config Client Availability
 


### PR DESCRIPTION
per @Code1110 , 
"""This should be reflected in the docs as well. https://meshtastic.org/docs/configuration/module/mqtt/ still says the default is 900 seconds and doesn't mention that the minimum is now 3600 seconds. Entering a value smaller than 3600 seconds in the UI changes the value silently to 3600 seconds and is therefore confusing."""