### PR TITLE
docs: fix markdown table formatting

### DIFF
--- a/docs/configuration/region-by-country.mdx
+++ b/docs/configuration/region-by-country.mdx
@@ -159,11 +159,13 @@ If you'd like to contribute information for your country, click the "Edit this p
 
 ### T
 
-| Country  | LoRa Region        | Regulatory document|
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Taiwan   | TW                 | [Taiwan Regulations](https://www.ncc.gov.tw/english/files/23070/102_5190_230703_1_doc_C.PDF)                                                                                                                                                                                                                                 |
-| Thailand | TH                 | [LoRaWAN Regional Parameters](https://lora-alliance.org/wp-content/uploads/2020/11/lorawan_regional_parameters_v1.0.3reva_0.pdf)                                                                                                                                                                                             |
+| Country  | LoRa Region        | Regulatory document                                                                                                                                                       |
+| -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Taiwan   | TW                 | [Taiwan Regulations](https://www.ncc.gov.tw/english/files/23070/102_5190_230703_1_doc_C.PDF)                                                                              |
+| Thailand | TH                 | [LoRaWAN Regional Parameters](https://lora-alliance.org/wp-content/uploads/2020/11/lorawan_regional_parameters_v1.0.3reva_0.pdf)                                         |
 | Türkiye  | EU_868<br />EU_433 | [Mevzuat](https://www.mevzuat.gov.tr/mevzuat?MevzuatNo=15416&MevzuatTur=7&MevzuatTertip=5), [BTK Frekans Tahsisi](https://www.btk.gov.tr/uploads/pages/frekans-tahsisinden-muaf-telsiz-cihaz-sistemleri-olcutler-633d4ca68c0b1.pdf), [BTK Milli Frekans Planı](https://www.btk.gov.tr/uploads/pages/milli-frekans-plani.pdf) |
+
+
 
 ### U
 


### PR DESCRIPTION

## What did you change
Fixed the markdown table separator row formatting in the LoRa regions table.

The previous separator row had mismatched column formatting and excessive dash width, which caused rendering inconsistencies in some markdown viewers.

Standardized the separator row to properly match the number of columns and improve readability.

No content or functional changes were made.
<!-- Describe what your changes will do if merged -->

## Why did you change it
To ensure consistent markdown rendering across different viewers and improve table maintainability.
