### PR TITLE
Update ota.mdx

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/ota.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/ota.mdx
@@ -66,22 +66,20 @@ OTA firmware updates are available for Android using an older release of the mor
 
 #### Apple
 
-OTA firmware updates are available on iOS & iPadOS using the nRF Device Firmware Update App available through the [Apple App Store](https://apps.apple.com/us/app/nrf-device-firmware-update/id1624454660)
+OTA firmware updates are available on iOS & iPadOS using the nRF Device Firmware Update App available through the [Apple App Store](https://apps.apple.com/us/app/nrf-device-firmware-update/id1624454660). Note that if the OTA update fails your device may stop working until you gain physical access to it and upload firmware over USB.
 
 1. Download the firmware release you wish to install from the [Meshtastic Download Page](/downloads), [Meshtastic GitHub](https://github.com/meshtastic/firmware/releases), or via the iOS or iPadOS app.
 2. Unzip the firmware folder
 3. Open the nRF DFU App and select the correct device firmware file (will end with -ota.zip)
-4. In the nRF DFU Settings (in the upper right hand corner) enable "Packets receipt notification" and set the "Numer of Packets" to 10 or less. If your device is hard to get to, then start with a low number until you know it works; if the number is too high you might lock up your device and require a physical connection to flash the firmware.
-5. Connect to your device
-6. Upload the firmware. This can take 5 minutes.
+4. Connect to your device
+5. Upload the firmware
 
 :::Info
-On the iPhone interrupting the upload can cause it to fail. You should consider turning on Airplane mode and disabling WiFi to prevent interruptions during the upload. Also, the iPhone's auto-lock feature could potentially interrupt the Bluetooth firmware upload. To avoid this, occasionally tap on your screen, or temporarily set the auto-lock to "Never" during the upload process to ensure that the phone stays awake and the upload completes without interruption. 
+With the iPhone, interrupting the OTA upload can cause it to fail and leave your device in a non-working state. If your node is difficult to reach physically (such as on a roof top) you should follow the steps below before beginning the firmware upload to increase your chances of a successful OTA update.
 :::
+1. In the nRF Device Firmware Update App application Settings (in the upper right hand corner) enable "**Packets receipt notification**" and set the "**Numer of Packets**" to 5. 
+2. Turn on Airplane mode and disable WiFi to prevent interruptions during the upload. 
+3. The iPhone's auto-lock feature could potentially interrupt the Bluetooth firmware upload. To avoid this, occasionally tap on your screen, or temporarily set the auto-lock to "Never" during the upload process to ensure that the phone stays awake and the upload completes without interruption. 
 
-If the update fails, you may find that adjusting the packet settings can help:
-
-1. In settings, enable "**Packets Receipt Notification**". 
-2. Change "**Number of Packets**" to a lower value. Some users report success with "5". 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Make the change to Packets Receipt Notification a normal part of the process. 

## What did you change
Moved the recommendation to change packets receipt notification to a recommended step rather than an after failure action since a failure can brick the device.

## Why did you change it
I did this because a failure during OTA update can fail in a way that requires physical access to the device to recover. It seems better to make this a regular step rather than expose the user to a greater chance of failure.
