### PR TITLE
Update @meshtastic/protobufs to v2.7.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mdx-js/react": "^3.1.1",
     "@mermaid-js/layout-elk": "^0.2.2",
     "@meshtastic/core": "jsr:^2.6.6",
-    "@meshtastic/protobufs": "jsr:^2.7.20",
+    "@meshtastic/protobufs": "jsr:^2.7.26",
     "@radix-ui/react-popover": "^1.1.19",
     "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/react-tooltip": "^1.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: jsr:^2.6.6
         version: '@jsr/meshtastic__core@2.6.6'
       '@meshtastic/protobufs':
-        specifier: jsr:^2.7.20
-        version: '@jsr/meshtastic__protobufs@2.7.20'
+        specifier: jsr:^2.7.26
+        version: '@jsr/meshtastic__protobufs@2.7.26'
       '@radix-ui/react-popover':
         specifier: ^1.1.19
         version: 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1665,6 +1665,9 @@ packages:
 
   '@jsr/meshtastic__protobufs@2.7.20':
     resolution: {integrity: sha512-GrHWfOzi9i7xk2Br3MkKWLxbzreZuwgjZKNooednYpa1V/abnSj9e4twNTtKyqXYaAOzthY3Cdk4IXouBN9dbA==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.7.20.tgz}
+
+  '@jsr/meshtastic__protobufs@2.7.26':
+    resolution: {integrity: sha512-NxqJDr8kRgeFv0YzkIn97n9zLQYz75lMZAxTFQKFI4NcFH11ijVczQXRRmbNlj9gtXKQAnuGKJIaFm6nODiS6g==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.7.26.tgz}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -10768,6 +10771,10 @@ snapshots:
       - buffer
 
   '@jsr/meshtastic__protobufs@2.7.20':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+
+  '@jsr/meshtastic__protobufs@2.7.26':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - "."
 
 minimumReleaseAge: 7200 # 5 Days
+# Exclude @meshtastic packages (maintained by us) from minimumReleaseAge.
+minimumReleaseAgeExclude:
+  - "@meshtastic/*"
+  - "@jsr/meshtastic__*"
 
 overrides:
   path-to-regexp: "^3.3.0"


### PR DESCRIPTION
https://jsr.io/@meshtastic/protobufs@2.7.26

This pull request updates the `@meshtastic/protobufs` dependency to a newer version and adjusts the workspace configuration to exclude certain packages from the minimum release age requirement. The most important changes are:

**Dependency Updates**
- Upgraded `@meshtastic/protobufs` from version `2.7.20` to `2.7.26` in `package.json` and updated all relevant lockfile entries in `pnpm-lock.yaml` to ensure the project uses the latest version. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L47-R47) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL66-R67) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1669-R1671) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10777-R10780)

**Workspace Configuration**
- Added a `minimumReleaseAgeExclude` field in `pnpm-workspace.yaml` to exclude all `@meshtastic/*` and `@jsr/meshtastic__*` packages from the minimum release age policy, allowing these internally maintained packages to be updated without delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Meshtastic protocol support to improve compatibility with the latest protocol definitions.
  * Included the latest upstream corrections and enhancements for Meshtastic-related functionality.

* **Chores**
  * Improved release handling for Meshtastic packages to help updates become available more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->