### PR TITLE
Add MeshDash to Community Software listings

### DIFF
--- a/docs/community/software/index.mdx
+++ b/docs/community/software/index.mdx
@@ -15,6 +15,7 @@ Current community projects:
 - [Harbor Scale - Grafana](/docs/community/software/harbor-scale) - A cloud-based solution for collecting, storing, and visualizing Meshtastic telemetry data using grafana.
 - [Connect](https://github.com/pdxlocations/connect) - A standalone Python client for communicating with Meshtastic devices via MQTT
 - [Contact](https://github.com/pdxlocations/contact) - A terminal-based Python chat and configuration client for Meshtastic devices.
+- [MeshDash](https://meshdash.co.uk) - A self-hosted, open-source web dashboard for Meshtastic mesh networks, connecting via Serial, TCP, BLE, MQTT, or WebSerial. Features real-time node monitoring, MeshShark packet analysis, GPS mapping, direct messaging, telemetry analytics, task scheduler, auto-reply engine, traceroute, node config editor, plugin system, and Docker deployment.
 - [MeshHessen Client](https://github.com/SMLunchen/mh_windowsclient) - The MeshHessen Client is a .NET-based offline Windows application developed by the MeshHessen community for civil protection and emergency response, designed to run immediately without complex setup or technical expertise. It features maps (offline maps are currently Germany only), node visualization with labels and colors, alert highlighting/sounds, message logging, and supports serial, TCP/IP, and BLE connections.
 
 Support for these projects should be sought from their respective authors.


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change

Added MeshDash to the Community Apps listing in `docs/community/software/index.mdx`.
<!-- Describe what your changes will do if merged -->

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord conversations -->

MeshDash is a self-hosted, open-source (GPL-3.0) web dashboard for Meshtastic mesh networks that's been in production for multiple major releases. Adding it to the official community software listings will help Meshtastic users discover it.

- **Website:** https://meshdash.co.uk
- **Source:** https://github.com/ruspea/MeshDash
- **License:** GPL-3.0-only
- **Docker:** https://hub.docker.com/r/rusjpmd/meshdash-runner

## Personal Note: Huge thanks to the Meshtastic team for building and maintaining the incredible open-source platform that makes projects like this possible. MeshDash exists to complement and celebrate the ecosystem you've created — your work powers the entire mesh community, and we're grateful to be a small part of it.