### PR TITLE
Add cooldown configuration for npm updates in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 6 # 1 day after pnpm's cutoff, prevent a race


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings. It introduces a cooldown period to help manage update frequency and avoid potential conflicts with our pnpm policy (at least 5 days old).

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-