### PR TITLE
Update LoRa documentation for node ignoring options

### DIFF
--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -117,7 +117,7 @@ This setting controls the actual hardware frequency at which the radio transmits
 For testing it is useful sometimes to force a node to never listen to particular other nodes (simulating radio out of range). All nodenums listed in the ignore_incoming array will have packets they send dropped on receive (by router.cpp)
 
 :::note
-This option is **deprecated** in the mobile apps; however, the recommended way to ignore nodes is to use the newer option of marking a node as ignored in the apps. This acts the same as the ignore list (blocking packets from the ignore node from being received or relayed), with the added benefit of being able to ignore a lot more nodes.
+This option is **deprecated** in the client apps.  To ignore nodes, long-press on (or click for web client) a node and mark it as ignored. This acts the same as the ignore list (blocking packets from the ignore node from being received or relayed), with the added benefit of being able to ignore more than three nodes.
 :::
 
 ### Ignore MQTT


### PR DESCRIPTION
Clarified the note about ignoring nodes in iOS to recommend users to use the newer ignore nodes function.