### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -310,7 +310,7 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 ### Kansas
 
-- [SecKC Amateur Radio Club of Kansas City and Surrounding Cities for Amateur Radio](https://ks3ckc.radio/home)
+- [SecKC Amateur Radio Club of Kansas City and Surrounding Cities for Amateur Radio](https://ks3ckc.radio/meshtastic)
 
 ### Maine
 


### PR DESCRIPTION
Updated Kansas SecKC Meshtastic URL link to new webpage for Meshtastic (https://ks3ckc.radio/meshtastic).

<!-- Add or remove sections as needed -->
Updated the URL for the Kansas local group hosted by SecKC with new URL https://ks3ckc.radio/meshtastic

<!-- Describe what your changes will do if merged -->
Accurate link to the Meshtastic specific page for Kansas

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->
To have the Kansas Meshtastic local group with an accurate link directly to the org's Meshtastic page. 

## Screenshots
### Before


### After
