### PR TITLE
Replace ReactPlayer YouTube embeds with responsive iframes and adjust Docusaurus config

### DIFF
--- a/docs/configuration/module/canned-message.mdx
+++ b/docs/configuration/module/canned-message.mdx
@@ -15,12 +15,27 @@ The Canned Message Module will allow you to send messages to the mesh network fr
 The canned message module config options are: Enabled, Send Bell, Messages, Input Source, Rotary Encoder Enabled, Up Down Encoder Enabled, Input Broker Pin A, Input Broker Pin B, Input Broker Pin Press, Input Broker Event Clockwise, Input Broker Event Counter Clockwise, and Input Broker Event Press. Canned Message config uses an admin message sending a `ConfigModule.CannedMessage` protobuf.
 
 <div style={{ maxWidth: "800px", margin: "auto" }}>
-  <ReactPlayer
-    url="https://youtu.be/qKQVYUbLLkg"
-    controls
-    width="100%"
-    height="400px"
-  />
+  <div
+    style={{
+      position: "relative",
+      paddingTop: "56.25%", // 16:9 aspect ratio
+    }}
+  >
+    <iframe
+      src="https://www.youtube.com/embed/qKQVYUbLLkg"
+      title="Meshtastic demo"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        border: 0,
+      }}
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  </div>
 </div>
 
 ## Canned Message Module Config Values

--- a/docs/configuration/module/external-notification.mdx
+++ b/docs/configuration/module/external-notification.mdx
@@ -15,12 +15,27 @@ The External Notification Module will allow you to connect a buzzer, speaker, LE
 The External Notification Module config options are: Enabled, Active, Alert Bell (General),Alert Bell Vibra, Alert Bell Buzzer, Alert Message (General), Alert Message Vibra, Alert Message Buzzer, Output (General), Output Vibra, Output Buzzer, Output Milliseconds, Use PWM, and Nag Timeout. External Notification config uses an admin message sending a `ConfigModule.ExternalNotificationConfig` protobuf.
 
 <div style={{ maxWidth: "800px", margin: "auto" }}>
-  <ReactPlayer
-    url="https://youtu.be/MWt3RHMpifo"
-    controls
-    width="100%"
-    height="400px"
-  />
+  <div
+    style={{
+      position: "relative",
+      paddingTop: "56.25%", // 16:9 aspect ratio
+    }}
+  >
+    <iframe
+      src="https://www.youtube.com/embed/MWt3RHMpifo"
+      title="Meshtastic demo"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        border: 0,
+      }}
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  </div>
 </div>
 
 ## External Notification Module Config Values

--- a/docs/configuration/module/serial.mdx
+++ b/docs/configuration/module/serial.mdx
@@ -17,12 +17,27 @@ This is an interface to talk to and control your Meshtastic device over a serial
 ![image](/img/modules/Serial/jet.webp)
 
 <div style={{ maxWidth: "800px", margin: "auto" }}>
-  <ReactPlayer
-    url="https://youtu.be/HdOiGKBtapw"
-    controls
-    width="100%"
-    height="400px"
-  />
+  <div
+    style={{
+      position: "relative",
+      paddingTop: "56.25%", // 16:9 aspect ratio
+    }}
+  >
+    <iframe
+      src="https://www.youtube.com/embed/HdOiGKBtapw"
+      title="Meshtastic demo"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        border: 0,
+      }}
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  </div>
 </div>
 
 ## Serial Module Config Values

--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -15,12 +15,27 @@ The Telemetry Module provides four types of data over the mesh: Device metrics (
 Supported sensors connected to the I2C bus of the device will be automatically detected at startup. The Environment Telemetry, Air Quality, and Health Telemetry modules must be enabled for them to be instrumented and their readings sent over the mesh.
 
 <div style={{ maxWidth: "800px", margin: "auto" }}>
-  <ReactPlayer
-    url="https://youtu.be/6jj1s-fsPlc"
-    controls
-    width="100%"
-    height="400px"
-  />
+  <div
+    style={{
+      position: "relative",
+      paddingTop: "56.25%", // 16:9 aspect ratio
+    }}
+  >
+    <iframe
+      src="https://www.youtube.com/embed/6jj1s-fsPlc"
+      title="Meshtastic demo"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        border: 0,
+      }}
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  </div>
 </div>
 
 ### Currently Supported Sensor Types

--- a/docs/configuration/module/traceroute.mdx
+++ b/docs/configuration/module/traceroute.mdx
@@ -21,12 +21,27 @@ In order to use it, make sure your devices use firmware version 2.0.8 or higher.
 From firmware version ≥ 2.5, the route back to the origin is recorded, along with the Signal-to-Noise Ratio (SNR) for each link. Nodes with older firmware or those unable to decrypt the traceroute will be shown as "Unknown" (represented by an ID equal to 4294967295 or 0xFFFFFFFF in hexadecimal) if all nodes in the route are using at least firmware version 2.3.12.
 
 <div style={{ maxWidth: "800px", margin: "auto" }}>
-  <ReactPlayer
-    url="https://youtu.be/PKUmaELKaUo"
-    controls
-    width="100%"
-    height="400px"
-  />
+  <div
+    style={{
+      position: "relative",
+      paddingTop: "56.25%", // 16:9 aspect ratio
+    }}
+  >
+    <iframe
+      src="https://www.youtube.com/embed/PKUmaELKaUo"
+      title="Meshtastic demo"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        border: 0,
+      }}
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  </div>
 </div>
 
 ## Repeater Behavior

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,6 @@ const config = {
   baseUrl: "/",
   trailingSlash: true,
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
   favicon: "design/web/favicon.ico",
   organizationName: "meshtastic",
   projectName: "meshtastic",


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->
- Replaced `ReactPlayer` YouTube embeds with responsive native YouTube `<iframe>` embeds in:
  - `docs/configuration/module/canned-message.mdx`
  - `docs/configuration/module/external-notification.mdx`
  - `docs/configuration/module/serial.mdx`
  - `docs/configuration/module/telemetry.mdx`
  - `docs/configuration/module/traceroute.mdx`
- Kept the same visual layout (centered, max width 800px, 16:9 aspect ratio).
- Updated `docusaurus.config.js` by removing the `onBrokenMarkdownLinks` option.

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->
Fixes #2122.

Switching from `ReactPlayer` to native iframes simplifies the embeds and avoids media-related console noise during navigation and hot reload while keeping the docs layout the same.

## Screenshots
### Before
<img width="960" height="480" alt="image" src="https://github.com/user-attachments/assets/3cd1c040-a1a7-4e44-9d00-38471a8e46f8" />
<img width="1175" height="301" alt="image" src="https://github.com/user-attachments/assets/c729601a-9927-4562-a81b-b58b8106cbd9" />


### After
<img width="1021" height="586" alt="image" src="https://github.com/user-attachments/assets/fcf270df-682e-46b3-b78a-fde60acad298" />

<img width="1178" height="244" alt="image" src="https://github.com/user-attachments/assets/754cc5cb-75dc-44a3-9bc3-9746289125ea" />