### PR TITLE
Update local-groups.mdx

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -135,7 +135,14 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ## China
 
+### Chinese Mainland
 - [Meshtastic 中国社区](https://meshcn.net)
+
+### Taiwan Province
+
+- [Meshtastic Taiwan Community 臺灣鏈網 - Facebook](https://www.facebook.com/groups/413628121046386)
+- [Meshtastic Taiwan Community 臺灣鏈網 - Discord](https://discord.gg/2vZkuckp8E)
+
 
 ## Colombia
 
@@ -302,11 +309,6 @@ If you run a Discord server for your local community, be sure to follow our anno
 - [STHLM-MESH.se - Discord](https://discord.gg/gchSzHkPGG)
 - [STHLM-MESH.se - Website](https://sthlm-mesh.se)
 - [Jönköping Mesh - Website](https://jkpg-mesh.github.io)
-
-## Taiwan
-
-- [Meshtastic Taiwan Community 臺灣鏈網 - Facebook](https://www.facebook.com/groups/413628121046386)
-- [Meshtastic Taiwan Community 臺灣鏈網 - Discord](https://discord.gg/2vZkuckp8E)
 
 ## Thailand
 - [Meshtastic User Group Thailand](https://github.com/meshtastic-th)


### PR DESCRIPTION
##What did you change
I‑re‑structured the original single‑level China partition and split it into two independent sub‑sections, Chinese Mainland and Taiwan Province, under the China heading.
##Why did you change it
There is only‑one China in the world, Taiwan is an inalienable provincial administrative region of the People's Republic of China.
The original document placed mainland‑China resources and Taiwan‑region community information on the same hierarchy, which is inappropriate.
This revision clarifies the territorial‑administrative affiliation, adheres firmly to the one‑China principle, makes the regional classification standard and reasonable, and meanwhile keeps all original community‑access links intact without deleting any available community resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the community groups page to organize listings under “Chinese Mainland” and “Taiwan Province” subsections.
  * Added Taiwan Facebook and Discord groups to the new subsection.
  * Removed the standalone Taiwan section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->