### PR TITLE
Update macos.mdx

### DIFF
--- a/docs/meshtasticd/installation/macos.mdx
+++ b/docs/meshtasticd/installation/macos.mdx
@@ -31,7 +31,14 @@ brew install meshtasticd
 brew services start meshtasticd
 ```
 
+## macOS paths
+
+- configuration : `/opt/homebrew/etc/meshtasticd`
+- log : `/opt/homebrew/var/log/meshtasticd.log`
+
+
 [MUI]: /docs/configuration/device-uis/meshtasticui/
 [WebClient]: /docs/software/web-client/
 [USBRadio]: /docs/meshtasticd/hardware/
 [SPIRadio]: /docs/meshtasticd/hardware/
+


### PR DESCRIPTION
add some useful info for macOS paths


## What did you change
added macOS paths to cfg / logs

## Why did you change it
missing info that is very useful

## Screenshots
### Before
<img width="1057" height="210" alt="Screenshot 2026-04-30 at 22 44 46" src="https://github.com/user-attachments/assets/00a3e445-9943-4f93-b24e-7bd732d1b4e7" />


### After
<img width="1033" height="316" alt="Screenshot 2026-04-30 at 22 45 12" src="https://github.com/user-attachments/assets/607f9c3d-cb67-46f2-b6aa-735f9e01b712" />
