### PR TITLE
Add CNYMesh to local groups list

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -479,6 +479,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 - [Rochester ROCMesh](https://rocmesh.com/)
 - [Capital Region - Upstate Mesh](https://www.upstatemesh.org/)
 - [Southern Tier Mesh](https://stmesh.net)
+- [Syracuse and Surrounding Counties - CNYMesh](https://cnymesh.org)
 
 ### North Carolina
 


### PR DESCRIPTION
## What did you change
Added single link to CNYMesh website, local group exploring Mesh technologies in the Syracuse and surrounding areas in NY State, USA.

## Why did you change it
Help support local growth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new local group listing under the United States → New York section for “Syracuse and Surrounding Counties - CNYMesh.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->