### PR TITLE
Update power.mdx

### DIFF
--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -112,6 +112,7 @@ Should be set to floating point value between 2 and 6
       | rak4631 | 1.73 |
       | rpipico | 3.1 |
       | rpipicow | 3.1 |
+      | seeed xiao nrf52840 | 3.1 |
       | station-g1 | 6.45 |
       | station-g2 | 4 |
       | tlora_v2_1_16 | 2 |


### PR DESCRIPTION
added default adc multipliers value for seeed xiao nrf52840

<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->

## Screenshots
### Before


### After
