### PR TITLE
changed name

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -407,7 +407,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ### Utah
 
-- [The Intermountain Mesh](https://freq51.net/)
+- [Intermountain Mesh](https://freq51.net/)
 
 ### Virginia
 


### PR DESCRIPTION
Removed The from our name.

<!-- Add or remove sections as needed -->
Removed "the" from group name

<!-- Describe what your changes will do if merged -->
Will not have the in front of it
## Why did you change it
incorrectly named.

## Screenshots
### Before


### After
