### PR TITLE
Added section to BaseUI for battery calibration

### DIFF
--- a/docs/configuration/device-uis/baseui/index.mdx
+++ b/docs/configuration/device-uis/baseui/index.mdx
@@ -147,6 +147,14 @@ _**Note**: Certain options described below may only be available depending on sp
 
 <img src="/img/configuration/baseui/baseui-06-clock.webp" alt="Clock Display" />
 
+#### Battery calibration
+
+The battery calibration menu displays a chart of battery percentage over time. In order to get a more accurate percentage estimate, you can calibrate the firmware to your specific battery.
+Calibration consists of fully charging your device, starting calibration, then using your device normally until the battery naturally dies. After that, when the device is powered up and charged, the percentage estimate should be more accurate.
+
+- Begin Calibration - Once fully charged, select this option to begin the battery calibration process
+- Reset OCV Array - Removes calibration data and falls back to the default battery percentages
+
 #### Favorites
 
 - New Preset Message - Send predefined text messages to the mesh network from the device without using the phone app. To enable this feature, [set a list of predefined messages](/docs/configuration/module/canned-message/#messages).


### PR DESCRIPTION
Added section for battery calibration to BaseUI documentation.

<img width="1853" height="1008" alt="image" src="https://github.com/user-attachments/assets/5ecf028f-1e41-4199-b08e-d7f44048b61c" />
