### PR TITLE
Improve warnings for newcomers transmitting without antenna

### DIFF
--- a/docs/getting-started/flashing-firmware/esp32/cli-script.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/cli-script.mdx
@@ -12,7 +12,7 @@ import { Icon } from "@iconify/react";
 import Link from "@docusaurus/Link";
 
 :::caution
-Make sure not to power the radio on without first attaching the antenna! You could damage the radio chip!
+Do not connect USB, battery, or solar power if your antenna is disconnected. You risk permanent damage when your board transmits. Without an antenna, transmitted energy is reflected back into the board.
 :::
 
 Before you flash your device start by verifying connectivity with the device being flashed. Outlined below are steps that can be taken to verify connectivity and, if necessary, to install the appropriate drivers. If you end up needing to install drivers be sure to reboot your computer afterwards to verify the installation is complete.

--- a/docs/getting-started/flashing-firmware/esp32/external-serial-adapter.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/external-serial-adapter.mdx
@@ -15,7 +15,7 @@ This information will likely only be helpful if you've already attempted to go t
 :::
 
 :::caution
-Make sure not to power the radio on without first attaching the antenna! You could damage the radio chip!
+Do not connect USB, battery, or solar power if your antenna is disconnected. You risk permanent damage when your board transmits. Without an antenna, transmitted energy is reflected back into the board.
 :::
 
 ## Background

--- a/docs/getting-started/flashing-firmware/esp32/web-flasher.mdx
+++ b/docs/getting-started/flashing-firmware/esp32/web-flasher.mdx
@@ -9,7 +9,7 @@ description: Instructions for using the Web Flasher(recommended) to flash Meshta
 import Link from "@docusaurus/Link";
 
 :::caution
-Make sure not to power the radio on without first attaching the antenna! You could damage the radio chip!
+Do not connect USB, battery, or solar power if your antenna is disconnected. You risk permanent damage when your board transmits. Without an antenna, transmitted energy is reflected back into the board.
 :::
 
 ## Flash Device

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -156,7 +156,7 @@ If your device is not listed above, please review our [supported devices](/docs/
 
 :::danger STOP! Put The Power Cable Down!
 
-Never power on the radio without attaching an antenna as doing so could damage the radio chip!
+Do not connect USB, battery, or solar power if your antenna is disconnected. You risk permanent damage when your board transmits. Without an antenna, transmitted energy is reflected back into the board.
 
 :::
 

--- a/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
+++ b/docs/getting-started/serial-drivers/test-serial-driver-installation.mdx
@@ -12,7 +12,7 @@ import TabItem from "@theme/TabItem";
 import { Icon } from "@iconify/react";
 
 :::caution
-Make sure not to power the radio on without first attaching the antenna! You could damage the radio chip!
+Do not connect USB, battery, or solar power if your antenna is disconnected. You risk permanent damage when your board transmits. Without an antenna, transmitted energy is reflected back into the board.
 :::
 
 ### Test Serial Driver Installation


### PR DESCRIPTION
First day exploring meshtastic, noticed this warning on some pages, but not on the first page I landed on

## What did you change
Copied existing caution templates to two "getting started" pages that prompt the user to connect USB.
Added detail to the caution, including mentioning USB. 

## Why did you change it
Would hate for newcomers to make an easy mistake 