### PR TITLE
Revise OTA firmware update instructions for Android/iOS

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/ota.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/ota.mdx
@@ -44,21 +44,13 @@ OTA firmware updates come with an increased risk of failure. If the update proce
 
 #### Android
 
-:::info
-As of this writing, the current Android release of the nRF DFU app (v2.3.0) is not compatible with Meshtastic firmware updates. Please use the instructions below for updating via OTA with the nRF Connect App.
-:::
+OTA firmware updates are available for Android using the nRF DFU application in the Play Store.
 
-OTA firmware updates are available for Android using an older release of the more advanced nRF Connect App **version 4.24.3** which is available for download from the [Nordic Semiconductor GitHub page](https://github.com/NordicSemiconductor/Android-nRF-Connect/releases/tag/v4.24.3).
-
-1. Download the firmware release you wish to install from the [Meshtastic Download Page](/downloads) or [Meshtastic GitHub](https://github.com/meshtastic/firmware/releases).
+1. Download the firmware release you wish to install from the [Meshtastic Download Page](/downloads), [Meshtastic GitHub](https://github.com/meshtastic/firmware/releases)
 2. Unzip the firmware folder
-3. Open the nRF Connect App and select CONNECT on your device from the SCANNER tab
-4. If the top right corner of the interface that is shown says DISCONNECT, proceed to step 5, if it says CONNECT, select CONNECT
-5. Select the DFU icon from the top-right of the screen
-6. Select OK after verifying that "Distribution Packet (ZIP)" is selected
-7. Select the correct device firmware file (will end with -ota.zip)
-8. The update will start automatically (this will be slow)
-9. Once the update is complete, the device will reboot automatically
+3. Open the nRF DFU App and select the correct device firmware file (will end with -ota.zip)
+4. Connect to your device
+5. Upload the firmware (this will take a while)
 
 </TabItem>
 
@@ -72,7 +64,7 @@ OTA firmware updates are available on iOS & iPadOS using the nRF Device Firmware
 2. Unzip the firmware folder
 3. Open the nRF DFU App and select the correct device firmware file (will end with -ota.zip)
 4. Connect to your device
-5. Upload the firmware
+5. Upload the firmware (this will take a while)
 
 The iPhone's auto-lock feature could potentially interrupt the Bluetooth firmware upload. To avoid this, occasionally tap on your screen, or temporarily set the auto-lock to "Never" during the upload process to ensure that the phone stays awake and the upload completes without interruption.
 


### PR DESCRIPTION
Updated instructions for OTA firmware updates on Android and iOS, clarifying app versions and steps.

<!-- Add or remove sections as needed -->
## What did you change
Changed instructions for android to the new nRF DFU app (has worked on Android for a while now), and improved consistency between iOS and Android wiki pages due to using the same app.

## Why did you change it
The new app functions just as nicely, if not more reliably.