### PR TITLE
Add MeshOregon to Oregon local groups list

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -467,6 +467,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ### Oregon
 
+- [MeshOregon](https://meshoregon.com)
 - [Southern Oregon Meshtastic Community](https://sites.google.com/view/someshtastic/home)
 - [PDXMesh for Portland & SW Washington](https://pdxmesh.com)
 - [Willamette Valley Mesh Eugene / Springfield](https://discord.gg/gf4mShtJz4)


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
I have added the MeshOregon site for a whole Oregon Mesh community rather than just selective cities.

## Why did you change it
The Mesh Oregon community leaders thought this might be a good idea.

## Screenshots
### Before
```
- [Southern Oregon Meshtastic Community](https://sites.google.com/view/someshtastic/home)
- [PDXMesh for Portland & SW Washington](https://pdxmesh.com)
- [Willamette Valley Mesh Eugene / Springfield](https://discord.gg/gf4mShtJz4)
```

### After
```
- [MeshOregon](https://meshoregon.com)
- [Southern Oregon Meshtastic Community](https://sites.google.com/view/someshtastic/home)
- [PDXMesh for Portland & SW Washington](https://pdxmesh.com)
- [Willamette Valley Mesh Eugene / Springfield](https://discord.gg/gf4mShtJz4)
```