### PR TITLE
Fix broken internal link in FAQ

### DIFF
--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -121,7 +121,7 @@ export const Faq = {
     },
     {
       title: "Where do I purchase the device hardware?",
-      content: `Each [supported device](/docs/hardware/devices) has a "Purchase Link".`,
+      content: `Each [supported device](/docs/hardware/devices/) has a "Purchase Link".`,
     },
     {
       title:

--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -121,7 +121,7 @@ export const Faq = {
     },
     {
       title: "Where do I purchase the device hardware?",
-      content: `Each [supported device](/docs/hardware/devices/index.mdx) has a "Purchase Link".`,
+      content: `Each [supported device](/docs/hardware/devices) has a "Purchase Link".`,
     },
     {
       title:


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->
Fix link on FAQ pointing to supported hardware page. Removed the `/index.mdx` on the end.

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->
It was sending me to a 404 page.