### PR TITLE
Add jsoncpp to Meshtastic build tools dependencies for Fedora

### DIFF
--- a/docs/development/linux.mdx
+++ b/docs/development/linux.mdx
@@ -35,7 +35,7 @@ The following libraries must be installed before building `meshtasticd` or `nati
   # Enable the Meshtastic build tools COPR repository
   sudo dnf copr enable @meshtastic/build-tools
   # Base dependencies
-  sudo dnf install gcc-c++ pkgconfig(yaml-cpp) pkgconfig(libgpiod) pkgconfig(bluez) pkgconfig(libusb-1.0) libi2c-devel pkgconfig(libuv)
+  sudo dnf install gcc-c++ pkgconfig(yaml-cpp) pkgconfig(libgpiod) pkgconfig(bluez) pkgconfig(libusb-1.0) libi2c-devel pkgconfig(libuv) pkgconfig(jsoncpp)
   # Optional dependencies for web server support
   sudo dnf install pkgconfig(openssl) pkgconfig(liborcania) pkgconfig(libyder) pkgconfig(libulfius)
   # Optional dependencies for sdl support


### PR DESCRIPTION
Added jsoncpp as a dependency for the Meshtastic build tools. Closes #2466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Fedora installation instructions to include the required `jsoncpp` development package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->