### PR TITLE
Lock Obtainium to specific app variant

### DIFF
--- a/docs/software/android/installation.mdx
+++ b/docs/software/android/installation.mdx
@@ -64,7 +64,9 @@ If you do sideload, you may have to give your browser permissions to run a packa
 1. Download and Install the Obtainium app from [GitHub](https://github.com/ImranR98/Obtainium).
 2. Open the Obtainium app and navigate to `+ Add App`.
 3. You can easily search for the Android repo with the search field by typing `Meshtastic-Android` and selecting the `Meshtastic/Meshtastic-Android` repo. You may also manually enter the Meshtastic Android GitHub Releases address as follows: `https://github.com/meshtastic/Meshtastic-Android/releases`.
-4. Under `Additional Options for GitHub` toggle as desired `Include prereleases`\* or `Fallback to older releases` and press `Add`.
+4. Under `Additional Options for GitHub`
+    * Toggle as desired `Include prereleases`\* or `Fallback to older releases` and press `Add`.
+    * Enter either `google` or `fdroid` in the `Filter APKs by regular expression` field, to ensure that Obtainium only installs the variant of your choice.
 5. The first time you add an application, obtainium will prompt you for permission to install unknown apps, you will need to toggle `Allow from this source` and press back. Obtainium will download the Android .APK from the GitHub release page.
 6. Press `Install`. Android Installer will prompt "Do you want to install this app?" press `Install`.
 7. Press `Open`.

--- a/docs/software/android/installation.mdx
+++ b/docs/software/android/installation.mdx
@@ -65,8 +65,9 @@ If you do sideload, you may have to give your browser permissions to run a packa
 2. Open the Obtainium app and navigate to `+ Add App`.
 3. You can easily search for the Android repo with the search field by typing `Meshtastic-Android` and selecting the `Meshtastic/Meshtastic-Android` repo. You may also manually enter the Meshtastic Android GitHub Releases address as follows: `https://github.com/meshtastic/Meshtastic-Android/releases`.
 4. Under `Additional Options for GitHub`
-    * Toggle as desired `Include prereleases`\* or `Fallback to older releases` and press `Add`.
-    * Enter either `google` or `fdroid` in the `Filter APKs by regular expression` field, to ensure that Obtainium only installs the variant of your choice.
+    1. Toggle as desired `Include prereleases`\* or `Fallback to older releases`.
+    2. Enter either `google` or `fdroid` in the `Filter APKs by regular expression` field, to ensure that Obtainium only installs the variant of your choice.
+    3. Press `Add`.
 5. The first time you add an application, obtainium will prompt you for permission to install unknown apps, you will need to toggle `Allow from this source` and press back. Obtainium will download the Android .APK from the GitHub release page.
 6. Press `Install`. Android Installer will prompt "Do you want to install this app?" press `Install`.
 7. Press `Open`.


### PR DESCRIPTION
## What did you change
Add instructions on how to tell Obtainium to only install either Google or F-Droid app veriant.

## Why did you change it
The current install guide results in a setup where Obtainium seemingly at random switches between the Google and F-Droid variants of the Meshtastic Android app. This is obviously not wanted nor expected, and is very confusing to the user.

## Screenshots
### Before
<img width="978" height="421" alt="image" src="https://github.com/user-attachments/assets/5d4bc19f-dd3d-4545-9147-2ecb9518208d" />


### After
<img width="1045" height="422" alt="image" src="https://github.com/user-attachments/assets/eceee077-4b1c-4ead-b79c-02a53aea36ca" />

(Ignore style differences. First screenshot is from Meshtastic.org, and the second is from Github preview.)