### PR TITLE
chore(deps): increase npm open-pull-requests-limit in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 6 # 1 day after pnpm's cutoff, prevent a race
+    open-pull-requests-limit: 10 # Increase PR limit
     groups:
       react-ecosystem:
         patterns:


### PR DESCRIPTION
increase npm open-pull-requests-limit in dependabot config like we do in meshtastic/web

node is noisy!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum number of automated dependency update pull requests that can be opened at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->