### PR TITLE
add libsqlite3-dev to native deps

### DIFF
--- a/docs/blocks/_native-libraries.mdx
+++ b/docs/blocks/_native-libraries.mdx
@@ -7,7 +7,7 @@ The following libraries must be installed before building `meshtasticd` or `nati
   <TabItem value="debian" label={<><Icon icon="mdi:debian" style={{ marginRight: "0.25rem" }} height="1.5rem" /> Debian</>} default>
   ```shell
   # Base dependencies
-  sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev libuv1-dev libxkbcommon-dev libinput-dev
+  sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev libuv1-dev libxkbcommon-dev libinput-dev libsqlite3-dev
   # Optional dependencies for web server support
   sudo apt install openssl libssl-dev libulfius-dev liborcania-dev
   # Optional dependencies for sdl support


### PR DESCRIPTION
This PR add libsqlite3-dev as a required dependency for native builds per: https://github.com/meshtastic/firmware/pull/9328