### PR TITLE
Add Meshtastic Italia Network to Italy section.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -205,7 +205,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 - [Israel Meshtastic Club](https://www.mesh-il.com)
 
 ## Italy
-
+- [Meshtastic Italia Network - The Community of Italy](https://www.meshtasticitalia.it)
 - [Meshtastic Italia Community](https://t.me/meshtastic_italia_community)
 - [Mesh_ITA Discord Server](https://discord.gg/ETFmtyzbFT)
 


### PR DESCRIPTION
Added the link for "Meshtastic Italia Network - The Community of Italy".  We are a rapidly growing community (300+ users) founded on Dec 1st, 2025.  We provide daily support for Heltec, Lilygo, and RAKwireless hardware and we are currently testing long-range connections between Lazio and Campania. Admin: Rino Mazzella.
