### PR TITLE
Add MT Users Norway

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -251,8 +251,6 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 - [MeshNorway Matrix Space](https://matrix.to/#/#meshnorway:matrix.org)
 - [Meshtastic Users Norway](https://868.no)
-  - [Facebook group](https://www.facebook.com/groups/967177764828365)
-  - [Discord server](https://discord.gg/e5ZWsehQkR)
 
 ## Poland
 


### PR DESCRIPTION
Adds links to the Norwegian MT hub site 868.no, and our Facebook group and Discord server.

Supersedes https://github.com/meshtastic/meshtastic/pull/2186