### PR TITLE
Remove meshenvy.org grifter

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -380,7 +380,6 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 - [LASmesh](https://lasmesh.com)
 - [VegasMesh Discord](https://discord.gg/vUmWuZxYPh)
-- [MeshEnvy Statewide Group](https://meshenvy.org)
 
 ### New Hampshire
 


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
Removed meshenvy.org entry from local groups page

## Why did you change it
This "local group" claims to grant "Network usage privileges" for $10 USD contributions.

See https://meshenvy.org/fundraiser

Meshtastic shouldn't link to someone trying to run a grift off of a FOSS project.

## Screenshots

<img width="1461" height="988" alt="meshenvy_screenshot" src="https://github.com/user-attachments/assets/af3a270e-953f-4ad0-aba8-5b07a9537848" />
