### PR TITLE
Fix RAK4631-R conversion guide code fence indentation.

### DIFF
--- a/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
@@ -23,7 +23,7 @@ Here are two ways to flash the bootloader:
 4. Connect your RAK device by USB.
 5. Flash the bootloader
    ```shell
-  adafruit-nrfutil --verbose dfu serial --package ./wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+   adafruit-nrfutil --verbose dfu serial --package ./wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
    ```
    Note: The serial port name (`/dev/ttyACM0`) may differ depending on your operating system. Make sure to identify the correct port name for your setup.
 6. Continue with the normal [flashing instructions](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop)
@@ -57,7 +57,7 @@ This conversion requires the use of either a [DAPLink](https://daplink.io/) or [
    [<img src="/img/rak4631-rakdap1.webp" alt="RAK4631 connected to a RAKDAP1 debug probe" style={{zoom:'25%'}} />](/img/rak4631-rakdap1.webp)
 5. Flash the bootloader
    ```shell
-  pyocd flash -t nrf52840 .\wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex
+   pyocd flash -t nrf52840 .\wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex
    ```
 6. Continue with the normal [flashing instructions](/docs/getting-started/flashing-firmware/nrf52/drag-n-drop)
 


### PR DESCRIPTION
## Summary
- restore 3-space indentation inside the DFU and Debugger `shell` code blocks in `convert-rak4631r.mdx`
- this fixes the broken Docusaurus rendering introduced by #2595, where under-indented command lines caused the closing fence to open a new code block and swallow the rest of the page

## Test plan
- [x] verified command lines now use the same 3-space indent as the surrounding fences
- [ ] confirm https://meshtastic.org/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r/ renders correctly after deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected indentation for USB DFU and debugger bootloader commands in the RAK4631-R flashing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->