### PR TITLE
Add LONG_TURBO case to modem preset switch

### DIFF
--- a/src/components/tools/FrequencyCalculator.tsx
+++ b/src/components/tools/FrequencyCalculator.tsx
@@ -319,6 +319,8 @@ const getChannelName = (
       return "LongSlow";
     case Protobuf.Config.Config_LoRaConfig_ModemPreset.LONG_FAST:
       return "LongFast";
+    case Protobuf.Config.Config_LoRaConfig_ModemPreset.LONG_TURBO:
+      return "LongTurbo";
     case Protobuf.Config.Config_LoRaConfig_ModemPreset.LONG_MODERATE:
       return "LongMod";
     default:


### PR DESCRIPTION
LONG_TURBO was half-way added in a previous commit

## What did you change
Completed adding LONG_TURBO to the Frequency Calculator

## Why did you change it
It was missing/incomplete
