### PR TITLE
Add csv deletion to range test config

### DIFF
--- a/docs/configuration/module/range-test.mdx
+++ b/docs/configuration/module/range-test.mdx
@@ -23,7 +23,7 @@ Be sure to turn off the module or disable sending when not in use. This will use
 
 :::
 
-The range test module config options are: Enabled, Sender, and Save. Range Test Module config uses an admin message sending a `ModuleConfig.RangeTestConfig` protobuf.
+The range test module config options are: `enabled`, `sender`, `save` and `clear_on_reboot`. Range Test Module config uses an admin message sending a `ModuleConfig.RangeTestConfig` protobuf.
 
 ## Range Test Module Config Values
 
@@ -57,6 +57,18 @@ If enabled, all received messages are saved to the device's flash memory in a fi
 To access this file, first turn on the WiFi on your device and connect to your network. Once you can connect to your device, navigate to `meshtastic.local/rangetest.csv` (or your_device_ip/rangetest.csv) and the file will be downloaded automatically. This file will only be created after receiving initial messages.
 
 To prevent filling up the storage, the device will abort writing if there is less than 50kb of space on the filesystem.
+
+### Remove CSV file
+
+:::info
+
+**Leave disabled when using the Android or Apple apps.** Removes the file directly from the device's flash memory, and is only available on ESP32-based devices.
+
+**Backup past tests.** This action is irreversible. Make sure you have downloaded any important test results from your device prior to deletion.
+
+:::
+
+If enabled, any previously created `rangetest.csv` file is removed from the device whenever a reboot is invoked; effectively deleting any past test results.
 
 ## Range Test Module Config Client Availability
 


### PR DESCRIPTION
## What did you change
This PR includes information regarding usage of the range test module's new `clear_on_reboot` configuration option which has been merged into protobufs. There is a PR open in the firmware repository which implements this change.

## Why did you change it
These changes warranted updates to the docs
- https://github.com/meshtastic/protobufs/pull/757
- https://github.com/meshtastic/firmware/pull/7703

## Screenshots
### Before
<img width="1899" height="931" alt="image" src="https://github.com/user-attachments/assets/243b94e1-a65b-4d88-8894-00d0dbf88d14" />


### After
<img width="1922" height="960" alt="image" src="https://github.com/user-attachments/assets/be295747-4051-4fca-8486-9883fc27401f" />
