### PR TITLE
Fix formatting in RAK Wireless devices table

### DIFF
--- a/docs/hardware/devices/rak-wireless/index.mdx
+++ b/docs/hardware/devices/rak-wireless/index.mdx
@@ -17,12 +17,11 @@ Modular hardware system with Base, Core and Peripheral modules including the low
 | :-------------------------------------------------- | :------- | :----- | :----------: | :-: | :----: |
 | [RAK4631](./wisblock/core-module?rakcore=RAK4631)   | nRF52840 | SX1262 |      NO      | 5.0 | ADD-ON |
 | [RAK11200](./wisblock/core-module?rakcore=RAK11200) | ESP32    | ADD-ON | 2.4GHz b/g/n | 4.2 | ADD-ON |
-| [RAK11310](./wisblock/core-module?rakcore=RAK11310) | RP2040   | SX1262 |      NO      | NO  | ADD-ON |
-
-[**Base Boards**](./wisblock/base-board/)
+| [RAK11310](./wisblock/core-module?rakcore=RAK11310) | RP2040   | SX1262 |      NO      | NO  | ADD-| [**Base Boards**](./wisblock/base-board/)
 
 | Name                                                 | Type                                 |
 | :--------------------------------------------------- | :----------------------------------- |
+| [RAK3112](./wisblock/base-board?rakbase=RAK3112)     | WisBlock LoRaWAN Concentrator Base Board. |
 | [RAK5005-O](./wisblock/base-board?rakbase=RAK5005-O) | WisBlock Base Board (End Of life).   |
 | [RAK19007](./wisblock/base-board?rakbase=RAK19007)   | WisBlock Base Board (2nd Generation) |
 | [RAK19003](./wisblock/base-board?rakbase=RAK19003)   | WisBlock Mini Base Board.            |


### PR DESCRIPTION
New Row: Added RAK3112 with a query param ?rakbase=RAK3112to match the pattern (this assumes the linked page uses URL params for filtering, as in the originals).
•  Description: Kept it concise and Meshtastic-relevant, highlighting its LoRaWAN focus for mesh networking.

<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->

## Screenshots
### Before


### After
