### PR TITLE
Fix "Meshtastic Site Planner" doc

### DIFF
--- a/docs/software/site-planner/index.mdx
+++ b/docs/software/site-planner/index.mdx
@@ -14,7 +14,7 @@ The Meshtastic Site Planner is a open-source web utility for predicting node ran
 1. Go to the [official version](https://site.meshtastic.org) or run a development copy and open the tool in a web browser. 
 2. In `Site Parameters > Site / Transmitter`, enter a name for the site, the geographic coordinates, and the antenna height above ground. Refer to the Meshtastic regional parameters (https://meshtastic.org/docs/configuration/region-by-country/) and input the transmit power, frequency, and antenna gain for your device. 
 3. In `Site Parameters > Receiver`, enter the receiver sensitivity (`-130 dBm` for the default `LongFast` channel), the receiver height, and the receiver antenna gain.
-4. In `Site Parameters > Receiver`, enter the maximum range for the simulation in kilometers. Selecting long ranges (> 50 kilometers) will result in longer computation times.
+4. In `Simulation Options > Receiver`, enter the maximum range for the simulation in kilometers. Selecting long ranges (> 50 kilometers) will result in longer computation times.
 5. Press "Run Simulation." The coverage map will be displayed when the calculation completes. 
 
 Multiple radio sites can be added to the simulation by repeating these steps. The other adjustable parameters default to sensible choices for meshtastic radios, but you can change them if your project uses different hardware. 


### PR DESCRIPTION
Fix the documentation so that it is accurate to the current version deployed at https://site.meshtastic.org/

## Why did you change it
To let the documentation reflect the currently deployed version of the page. So that new users find options easier.