### PR TITLE
Add EU distributor purchase link for Wisblock kit

### DIFF
--- a/docs/hardware/devices/rak-wireless/wisblock/index.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/index.mdx
@@ -31,6 +31,8 @@ Please see the RAK documentation for the correct way to connect your hardware to
   - Additional purchase links under specific base boards, core modules, and peripherals
 - **US:**
   - US Distributor Rokland [RAKwireless Starter Kit w/ Gen2 Base board](https://msh.to/rokland-meshtastic-starter-kit)
+- **EU:**
+  - EU Distributor Hexaspot [RAKwireless Starter Kit](https://hexaspot.com/collections/wisblock-kits/products/wisblock-meshtastic-starter-kit-eu868-the-basic-rak4631-meshtastic-kit-for-lora)
 - **International:**
   - RAKwireless Direct [RAKwireless Starter Kit w/ Gen2 Base board](https://msh.to/rak4631)
   - RAKwireless Direct [RAKwireless WisMesh RP2040 Starter Kit](https://msh.to/rak11310)


### PR DESCRIPTION
## What did you change

Added a link to a EU distributor

## Why did you change it

Because I think it might be beneficial for Europeans to orders Meshtastic devices from EU.
