### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -329,7 +329,6 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ### Georgia
 
-- [Mountain Mesh - Metro Atlanta / Athens / North GA](https://mtnme.sh)
 - [CSRA Mesh - Augusta, GA/North Augusta, SC Area](https://discord.gg/rQSTQDZKgs)
 - [Georgia Statewide Mesh Coalition - Encompassing all of Georgia](https://gamesh.net)
 - [Southeast Georgia Mesh (SEGAMesh)](https://smp8.simplex.im/g#1k2HC-3aeDnq-U3M3xpAx6GUGSKEXXX1ZylkYswlWgo)


### PR DESCRIPTION
I'm requesting the removal of Mtn Mesh from the community list.  

I recently joined this mesh, made contact, ran a couple Traceroutes, and found all of my nodes blocked. When checking the discord, I found that this mesh group is blocking all new nodes because of "hostile emi".  When I switched to longfast (mtn mesh operates on mediumfast) I found that every message sent is replied to by a bot running on a router that states "Mtn Mesh has moved to MediumFast". Blocking this bot has the effect of locking yourself out from the local routers that remain on longfast.

The decision to submit this request does not come lightly. This is an issue that myself and countless others are currently dealing with. This Mesh group has proven to be actively hostile towards newcomers, and any node the group doesn't approve of. As such, I don't believe such a closed group should be advertised on the Meshtastic communities group. 

Thank you for your consideration.

<!-- Add or remove sections as needed -->
Mtn Mesh removed from listing
<!-- Describe what your changes will do if merged -->

## Why did you change it
Mtn Mesh has changed to a closed community, actively blocking new nodes that join. 

## Screenshots
### Before


### After
