### PR TITLE
Add Armenian community TG chat

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -29,6 +29,10 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 - [Meshtastic Argentina Community](https://github.com/Meshtastic-Argentina/)
 
+## Armenia
+
+- [Armenia Mesh TG chat](https://t.me/armeniamesh)
+
 ## Australia
 
 ### Australian Capital Territory


### PR DESCRIPTION

## What did you change
Added link to Armenian mesh community TG chat
## Why did you change it
We've recently created a TG chat for Armenian community. We want to share in here too.

## Screenshots
### Before
<img width="488" height="364" alt="image" src="https://github.com/user-attachments/assets/5ee29001-d0a8-495b-81a7-2f66e8a57b65" />


### After
<img width="451" height="445" alt="image" src="https://github.com/user-attachments/assets/f0e0eb47-12a4-42da-8ec6-2ae594bcf9a6" />

