### PR TITLE
Add Debian 13 Linux docs

### DIFF
--- a/docs/blocks/_linux-install.mdx
+++ b/docs/blocks/_linux-install.mdx
@@ -7,7 +7,16 @@ import { Icon } from "@iconify/react";
     Debian packages are provided via [OpenSUSE Build Service](https://build.opensuse.org/project/show/network:Meshtastic:beta).
      [![Debian build status](https://build.opensuse.org/projects/network:Meshtastic:beta/packages/meshtasticd/badge.svg?type=percent)](https://build.opensuse.org/package/show/network:Meshtastic:beta/meshtasticd)
 
-    Supported: `bookworm` (12)
+    Supported: `trixie` (13), `bookworm` (12)
+
+    **Install - Debian 13 (`trixie`):**
+
+    ```shell
+    echo 'deb http://download.opensuse.org/repositories/network:/Meshtastic:/beta/Debian_13/ /' | sudo tee /etc/apt/sources.list.d/network:Meshtastic:beta.list
+    curl -fsSL https://download.opensuse.org/repositories/network:Meshtastic:beta/Debian_13/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/network_Meshtastic_beta.gpg > /dev/null
+    sudo apt update
+    sudo apt install meshtasticd
+    ```
 
     **Install - Debian 12 (`bookworm`):**
 
@@ -23,9 +32,9 @@ import { Icon } from "@iconify/react";
 
       These builds are provided without support, please **do not file issues** relating to Experimental builds.
 
-      Experimental Support: `trixie` (testing), `sid` (unstable)
+      Experimental Support: `forky` (testing), `sid` (unstable)
 
-      **Install - Debian 13 (`trixie`):**
+      **Install - Debian 14 (`forky`):**
 
       ```shell
       echo 'deb http://download.opensuse.org/repositories/network:/Meshtastic:/beta/Debian_Testing/ /' | sudo tee /etc/apt/sources.list.d/network:Meshtastic:beta.list


### PR DESCRIPTION
Add docs for [Debian 13](https://www.debian.org/News/2025/20250809) installation.

`meshtasticd` is building happily for Debian 13 :muscle:
https://build.opensuse.org/package/show/network:Meshtastic:beta/meshtasticd