### PR TITLE
Add a section about computing the AES-128 key for one byte long AES keys.

### DIFF
--- a/docs/development/reference/encryption-technical.mdx
+++ b/docs/development/reference/encryption-technical.mdx
@@ -82,7 +82,6 @@ PSKs and the expanded use of PKC and session IDs across different MCU architectu
 ### One byte long PSK
 
 Meshtastic supports 1, 16 and 32 byte long AES PSKs.
-The last two select between AES-128 and AES-256 respectively.
 
 However, for single-byte PSKs, such as the default `AQ==`, the system actually replaces the input with a hardcoded [AES-128 or AES-256 key](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.h#L143-L149) based on the settings.
 

--- a/docs/development/reference/encryption-technical.mdx
+++ b/docs/development/reference/encryption-technical.mdx
@@ -84,6 +84,6 @@ PSKs and the expanded use of PKC and session IDs across different MCU architectu
 Meshtastic supports 1, 16 and 32 byte long AES PSKs.
 The last two select between AES-128 and AES-256 respectively.
 
-However for the one byte long PSKs such as the default `AQ==`, it actually replaces it with a hardcoded [AES-128 or AES-256 key](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.h#L143-L149) based on the settings.
+However, for single-byte PSKs, such as the default `AQ==`, the system actually replaces the input with a hardcoded [AES-128 or AES-256 key](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.h#L143-L149) based on the settings.
 
 It then [modifies the last byte](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.cpp#L227-L239) of that well-known key using the operation `+= key[0] - 1`, where `key` is the provided 1-byte key.

--- a/docs/development/reference/encryption-technical.mdx
+++ b/docs/development/reference/encryption-technical.mdx
@@ -86,4 +86,4 @@ The last two select between AES-128 and AES-256 respectively.
 
 However for the one byte long PSKs such as the default `AQ==`, it actually replaces it with a hardcoded [AES-128 or AES-256 key](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.h#L143-L149) based on the settings.
 
-Then it [modifies the last byte of the wellknown hardcoded key according to `+= key[0] - 1`](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.cpp#L227-L239) where `key` is the one byte long key.
+It then [modifies the last byte](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.cpp#L227-L239) of that well-known key using the operation `+= key[0] - 1`, where `key` is the provided 1-byte key.

--- a/docs/development/reference/encryption-technical.mdx
+++ b/docs/development/reference/encryption-technical.mdx
@@ -76,3 +76,14 @@ Below is a detailed overview of how PSK, PKC, and Session IDs are integrated int
 ## Conclusion
 
 PSKs and the expanded use of PKC and session IDs across different MCU architectures—ESP32, nRF52, and ARM—demonstrates a tailored approach to security that balances performance, power consumption, and memory management. Each architecture's strengths are leveraged to ensure that secure communications are maintained without compromising the efficiency or scalability of the system. This approach provides robust security for a wide range of applications, from low-power wearable devices to more powerful, feature-rich systems.
+
+## Implementation Pitfalls:
+
+### One byte long PSK
+
+Meshtastic supports 1, 16 and 32 byte long AES PSKs.
+The last two select between AES-128 and AES-256 respectively.
+
+However for the one byte long PSKs such as the default `AQ==`, it actually replaces it with a hardcoded [AES-128 or AES-256 key](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.h#L143-L149) based on the settings.
+
+Then it [modifies the last byte of the wellknown hardcoded key according to `+= key[0] - 1`](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.cpp#L227-L239) where `key` is the one byte long key.

--- a/docs/development/reference/encryption-technical.mdx
+++ b/docs/development/reference/encryption-technical.mdx
@@ -81,7 +81,7 @@ PSKs and the expanded use of PKC and session IDs across different MCU architectu
 
 ### One byte long PSK
 
-Meshtastic supports 1, 16 and 32 byte long AES PSKs.
+Meshtastic supports 1, 16, and 32-byte AES PSKs. The 16 and 32-byte keys enable AES-128 and AES-256, respectively.
 
 However, for single-byte PSKs, such as the default `AQ==`, the system actually replaces the input with a hardcoded [AES-128 or AES-256 key](https://github.com/meshtastic/firmware/blob/0157a769c350a7430079f5a8000b0008b1b11053/src/mesh/Channels.h#L143-L149) based on the settings.
 


### PR DESCRIPTION
## What did you change

Added a piece of text that describes how to go from a 1 byte AES key to an AES-128 / AES-256 key.

## Why did you change it
See #2215