### PR TITLE
docs: fix typo that incorrectly names an already used pin for mosfet gate

### DIFF
--- a/docs/hardware/devices/heltec-automation/lora32/peripherals.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/peripherals.mdx
@@ -65,7 +65,7 @@ Note: these instructions assume a 2N7000 MOSFET is used. For other parts, always
 3.  Solder a wire from the VCC pin on the GPS module to 3V/5V pin on Heltec board.
 4.  Solder a wire from Right leg (lead 3, Drain) of NPN MOSFET to GND on GPS module.
 5.  Solder a wire from Left leg (lead 1, Source) of NPN MOSFET to GND on Heltec board.
-6.  Solder a wire from Middle leg (lead 2, Gate) of NPN MOSFET to GPIO 48 of Heltec board. (Another GPIO pin may be chosen)
+6.  Solder a wire from Middle leg (lead 2, Gate) of NPN MOSFET to GPIO 46 of Heltec board. (Another GPIO pin may be chosen)
 7.  Go to Meshtastic app > Radio Configurations > Position
 8.  Set GPS_RX_PIN to 48 (This will communicate to the TXD pin on the GPS)
 9.  Set GPS_TX_PIN to 47 (This will communicate to the RXD pin on the GPS)


### PR DESCRIPTION
https://meshtastic.org/de/docs/hardware/devices/heltec-automation/lora32/peripherals/#instructions-through-hole-mosfet states:

```
1. Solder a wire from the TXD pin on the GPS module to GPIO 48 on Heltec board. [...]
...
6. Solder a wire from Middle leg (lead 2, Gate) of NPN MOSFET to GPIO 48 of Heltec board. [...]
....
10. Set PIN_GPS_EN to 46 [...]
```

Since GPIO 48 is already soldered to GPS TXD and given the instruction to set PIN_GPS_EN to 46, I'm pretty sure bullet point six should actually say to solder to GPIO 46.