### PR TITLE
Update range-test.mdx - Added that Unset is the default on Apple apps

### DIFF
--- a/docs/configuration/module/range-test.mdx
+++ b/docs/configuration/module/range-test.mdx
@@ -33,7 +33,7 @@ Enables the range test module. **Both Sender and Receiver must have the module e
 
 ### Sender Interval
 
-How long to wait between sending sequential test packets. 0 is default which disables sending messages.
+How long to wait between sending sequential test packets. 0 is default which disables sending messages ("Unset" in the Apple apps).
 
 ### Recommended Sender Settings
 


### PR DESCRIPTION
Added that "Unset" is the default in the Apple apps; 0 is not an option.

## Why did you change it
Documentation said 0 is the default Sender interval, but that is not a choice in the Apple apps.
