### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -366,7 +366,7 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 ### Pennsylvania
 
-- [Philly Radio & Meshtastic](https://discord.gg/MWWbAkRR9v)
+- [Philly Radio & Meshtastic](https://phillymesh.net/)
 
 ### Tennessee
 


### PR DESCRIPTION
updated Philly Radio & Meshtastic's link from our discord to our website homepage (which links to our discord)


<!-- Describe what your changes will do if merged -->
My changes change our link from discord to our website.

## Why did you change it
We have recently built up our web presence, so a link directly to our website (which links to our discord) makes more sense here than just a link to our discord.
