### PR TITLE
Add docs link to links.json

### DIFF
--- a/src/data/links.json
+++ b/src/data/links.json
@@ -1,6 +1,6 @@
 {
   "getStarted": "/docs/getting-started/",
-  "docs": "/docs/",
+  "docs": "/docs/introduction/",
   "ios": "https://msh.to/ios",
   "android": "https://msh.to/android",
   "webClient": "https://client.meshtastic.org/",


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
This fixes the broken link  on the "read docs" button on the homepage. It was removed in a prior commit.

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord conversations -->
Because it was broken.
## Screenshots
### Before


### After
