### PR TITLE
Linux: Add Raspbian warnings to install instructions

### DIFF
--- a/docs/blocks/_linux-install.mdx
+++ b/docs/blocks/_linux-install.mdx
@@ -27,6 +27,7 @@ import { Icon } from "@iconify/react";
     **Install - Debian 12 (`bookworm`):**
 
     ```shell
+    [[ "$(. /etc/os-release && echo $NAME)" == Raspbian* ]] && echo "ERROR: Raspberry Pi OS (32-bit) detected, please use the Raspbian repos."
     echo 'deb http://download.opensuse.org/repositories/network:/Meshtastic:/beta/Debian_12/ /' | sudo tee /etc/apt/sources.list.d/network:Meshtastic:beta.list
     curl -fsSL https://download.opensuse.org/repositories/network:Meshtastic:beta/Debian_12/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/network_Meshtastic_beta.gpg > /dev/null
     sudo apt update
@@ -81,6 +82,7 @@ import { Icon } from "@iconify/react";
     **Install - Raspbian 12 (`bookworm`):**
 
     ```shell
+    [[ "$(. /etc/os-release && echo $NAME)" != Raspbian* ]] && echo "ERROR: Raspberry Pi OS (32-bit) not detected, please use the Debian repos."
     echo 'deb http://download.opensuse.org/repositories/network:/Meshtastic:/beta/Raspbian_12/ /' | sudo tee /etc/apt/sources.list.d/network:Meshtastic:beta.list
     curl -fsSL https://download.opensuse.org/repositories/network:Meshtastic:beta/Raspbian_12/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/network_Meshtastic_beta.gpg > /dev/null
     sudo apt update


### PR DESCRIPTION
Simple change: Add warnings to the installation instructions for Raspberry Pi OS 12 and Debian 12.


When installing from the Debian 12 repo on a Raspbian 32-bit OS, the following will be echo'd:
> ERROR: Raspberry Pi OS (32-bit) detected, please use the Raspbian repos.

When installing from the Raspbian 12 repo without 32-bit Raspbian OS, the following will be echo'd:
> ERROR: Raspberry Pi OS (32-bit) not detected, please use the Debian repos.


This is possible because in `/etc/os-release` on 64-Bit Raspbian `NAME=Debian GNU/Linux` and on 32-Bit Raspbian `NAME=Raspbian GNU/Linux`

As written, this does not halt the installation, and simply presents the error message :sweat_smile: 