### PR TITLE
Fix Broken Anchors

### DIFF
--- a/docs/about/contributing.mdx
+++ b/docs/about/contributing.mdx
@@ -21,7 +21,7 @@ Meshtastic is a team of volunteers, and as such there are always plenty of ways 
 - If you're into Python, check out the link to the repo below
 - If you're into SwiftUI, check out the link to the repo below
 - If you're into Ham Radio and LoRa, then this is a great project for you!
-- If you're a datacentre sysadmin, we need machines for [github runners](/docs/development/github#runner).
+- If you're a datacentre sysadmin, we need machines for [github runners](/docs/development/github#requirement-for-self-hosted-runners).
 - ... basically... we would love to have your help and feedback
 
 There are several developers, testers, and active users on [Discord](https://discord.gg/ktMAKGBnBs).

--- a/docs/blocks/_linux-install.mdx
+++ b/docs/blocks/_linux-install.mdx
@@ -305,5 +305,5 @@ import { Icon } from "@iconify/react";
 
 [MUI]: /docs/software/meshtastic-ui/
 [WebClient]: /docs/software/web-client/
-[USBRadio]: #usb
-[SPIRadio]: #spi-raspberry-pi
+[USBRadio]: /docs/hardware/devices/linux-native-hardware/
+[SPIRadio]: /docs/hardware/devices/linux-native-hardware/

--- a/docs/blocks/_linux-install.mdx
+++ b/docs/blocks/_linux-install.mdx
@@ -66,7 +66,7 @@ import { Icon } from "@iconify/react";
     :::warning
     These builds are only suitable for 32-bit *armhf* Raspberry Pi OS installations.
 
-    For **64-bit** Raspberry Pi OS installations, please use the [<Icon icon="mdi:debian"/> Debian](./?os=debian#installing-meshtasticd) packages.
+    For **64-bit** Raspberry Pi OS installations, please use the [<Icon icon="mdi:debian"/> Debian](/docs/software/linux/installation/?os=debian#installing-meshtasticd) packages.
     :::
 
     | Feature                  | Status |


### PR DESCRIPTION
This PR fixes a few broken anchor links that showed up as warnings in the build log:

```Run pnpm run build

> meshtastic@0.0.0 build /home/runner/work/meshtastic/meshtastic
> docusaurus build

[INFO] Website will be built for all these locales: 
- en
- cs-CZ
- de
- pl-PL
- sk-SK
- tr-TR
- zh-CN
- zh-TW
[INFO] [en] Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Warning:  Docusaurus found broken anchors!

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /docs/contributing/:
   -> linking to /docs/development/github/#runner
- Broken anchor on source page path = /docs/software/linux/installation/:
   -> linking to #usb (resolved as: /docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /docs/software/linux/installation/?os=debian#installing-meshtasticd)

[SUCCESS] Generated static files in "build".
[INFO] [cs-CZ] Creating an optimized production build...
Warning:  Docusaurus found broken anchors!

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /cs-CZ/docs/contributing/:
   -> linking to /cs-CZ/docs/development/github/#runner
- Broken anchor on source page path = /cs-CZ/docs/software/linux/installation/:
   -> linking to #usb (resolved as: /cs-CZ/docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /cs-CZ/docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /cs-CZ/docs/software/linux/installation/?os=debian#installing-meshtasticd)

[SUCCESS] Generated static files in "build/cs-CZ".
[INFO] [de] Creating an optimized production build...
Warning:  Docusaurus found broken anchors!

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /de/docs/contributing/:
   -> linking to /de/docs/development/github/#runner
- Broken anchor on source page path = /de/docs/software/linux/installation/:
   -> linking to #usb (resolved as: /de/docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /de/docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /de/docs/software/linux/installation/?os=debian#installing-meshtasticd)

[SUCCESS] Generated static files in "build/de".
[INFO] [pl-PL] Creating an optimized production build...
Warning:  Docusaurus found broken anchors!

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /pl-PL/docs/contributing/:
   -> linking to /pl-PL/docs/development/github/#runner
- Broken anchor on source page path = /pl-PL/docs/software/linux/installation/:
   -> linking to #usb (resolved as: /pl-PL/docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /pl-PL/docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /pl-PL/docs/software/linux/installation/?os=debian#installing-meshtasticd)

[SUCCESS] Generated static files in "build/pl-PL".
[INFO] [sk-SK] Creating an optimized production build...
Warning:  Docusaurus found broken anchors!

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /sk-SK/docs/contributing/:
   -> linking to /sk-SK/docs/development/github/#runner
- Broken anchor on source page path = /sk-SK/docs/software/linux/installation/:
   -> linking to #usb (resolved as: /sk-SK/docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /sk-SK/docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /sk-SK/docs/software/linux/installation/?os=debian#installing-meshtasticd)

[SUCCESS] Generated static files in "build/sk-SK".
[INFO] [tr-TR] Creating an optimized production build...
Warning:  Docusaurus found broken anchors!

[SUCCESS] Generated static files in "build/tr-TR".
Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.
[INFO] [zh-CN] Creating an optimized production build...

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /tr-TR/docs/contributing/:
   -> linking to /tr-TR/docs/development/github/#runner
- Broken anchor on source page path = /tr-TR/docs/software/linux/installation/:
   -> linking to #usb (resolved as: /tr-TR/docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /tr-TR/docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /tr-TR/docs/software/linux/installation/?os=debian#installing-meshtasticd)

Warning:  Docusaurus found broken anchors!
[SUCCESS] Generated static files in "build/zh-CN".

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /zh-CN/docs/contributing/:
   -> linking to /zh-CN/docs/development/github/#runner
- Broken anchor on source page path = /zh-CN/docs/software/linux/installation/:
   -> linking to #usb (resolved as: /zh-CN/docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /zh-CN/docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /zh-CN/docs/software/linux/installation/?os=debian#installing-meshtasticd)

[INFO] [zh-TW] Creating an optimized production build...
Warning:  Docusaurus found broken anchors!

Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.
[SUCCESS] Generated static files in "build/zh-TW".

Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /zh-TW/docs/contributing/:
   -> linking to /zh-TW/docs/development/github/#runner
- Broken anchor on source page path = /zh-TW/docs/software/linux/installation/:
   -> linking to #usb (resolved as: /zh-TW/docs/software/linux/installation/#usb)
   -> linking to #spi-raspberry-pi (resolved as: /zh-TW/docs/software/linux/installation/#spi-raspberry-pi)
   -> linking to ./?os=debian#installing-meshtasticd (resolved as: /zh-TW/docs/software/linux/installation/?os=debian#installing-meshtasticd)

[INFO] Use `npm run serve` command to test your build locally.```