### PR TITLE
chore(deps): add ox group for linting and formatting tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
       radix-ui:
         patterns:
           - "@radix-ui/*"
+      ox:
+        patterns:
+          - oxlint
+          - oxfmt


### PR DESCRIPTION
They're released together, meant to be updated together, and this will be less spammy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped Oxlint and Oxfmt dependency updates to simplify maintenance and reduce update noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->