### PR TITLE
fix: remove username references from Docs Review workflow

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -1,4 +1,4 @@
-name: Docs Review (@rcarteraz style)
+name: Docs Review
 
 on:
   pull_request_target:
@@ -128,7 +128,7 @@ jobs:
             }
 
             // Build the review comment
-            let body = `### 🤖 Docs Review (rcarteraz style)\n\n`;
+            let body = `### 🤖 Docs Review\n\n`;
             body += `Hey @${prAuthor}! Thanks for the ${hasBlogChanges ? "blog post" : "docs"} contribution! Here's a quick review:\n\n`;
 
             if (suggestions.length === 0) {
@@ -162,7 +162,7 @@ jobs:
 
             // Post or update the review comment
             const botCommentIdentifier =
-              "### 🤖 Docs Review (rcarteraz style)";
+              "### 🤖 Docs Review";
 
             // Check for existing bot comment
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
Removes `(@rcarteraz style)` and `(rcarteraz style)` from the Docs Review workflow name, comment header, and bot comment identifier.