### PR TITLE
meshtasticd: Bump supported distro versions

### DIFF
--- a/docs/meshtasticd/installation/epel.mdx
+++ b/docs/meshtasticd/installation/epel.mdx
@@ -22,7 +22,7 @@ Built with Red Hat's [UBI](https://www.redhat.com/en/blog/introducing-red-hat-un
 | 📱 [MUI][MUI]            | ✅     |
 | 🌐 [Web][WebClient]      | ✅     |
 
-Supported: EPEL `9`, EPEL `10`
+Supported: EPEL `10`, EPEL `9`
 
 CentOS Stream, Red Hat Enterprise Linux, AlmaLinux, Rocky Linux, and other [EPEL-supported](https://docs.fedoraproject.org/en-US/epel/getting-started/) distributions.
 

--- a/docs/meshtasticd/installation/fedora.mdx
+++ b/docs/meshtasticd/installation/fedora.mdx
@@ -21,7 +21,7 @@ Fedora packages are provided via [<Icon icon="mdi:fedora"/> Fedora COPR](https:/
 | 📱 [MUI][MUI]            | ✅     |
 | 🌐 [Web][WebClient]      | ✅     |
 
-Supported: Fedora `43`, Fedora `42`
+Supported: Fedora `44`, Fedora `43`
 
 **Install:**
 
@@ -31,18 +31,6 @@ sudo dnf copr enable @meshtastic/beta
 # Install meshtasticd
 sudo dnf install meshtasticd
 ```
-
-<details>
-  <summary>Experimental builds</summary>
-
-  These builds are provided without support, please **do not file issues** relating to Experimental builds.
-
-  Experimental Support: Fedora `44`
-
-  **Install:**
-
-  > Install via the instructions above.
-</details>
 
 [MUI]: /docs/configuration/device-uis/meshtasticui/
 [WebClient]: /docs/software/web-client/

--- a/docs/meshtasticd/installation/index.mdx
+++ b/docs/meshtasticd/installation/index.mdx
@@ -48,13 +48,13 @@ export const InstallCard = ({ icon, title, description, to }) => (
   }}
 >
   <InstallCard icon="mdi:apple" title="macOS" description="Homebrew" to="/docs/meshtasticd/installation/macos" />
-  <InstallCard icon="mdi:debian" title="Debian" description="Debian 12, 13" to="/docs/meshtasticd/installation/debian" />
+  <InstallCard icon="mdi:debian" title="Debian" description="Debian Linux" to="/docs/meshtasticd/installation/debian" />
   <InstallCard icon="cib:raspberry-pi" title="Raspbian" description="32-bit RPi OS" to="/docs/meshtasticd/installation/raspbian" />
-  <InstallCard icon="mdi:ubuntu" title="Ubuntu" description="22.04+, PPA" to="/docs/meshtasticd/installation/ubuntu" />
-  <InstallCard icon="mdi:fedora" title="Fedora" description="Fedora 42, 43" to="/docs/meshtasticd/installation/fedora" />
-  <InstallCard icon="mdi:redhat" title="Red Hat (EPEL)" description="EPEL 9, 10" to="/docs/meshtasticd/installation/epel" />
-  <InstallCard icon="mdi:docker" title="Docker" description="amd64, arm64, armv7" to="/docs/meshtasticd/installation/docker" />
-  <InstallCard icon="simple-icons:flatpak" title="Flatpak" description="via FlatHub" to="/docs/meshtasticd/installation/flatpak" />
+  <InstallCard icon="mdi:ubuntu" title="Ubuntu" description="PPA" to="/docs/meshtasticd/installation/ubuntu" />
+  <InstallCard icon="mdi:fedora" title="Fedora" description="COPR" to="/docs/meshtasticd/installation/fedora" />
+  <InstallCard icon="mdi:redhat" title="Red Hat (EPEL)" description="Enterprise Linux" to="/docs/meshtasticd/installation/epel" />
+  <InstallCard icon="mdi:docker" title="Docker" description="DockerHub" to="/docs/meshtasticd/installation/docker" />
+  <InstallCard icon="simple-icons:flatpak" title="Flatpak" description="FlatHub" to="/docs/meshtasticd/installation/flatpak" />
   <InstallCard icon="simple-icons:openwrt" title="OpenWrt" description="Routers" to="/docs/meshtasticd/installation/openwrt" />
   <InstallCard icon="simple-icons:nixos" title="NixOS" description="x86_64, aarch64" to="/docs/meshtasticd/installation/nixos" />
 </div>

--- a/docs/meshtasticd/installation/macos.mdx
+++ b/docs/meshtasticd/installation/macos.mdx
@@ -21,7 +21,7 @@ MacOS packages are installed via [<Icon icon="simple-icons:homebrew"/> Homebrew]
 | 📱 [MUI][MUI]            | ❌     |
 | 🌐 [Web][WebClient]      | ❌     |
 
-Supported MacOS: 15 `sequoia`, 26 `tahoe`
+Supported MacOS: 26 `tahoe`, 15 `sequoia`
 
 **Install:**
 

--- a/docs/meshtasticd/installation/ubuntu.mdx
+++ b/docs/meshtasticd/installation/ubuntu.mdx
@@ -21,7 +21,7 @@ Ubuntu packages are provided via [<Icon icon="simple-icons:launchpad"/> Canonica
 | 📱 [MUI][MUI]            | ✅     |
 | 🌐 [Web][WebClient]      | ✅     |
 
-Supported: `questing` (25.10), `noble` (24.04 LTS), `jammy` (22.04 LTS)
+Supported: `resolute` (26.04 LTS), `questing` (25.10), `noble` (24.04 LTS), `jammy` (22.04 LTS)
 
 **Install:**
 
@@ -33,18 +33,6 @@ sudo add-apt-repository ppa:meshtastic/beta
 # Install meshtasticd
 sudo apt install meshtasticd
 ```
-
-<details>
-  <summary>Experimental builds</summary>
-
-  These builds are provided without support, please **do not file issues** relating to Experimental builds.
-
-  Experimental Support: `resolute` (26.04 LTS)
-
-  **Install:**
-
-  > Install via the instructions above.
-</details>
 
 [MUI]: /docs/configuration/device-uis/meshtasticui/
 [WebClient]: /docs/software/web-client/


### PR DESCRIPTION
- Bump distro versions (Ubuntu, Fedora)
- Re-arrange the "Supported" strings so they are all newest -> oldest.
- Change the short-descriptions for the Icon array to not include OS versions (these will age poorly if we forget to update them in the future)
