### PR TITLE
Add LINC to local groups page

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -400,6 +400,7 @@ To be listed here, your group must be in compliance with our [Trademark Guidelin
 
 ### Washington
 
+- [LINC - Lincoln County Mesh Messaging](https://lincme.sh)
 - [Puget Mesh](https://PugetMesh.org)
 
 ### Washington DC


### PR DESCRIPTION
Added new group "LINC" under "Washington." We satisfy the requirements, other than we do not have a Discord server, so the invite link requirement doesn't apply.