### PR TITLE
Update docs on Spreading Factors 5 and 6 for firmware PR #9363

### DIFF
--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -66,6 +66,7 @@ Various data-rate options are available when configuring a frequency slot and ar
 - **Spreading Factor (SF)** - How much we "spread" our data over time.
   - Each step up in Spreading Factor doubles the airtime to transmit.
   - Each step up in Spreading Factor adds about 2.5db extra link budget.
+  - **Note:** Spreading Factors 5 and 6 are only supported on 2nd generation LoRa chips (SX126x, LR11xx, SX128x). 1st generation chips (SX127x / RF95) are limited to SF7-SF12. If you select SF5/6 on an unsupported device, the firmware will automatically clamp it to SF11.
 - **Bandwidth** - How big of a slice of the spectrum we use.
   - Each doubling of the bandwidth is almost 3db less link budget.
   - Bandwidths less than 31 may be unstable unless you have a high quality Crystal Oscillator.

--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -90,7 +90,9 @@ Please be aware that values < 62.5kHz may require a TCXO on some hardware device
 
 ### Spread Factor
 
-A number from 7 to 12. Indicates the number of chirps per symbol as 1[\<\<]spread_factor.
+A number from 5 to 12. Indicates the number of chirps per symbol as 1[\<\<]spread_factor.
+
+Older LoRa chips like (SX127x / RF95) only support spreading factors 7 to 12.
 
 ### Coding Rate
 


### PR DESCRIPTION
## What did you change
Updated the docs on Spreading Factors, including SF5 and 6, as @caveman99 requested on my meshtastic/firmware#9363 PR to include support for these SFs in the firmware.
