### PR TITLE
Fix incorrect UUID for log messages

### DIFF
--- a/docs/development/device/client-api.mdx
+++ b/docs/development/device/client-api.mdx
@@ -78,7 +78,7 @@ read,notify,write
 fromnum - the current packet # in the message waiting inside fromradio, if the phone sees this notify it should read messages
 until it catches up with this number.
 
-6c6fd238-78fa-436b-aacf-15c5be1ef2e3
+5a3d6e49-06e6-4423-9944-e9de8cdf9547
 notify
 A log message as LogRecord protobuf.  Clients are encouraged to listen for this notification and give the option of logging these
 debug messages.


### PR DESCRIPTION
## What did you change
The UUID for log notifications

## Why did you change it
Because it was wrong
https://github.com/search?q=5a3d6e49-06e6-4423-9944-e9de8cdf9547&type=code

List of all advertised characteristics
```
[
"ed9da18c-a800-4f66-a670-aa7547e34453",
"2c55e69e-4993-11ed-b878-0242ac120002",
"f75c76d2-129e-4dad-a1dd-7866124401e7",
"5a3d6e49-06e6-4423-9944-e9de8cdf9547"
]
```