### PR TITLE
Update Crowdin project link in translation guide

### DIFF
--- a/docs/software/android/user/translate.md
+++ b/docs/software/android/user/translate.md
@@ -26,7 +26,7 @@ Contributing translations helps make Meshtastic accessible to a wider audience. 
 
 ## How to Contribute
 
-1. **Visit the Crowdin project.** Open the [Meshtastic Android Crowdin project](https://crowdin.com/project/meshtastic-android) and sign in or create a free account.
+1. **Visit the Crowdin project.** Open the [Meshtastic Android Crowdin project](https://meshtastic.crowdin.com/android) and sign in or create a free account.
 2. **Choose your language.** Select an existing language or request a new one by opening a [GitHub issue](https://github.com/meshtastic/Meshtastic-Android/issues/new).
 3. **Translate strings.** Crowdin shows the English source on the left and your translation on the right. Translate each string and save.
 4. **Review context.** Many strings include screenshots or context comments — check these to understand where the text appears in the app.


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
I changed the link to Crowdin project

## Why did you change it
It was giving a 404 error

## Screenshots
### Before


### After


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Android translation contribution instructions with the current Crowdin project link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->