### PR TITLE
Update the build guide to also suggest installing Git

### DIFF
--- a/docs/development/firmware/building.mdx
+++ b/docs/development/firmware/building.mdx
@@ -9,12 +9,13 @@ Meshtastic uses [PlatformIO](https://platformio.org), a development environment 
 
 ## Setup the Build Environment
 
-1. [Install PlatformIO](https://platformio.org/platformio-ide)
-2. Clone the [Meshtastic Firmware](https://github.com/meshtastic/firmware) repository
+1. [Install Git](https://git-scm.com/downloads)
+2. [Install PlatformIO](https://platformio.org/platformio-ide)
+3. Clone the [Meshtastic Firmware](https://github.com/meshtastic/firmware) repository
    ```shell
    git clone https://github.com/meshtastic/firmware.git
    ```
-3. Update the repository's [submodules](https://github.com/meshtastic/firmware/blob/master/.gitmodules)
+4. Update the repository's [submodules](https://github.com/meshtastic/firmware/blob/master/.gitmodules)
    ```shell
    cd firmware && git submodule update --init
    ```


### PR DESCRIPTION
## What did you change
Add a suggestion to install Git first to the building firmware guide.

## Why did you change it
Some people might not have Git installed if they're not already developers and it's not obvious for Windows users where to get it.