### PR TITLE
Add NoCo Mesh to local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -322,6 +322,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 - [Denver Mesh](https://denvermesh.org)
 - [Colorado Springs Meshtastic Network](https://www.facebook.com/groups/cosmeshtastic)
+- [Northern Colorado Mesh Group](https://nocomesh.org)
 
 ### Connecticut
 


### PR DESCRIPTION
## What did you change

- Added [Northern Colorado Mesh Group](https://nocomesh.org) to local-groups.mdx

## Why did you change it

- A new community dedicated to Northern Colorado was recently formed

## Screenshots
### Before

<img width="3379" height="1295" alt="image" src="https://github.com/user-attachments/assets/7f26d101-c5bd-4c72-be5c-aa87ddaaab09" />


### After

<img width="3381" height="1323" alt="image" src="https://github.com/user-attachments/assets/052b7be1-a549-43a3-9c03-d071c4010a0e" />