### PR TITLE
Add TinyTronics purchase links

### DIFF
--- a/docs/hardware/devices/heltec-automation/lora32/index.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/index.mdx
@@ -358,6 +358,8 @@ This device may have issues charging a connected battery if utilizing a USB-C to
 - Purchase Links:
   - US
     - [Rokland](https://msh.to/rokland-heltec-wireless-paper/)
+  - Europe
+    - [TinyTronics](https://www.tinytronics.nl/index.php?route=product/product&product_id=5327)
   - International
     - [Heltec](https://msh.to/heltec-wireless-paper/)
     - [AliExpress](https://msh.to/aliexpress-heltec-wireless-paper/)

--- a/docs/hardware/devices/heltec-automation/mesh-node/index.mdx
+++ b/docs/hardware/devices/heltec-automation/mesh-node/index.mdx
@@ -59,6 +59,8 @@ values={[
 - Purchase links
   - US
     - [muzi ᴡᴏʀᴋꜱ](https://msh.to/muzi-heltec-mesh-node-t114/)
+  - Europe
+    - [TinyTronics](https://www.tinytronics.nl/index.php?route=product/product&product_id=6653)
   - International
     - [Heltec](https://msh.to/heltec-mesh-node-t114/)
     - [AliExpress](https://msh.to/aliexpress-heltec-mesh-node-t114/)


### PR DESCRIPTION
## What did you change
I have added TinyTronics as a source for the Heltec v3 and mesh node T114. I have verified that the T114 can be bought and works.

## Why did you change it
I was missing a vendor in europe, which ships a bit faster than AliExpress.
