### PR TITLE
Mention signalk-meshtastic as an integration

### DIFF
--- a/docs/software/integrations/index.mdx
+++ b/docs/software/integrations/index.mdx
@@ -15,6 +15,6 @@ Current Meshtastic integrations:
 
 - [MQTT](/docs/software/integrations/mqtt) - Bridging mesh networks over the internet and integrating Meshtastic protocols with popular technologies such as Home Assistant, Node Red, and Adafruit IO.
 
-- [signalk-meshtastic](https://github.com/meri-imperiumi/signalk-meshtastic#readme) - Integrates the Signal K marine data ecosystem with Meshtastic to enable telemetry and alerting over LoRa
+- [signalk-meshtastic](https://github.com/meri-imperiumi/signalk-meshtastic#readme) - Integrates the Signal K marine data ecosystem with Meshtastic to enable telemetry and alerting over LoRa. [Read more](https://signalk.org/2025/signalk-meshtastic/)
 
 Support for the integrated products should be sought from their respective authors or vendors.


### PR DESCRIPTION
## What did you change
Added link to [signalk-meshtastic](https://github.com/meri-imperiumi/signalk-meshtastic#readme) in the integrations list

## Why did you change it
This is a relatively comprehensive integration that allows boats running [Signal K](https://signalk.org) to transmit telemetry and alerts to crew over Meshtastic.
