### PR TITLE
Update Mesh Hub link for UK community groups

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -533,7 +533,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ## United Kingdom
 
-- [Mesh Hub Midlands](https://www.meshhubmids.com)
+- [Mesh Hub UK](https://meshhub.uk/)
 - [New Welsh Mesh](https://welshmesh.pysgod.xyz)
 
 ### Edit this page {#edit-this-page}


### PR DESCRIPTION
The Meshub must grow!

<!-- Add or remove sections as needed -->
## What did you change
Swapped Meshub midlands to Meshub UK.

## Why did you change it
The group and discord is growing, and changed URL and name to match the wider scope.

