### PR TITLE
Add Hexaspot Links

### DIFF
--- a/docs/hardware/devices/heltec-automation/lora32/index.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/index.mdx
@@ -63,6 +63,7 @@ values={[
     - [Rokland](https://store.rokland.com/products/heltec-wifi-lora-32v4-esp32s3-sx1262-lora-node-meshtastic-lorawan)
   - International
     - [Heltec](https://msh.to/heltec-v4/)
+    - [Hexaspot](https://msh.to/hexaspot-heltec-v4/)
 
 ![Heltec LoRa32 V4](/img/hardware/heltec/heltec-V4.webp)
 
@@ -132,7 +133,7 @@ Image Source: [Heltec](<https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-
   - International
     - [Heltec](https://heltec.org/project/wifi-lora-32-v3/)
     - [AliExpress](https://www.aliexpress.us/item/3256807466584635.html)
-    - [Hexaspot, Netherlands, EU](https://hexaspot.com/products/heltec-wifi-lora-32-v3)
+    - [Hexaspot](https://msh.to/hexaspot-heltec-v3/)
 
 </TabItem>
 

--- a/docs/hardware/devices/heltec-automation/lora32/index.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/index.mdx
@@ -132,6 +132,7 @@ Image Source: [Heltec](<https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-
   - International
     - [Heltec](https://heltec.org/project/wifi-lora-32-v3/)
     - [AliExpress](https://www.aliexpress.us/item/3256807466584635.html)
+    - [Hexaspot, Netherlands, EU](https://hexaspot.com/products/heltec-wifi-lora-32-v3)
 
 </TabItem>
 

--- a/docs/hardware/devices/rak-wireless/wismesh/pocket.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/pocket.mdx
@@ -69,6 +69,7 @@ The WisMesh Pocket V1, while still supported, is no longer available for purchas
   - International
     - [RAKwireless Store](https://msh.to/wismesh-pocket-v2)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-wismesh-pocket-v2)
+    - [Hexaspot, Netherlnds, EU] (https://hexaspot.com/products/wismesh-pocket-v2-ready-to-use-meshtastic-device)
 
 ![RAK Pocket V2](/img/hardware/rak/pocket-v2.webp)
 

--- a/docs/hardware/devices/rak-wireless/wismesh/pocket.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/pocket.mdx
@@ -69,7 +69,7 @@ The WisMesh Pocket V1, while still supported, is no longer available for purchas
   - International
     - [RAKwireless Store](https://msh.to/wismesh-pocket-v2)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-wismesh-pocket-v2)
-    - [Hexaspot, Netherlnds, EU] (https://hexaspot.com/products/wismesh-pocket-v2-ready-to-use-meshtastic-device)
+    - [Hexaspot] (https://msh.to/hexaspot-wismesh-pocket-v2/)
 
 ![RAK Pocket V2](/img/hardware/rak/pocket-v2.webp)
 

--- a/docs/hardware/devices/rak-wireless/wismesh/repeater.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/repeater.mdx
@@ -102,7 +102,7 @@ The WisMesh Repeater Mini is a compact and portable Meshtastic device designed f
   - International
     - [RAKwireless Store](https://msh.to/wismesh-repeater-mini)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-wismesh-repeater-mini)
-    - [Hexaspot, Netherlands, EU](https://hexaspot.com/products/wismesh-repeater-mini)
+    - [Hexaspot](https://msh.to/hexaspot-wismesh-repeater-mini/)
 
 ![RAK WisMesh Repeater Mini](/img/hardware/rak/wismesh-repeater-mini.webp)
 

--- a/docs/hardware/devices/rak-wireless/wismesh/repeater.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/repeater.mdx
@@ -58,6 +58,7 @@ The WisMesh Repeater is a robust, fixed-location Meshtastic device designed for 
     - [RAKwireless Store](https://msh.to/wismesh-repeater)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-wismesh-repeater)
 
+
 ![RAK WisMesh Repeater](/img/hardware/rak/wismesh-repeater.webp)
 
 </ TabItem>
@@ -101,6 +102,7 @@ The WisMesh Repeater Mini is a compact and portable Meshtastic device designed f
   - International
     - [RAKwireless Store](https://msh.to/wismesh-repeater-mini)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-wismesh-repeater-mini)
+    - [Hexaspot, Netherlands, EU](https://hexaspot.com/products/wismesh-repeater-mini)
 
 ![RAK WisMesh Repeater Mini](/img/hardware/rak/wismesh-repeater-mini.webp)
 

--- a/docs/hardware/devices/rak-wireless/wismesh/tag.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/tag.mdx
@@ -53,6 +53,6 @@ The WisMesh Tag is a compact Meshtastic device designed for portable location tr
   - International
     - [RAKwireless Store](https://msh.to/rak_wismeshtag/)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-wismesh-tag/)
-    - [Hexaspot, Netherlands, EU](https://hexaspot.com/products/wismesh-tag)
+    - [Hexaspot](https://msh.to/hexaspot-wismesh-tag/)
 
 ![RAK WisMesh Tag](/img/hardware/rak/wismesh-tag.webp)

--- a/docs/hardware/devices/rak-wireless/wismesh/tag.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/tag.mdx
@@ -53,5 +53,6 @@ The WisMesh Tag is a compact Meshtastic device designed for portable location tr
   - International
     - [RAKwireless Store](https://msh.to/rak_wismeshtag/)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-wismesh-tag/)
+    - [Hexaspot, Netherlands, EU](https://hexaspot.com/products/wismesh-tag)
 
 ![RAK WisMesh Tag](/img/hardware/rak/wismesh-tag.webp)


### PR DESCRIPTION
This pull request updates the hardware documentation to include additional international purchasing options for several Meshtastic-compatible devices. The main focus is on adding Hexaspot as a vendor for various Heltec and RAKwireless devices.

New vendor links added:

**Heltec devices**:
* Added Hexaspot as an international purchasing option for the `LoRa32 V4` and `LoRa32 V3` devices in `lora32/index.mdx`. [[1]](diffhunk://#diff-339f39a43dfda610f5a5a0a116e2eac6100e265641bbfd714a7d21a6edf05bfaR66) [[2]](diffhunk://#diff-339f39a43dfda610f5a5a0a116e2eac6100e265641bbfd714a7d21a6edf05bfaR136)

**RAKwireless devices**:
* Added Hexaspot as an international purchasing option for the following devices:
  - `WisMesh Pocket V2` in `wismesh/pocket.mdx`
  - `WisMesh Repeater Mini` in `wismesh/repeater.mdx`
  - `WisMesh Tag` in `wismesh/tag.mdx`

Other:
* Minor formatting change in `wismesh/repeater.mdx` (extra newline added).
