### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -136,6 +136,7 @@ If you run a Discord server for your local community, be sure to follow our anno
 ## China
 
 - [Meshtastic 中国社区](https://meshcn.net)
+- [MeshROC 互联之域](https://meshroc.cc.cd)
 
 ## Colombia
 


### PR DESCRIPTION
This update adds the regional [MeshROC] community group based in China.
I add the Chinese regional [MeshROC] community group, to bring together domestic Lo‑Ra mesh hardware developers for field‑test, hardware‑debugging and open‑source firmware discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the MeshROC community link to the China local-groups listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->