### PR TITLE
docs: Frequency Calculator - Initialize the Frequency Slot input to the Default Frequency Slot instead of the First Available Slot

### DIFF
--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -389,6 +389,7 @@ export const FrequencyCalculator = (): JSX.Element => {
         calculatedNumChannels,
       );
       setDefaultSlot(defaultSlot);
+      setChannel(defaultSlot);
     }
   }, [modemPreset, region]);
 


### PR DESCRIPTION
Initialize the Frequency Slot to the Default Frequency Slot when a new Modem Preset or Region is chosen instead of the First Available Slot. Does not affect any other functionality.

## What did you change

I changed src/components/tools/FrequencyCalculator.tsx to initialize the Frequency Slot to the Default Frequency Slot when a new Modem Preset or Region is selected.

## Why did you change it

Before the change, when the user selects a Modem Preset and a Region they are presented with the Default Frequency Slot and Number of Slots, but the Frequency Slot below that for the actual frequency calculator is initialized to the first available slot instead of the default slot. This can and has lead to some confusion. Let me know if you'd like some source on that claim, but I hope to demonstrate this through the screenshots.

After the change, when the user selects a Modem Preset and a Region they are presented with the Default Frequency Slot and Number of Slots as before, and the Frequency Slot below that for the actual frequency calculator is initialized to the default slot instead of the first available slot. This

## Screenshots
### Before
User selects LONG_FAST, US

<img width="436" height="368" alt="image" src="https://github.com/user-attachments/assets/50543f61-0703-4b0c-820a-724f273a36a2" />

Frequency Slot is initialized to the first available channel.

User selects LONG_FAST, CN

<img width="446" height="376" alt="image" src="https://github.com/user-attachments/assets/82a8c802-a333-4cd5-9a5a-5a0cdf7a4657" />

Frequency Slot is initialized to the first available channel.

### After

User selects LONG_FAST, US

<img width="448" height="369" alt="image" src="https://github.com/user-attachments/assets/fe2958cd-46a5-4e7c-b330-54df4063168a" />

Frequency Slot is initialized to the default channel.

User selects LONG_FAST, CN

<img width="451" height="368" alt="image" src="https://github.com/user-attachments/assets/f1f4bf6c-21c7-4bd7-b1d0-e408f11e4a04" />

Frequency Slot is initialized to the default channel.

## Disclaimers

I'm not very good at React nor TypeScript. There may be a better way to do this. I did test this locally using the instructions at https://meshtastic.org/docs/development/documentation/local-dev/ before submitting.