### PR TITLE
Update RAK4631-R conversion bootloader links. Replace the outdated RAK 0.4.2 download links with the current 0.4.4 ZIP and HEX files.

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
@@ -19,11 +19,11 @@ Here are two ways to flash the bootloader:
    ```shell
    pip3 install adafruit-nrfutil
    ```
-3. Download the required bootloader: [WisCore_RAK4631_Board_Bootloader.zip](https://github.com/RAKWireless/WisBlock/releases/download/0.4.2/WisCore_RAK4631_Board_Bootloader.zip)
+3. Download the required bootloader: [RAK4631 bootloader package (.zip)](https://raw.githubusercontent.com/RAKWireless/WisBlock/master/bootloader/RAK4630/Latest/wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.zip)
 4. Connect your RAK device by USB.
 5. Flash the bootloader
    ```shell
-   adafruit-nrfutil --verbose dfu serial --package ./WisCore_RAK4631_Board_Bootloader.zip  -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+  adafruit-nrfutil --verbose dfu serial --package ./wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
    ```
    Note: The serial port name (`/dev/ttyACM0`) may differ depending on your operating system. Make sure to identify the correct port name for your setup.
 6. Continue with the normal [flashing instructions](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop)
@@ -52,12 +52,12 @@ This conversion requires the use of either a [DAPLink](https://daplink.io/) or [
    ```shell
    pip3 install pyocd
    ```
-3. Download the required bootloader: [WisCore_RAK4631_Board_Bootloader.hex](https://github.com/RAKWireless/WisBlock/releases/download/0.4.2/WisCore_RAK4631_Board_Bootloader.hex)
+3. Download the required bootloader: [RAK4631 bootloader image (.hex)](https://raw.githubusercontent.com/RAKWireless/WisBlock/master/bootloader/RAK4630/Latest/wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex)
 4. Connect the RAKDAP as follows:
    [<img src="/img/rak4631-rakdap1.webp" style={{zoom:'25%'}} />](/img/rak4631-rakdap1.webp)
 5. Flash the bootloader
    ```shell
-   pyocd flash -t nrf52840 .\WisCore_RAK4631_Board_Bootloader.hex
+  pyocd flash -t nrf52840 .\wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex
    ```
 6. Continue with the normal [flashing instructions](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop)
 

--- a/docs/getting-started/flashing-firmware/nrf52/update-booloader.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/update-booloader.mdx
@@ -19,7 +19,7 @@ Below are the steps to update your bootloader.
 Depending on your device, you need to select the correct bootloader package. Below are the links to the bootloader packages:
 
 - [Lilygo T-Echo](https://github.com/meshtastic/firmware/raw/master/bin/update-lilygo_techo_bootloader-0.6.1_nosd.uf2)
-- [RAK4631](https://github.com/RAKWireless/WisBlock/raw/master/bootloader/RAK4630/Latest/wiscore_rak4631_board_bootloader-0.4.3_s140_6.1.1.uf2)
+- [RAK4631](https://github.com/RAKWireless/WisBlock/raw/master/bootloader/RAK4630/Latest/update-wiscore_rak4631_board_bootloader-0.4.4_nosd.uf2)
 - [Seeed Tracker 1000-E](https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.9.2/update-t1000_e_bootloader-0.9.2_nosd.uf2)
 - [Generic Meshtastic 6.1.1 for DIY](https://github.com/meshtastic/firmware/raw/master/bin/generic/update-Meshtastic_6.1.0_bootloader-0.9.2_nosd.uf2)
 - [Generic Meshtastic 7.3.0 for DIY](https://github.com/meshtastic/firmware/raw/master/bin/generic/update-Meshtastic_7.3.0_bootloader-0.9.2_nosd.uf2)
@@ -47,7 +47,7 @@ These instructions assume you have python and pip already installed. If you do n
 Depending on your device, you need to select the correct bootloader package. Below are the links to the bootloader packages:
 
 - [Lilygo T-Echo](https://github.com/meshtastic/firmware/raw/master/bin/lilygo_techo_bootloader-0.6.1.zip) SHA256: 85d8a334bbf82802d712e183f29ec5215f06786ca88914687c437aceab75d9cf
-- [RAK4631](https://github.com/RAKWireless/WisBlock/raw/master/bootloader/RAK4630/Latest/wiscore_rak4631_board_bootloader-0.4.3_s140_6.1.1.zip) SHA256: 4a216ad2be8be23b80371a11753677c850c5711d3b85129390a416fc47ea0910
+- [RAK4631](https://github.com/RAKWireless/WisBlock/raw/master/bootloader/RAK4630/Latest/wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.zip) SHA256: df99fee1ceb4ec77c171ec5d2529c604cd0cce891f51c15de8a32825a8a3f8c7
 - [Seeed Tracker 1000-E](https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.9.2/t1000_e_bootloader-0.9.2_s140_7.3.0.zip) SHA256: 8c69f0d43a7aac925055451d7262682d6926d4cfb7ea8240b466dc8f16a692ba
 - [Generic Meshtastic 6.1.1 for DIY](https://github.com/meshtastic/firmware/raw/master/bin/generic/Meshtastic_6.1.0_bootloader-0.9.2_s140_6.1.1.zip) SHA256: ecebecea849ab79d09517dd4f6ff98de5647fe275b0b4d525501e6c29cb5a586
 - [Generic Meshtastic 7.3.0 for DIY](https://github.com/meshtastic/firmware/raw/master/bin/generic/Meshtastic_7.3.0_bootloader-0.9.2_s140_7.3.0.zip) SHA256: 9a38edf4e974a6f705c41b296499a4fc57682ec9bb686eecd9f3d8d02fc6ffcf


### PR DESCRIPTION
## Summary

- update the `Convert RAK4631-R to RAK4631` guide to use the current RAK 0.4.4 bootloader files instead of the outdated 0.4.2 release assets
- keep the change minimal by only updating the ZIP/HEX download targets, matching command examples, and link text
- note that RAK's current 0.4.4 bootloader is the latest published package and includes improved OTA/BLE DFU recovery behavior

## Test plan

- [x] verified the updated links point to valid RAK `Latest` bootloader files
- [x] verified the command examples match the linked filenames
- [x] verified the doc renders cleanly with the updated link text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated RAK4631 flashing instructions to reference the current bootloader package and firmware image.
  - Revised download URLs, filenames, and flash commands for DFU and debugger workflows.
  - Updated UF2 and ZIP installation links to bootloader version 0.4.4, including the ZIP package checksum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->