### PR TITLE
Add Homebrew trust command for macOS installation

### DIFF
--- a/docs/meshtasticd/installation/macos.mdx
+++ b/docs/meshtasticd/installation/macos.mdx
@@ -27,6 +27,7 @@ Supported MacOS: 26 `tahoe`, 15 `sequoia`
 
 ```shell
 brew tap meshtastic/tap
+brew trust meshtastic/tap
 brew install meshtasticd
 brew services start meshtasticd
 ```


### PR DESCRIPTION
This pull request updates the MacOS installation instructions for `meshtasticd` to include an additional step for trusting the Homebrew tap. Required since Homebrew 6.0

Installation documentation update:

* Added the `brew trust meshtastic/tap` command to the installation instructions in `macos.mdx` to ensure the tap is trusted before installing.