### PR TITLE
Update radio-settings.mdx with Correct NA 915 MHz Maximum Output Power

### DIFF
--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -51,7 +51,7 @@ It is worth noting that 868 MHz is generally the most popular frequency band for
 
 ### 915 MHz (ISM Band)
 
-The maximum output power for North America is +30 dBm ERP ([Effective Radiated Power](https://en.wikipedia.org/wiki/Effective_radiated_power)).
+The maximum output power for North America is +30 dBm conducted output power and +36 dBm EIRP (Effective Isotropic Radiated Power).
 
 The band range is from 902 to 928 MHz.
 


### PR DESCRIPTION
[FCC 15.247(b)(3)](https://www.ecfr.gov/current/title-47/chapter-I/subchapter-A/part-15/subpart-C/subject-group-ECFR2f2e5828339709e/section-15.247) clearly states the maximum conducted output power is 30 dBm (1 W).

[FCC 15.247(b)(4)](https://www.ecfr.gov/current/title-47/chapter-I/subchapter-A/part-15/subpart-C/subject-group-ECFR2f2e5828339709e/section-15.247) states, "The conducted output power limit specified in paragraph (b) of this section is based on the use of antennas with directional gains that do not exceed 6 dBi."  In other words, the maximum EIRP (Effective Isotropic Radiated Power) is 36 dBm.  EIRP is calculated using the following formula:

EIRP = P_c + G_a - L

where,

P_c: Conducted output power (in dBm)
G_a: Antenna gain relative to an ideal isotropic radiator (in dBi)
L: Cable and connector losses between the transmitter and the antenna (in dB)

For an antenna with directional gain greater than 6 dBi, the conducted output power must be reduced by "the amount in dB that the directional gain of the antenna exceeds 6 dBi."  For example, with an 8 dBi antenna, the maximum conducted output power is 28 dBm.

<!-- Add or remove sections as needed -->
I changed "+30 dBm ERP (Effective Radiated Power)" to "+30 dBm conducted output power and +36 dBm EIRP (Effective Isotropic Radiated Power)"

[wikipedia](https://en.wikipedia.org/) doesn't define EIRP (Effective Isotropic Radiated Power) or I would've included a link.

<!-- Describe what your changes will do if merged -->

## Why did you change it
The existing meshtastic.org description of NA 915 MHz Maximum Output Power is incorrect.

It's important to correct the existing meshtastic.org description as more and more Meshtastic devices incorporate the RAK 1W Booster Kit.  The +22 dBm
Semtech SX1262 LoRa modem and SkyWorks SKY66122 +8 dBm power amplifier deliver a maximum of +30 dBM to the input terminals (feed point) of the antenna.   This is +30 dBm conducted output power which does not include the antenna gain nor account for cable and connector losses.  In leveraging a +30 dBm transmitter like the RAK 1W Booster Kit, it's crucial to recognize that FCC 15.247(b) allows for an antenna with gain up to 6 dBi (+36 dBm EIRP).