### PR TITLE
Add Meshtastic Italia Network Users Group to Italy section

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -225,6 +225,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 - [Meshtastic Italia Community](https://t.me/meshtastic_italia_community)
 - [Mesh_ITA Discord Server](https://discord.gg/ETFmtyzbFT)
 - [Meshtastic Italia Network Users Group](https://t.me/MeshtasticItalia)
+
 ## Japan
 
 - [Meshtastic Japan Community](https://www.facebook.com/share/g/BQCGxZhw9SxFQja8/?mibextid=K35XfP)

--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -224,7 +224,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 - [Meshtastic Italia Community](https://t.me/meshtastic_italia_community)
 - [Mesh_ITA Discord Server](https://discord.gg/ETFmtyzbFT)
-
+- [Meshtastic Italia Network Users Group](https://t.me/MeshtasticItalia)
 ## Japan
 
 - [Meshtastic Japan Community](https://www.facebook.com/share/g/BQCGxZhw9SxFQja8/?mibextid=K35XfP)


### PR DESCRIPTION
Adding a third Italian community group to the Italy section.

The display name follows the trademark policy pattern explicitly listed as permitted in the Social Media section of the trademark guidelines ("Meshtastic [Region] Users Group").

Submitting Telegram link only — no domain.

This group complements the two existing Italian listings with a broader, full-spectrum community focus: real-time mesh mapping, MQTT bridge infrastructure, technical guides and hardware support (ESP32, Heltec, T-Beam), automation and community bots, in-person meetups, and regional coordination across Northern, Central, and Southern Italy.

Group renamed prior to submission to comply with the guidelines feedback received on PR #2224.
