### PR TITLE
Add Kaliningrad community Telegram group to Local Groups

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -270,6 +270,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 ## Russia
 - [Meshtastic Barnaul Community](https://t.me/lora_mesh_barnaul)
 - [Meshtastic in Magnitogorsk](https://t.me/meshtastic_m)
+- [Meshtastic Kaliningrad Community](https://t.me/meshtastic_39)
 
 ## Singapore
 


### PR DESCRIPTION
- Added link to Kaliningrad-based Meshtastic community
- Provides a local hub for coordination, support, and network growth
- Permanent invite link included

## What did you change
Added a new entry to the Local Groups list for the Kaliningrad community, including a Telegram invite link and group name.

## Why did you change it
To make it easier for users in the Kaliningrad region to find and join a local Meshtastic community for communication, support, and network expansion.

### Before
Kaliningrad community was not listed.

### After
Kaliningrad community appears in the Local Groups list with a Telegram link.