### PR TITLE
Update Debian dependencies in Linux documentation

### DIFF
--- a/docs/development/linux.mdx
+++ b/docs/development/linux.mdx
@@ -22,7 +22,7 @@ The following libraries must be installed before building `meshtasticd` or `nati
   <TabItem value="debian" label={<><Icon icon="mdi:debian" style={{ marginRight: "0.25rem" }} height="1.5rem" /> Debian</>} default>
   ```shell
   # Base dependencies
-  sudo apt install libgpiod-dev libyaml-cpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev libuv1-dev libxkbcommon-dev libinput-dev libsqlite3-dev
+  sudo apt install libgpiod-dev libyaml-cpp-dev libjsoncpp-dev libbluetooth-dev libusb-1.0-0-dev libi2c-dev libuv1-dev libxkbcommon-dev libinput-dev libsqlite3-dev
   # Optional dependencies for web server support
   sudo apt install openssl libssl-dev libulfius-dev liborcania-dev
   # Optional dependencies for sdl support


### PR DESCRIPTION
This PR adds libjsoncpp-dev to debian install dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Linux development setup instructions to include an additional Debian package required for building.
  * Kept the command-line build/run guidance unchanged aside from minor text adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->