### PR TITLE
Add react ecosystem group to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 6 # 1 day after pnpm's cutoff, prevent a race
+    groups:
+      react-ecosystem:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react*"


### PR DESCRIPTION
Forces react, @types/react, and react-dom to update together.

---

This pull request introduces a configuration improvement to the Dependabot setup by grouping React-related dependencies together. This change will help manage updates for the React ecosystem more efficiently.

Dependabot configuration:

* Added a `react-ecosystem` group to the `dependabot.yml` file, which matches updates for `react`, `react-dom`, and all `@types/react*` packages, enabling them to be updated together.