### PR TITLE
Add AlsaMesh as French local group

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -135,6 +135,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ## France
 
+- [AlsaMesh](https://alsamesh.org)
 - [Autour de Meshtastic - Telegram](https://t.me/+EYBkU17mlcU2MWI8)
 - [Collectif Meshtastic France](https://www.facebook.com/groups/meshtastic.france)
 - [Réseau Gaulix - Telegram](https://t.me/+bkCEaiI-i-Q2ZTBk)


### PR DESCRIPTION
## What did you change

This pull request add [AlsaMesh](https://alsamesh.org) as French local group. This community focus on developing a Meshtatic mesh in Alsace and create bridges with neighboring countries like Germany and Switzerland.

