### PR TITLE
Add FlatHub verification for MeshtasticDesktop

### DIFF
--- a/static/.well-known/org.flathub.VerifiedApps.txt
+++ b/static/.well-known/org.flathub.VerifiedApps.txt
@@ -1,1 +1,5 @@
+# org.meshtastic.meshtasticd
 75d5bfab-5330-41f7-94d4-0e11cbdfb250
+
+# org.meshtastic.MeshtasticDesktop
+16572bd7-55fd-4f50-aa71-542d779c8615


### PR DESCRIPTION
Adds verification for MeshtasticDesktop on FlatHub, same as meshtasticd.

Fixes https://github.com/flathub/org.meshtastic.MeshtasticDesktop/issues/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verified-app listings for Meshtastic Desktop and meshtasticd.
  * Registered unique verification identifiers for both applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->