### PR TITLE
feat: make homepage devices modal linkable via #hardware hash

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -74,6 +74,51 @@ test.describe("Homepage", () => {
     await expect(sentMessage).toBeVisible();
   });
 
+  test("should open devices modal from Need Hardware button and update URL", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: /need hardware/i }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Devices" });
+    await expect(dialog).toBeVisible();
+    await expect(page).toHaveURL(/#hardware$/);
+  });
+
+  test("should open devices modal directly via #hardware deep link", async ({
+    page,
+  }) => {
+    await page.goto("/#hardware");
+    const dialog = page.getByRole("dialog", { name: "Devices" });
+    await expect(dialog).toBeVisible();
+  });
+
+  test("should close devices modal and remove hash when dismissed", async ({
+    page,
+  }) => {
+    await page.goto("/#hardware");
+    const dialog = page.getByRole("dialog", { name: "Devices" });
+    await expect(dialog).toBeVisible();
+
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(dialog).not.toBeVisible();
+    await expect(page).not.toHaveURL(/#hardware/);
+  });
+
+  test("should close devices modal with browser back button", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: /need hardware/i }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Devices" });
+    await expect(dialog).toBeVisible();
+
+    await page.goBack();
+    await expect(dialog).not.toBeVisible();
+    await expect(page).not.toHaveURL(/#hardware/);
+  });
+
   test("should add emoji reaction to a message", async ({ page }) => {
     // Device mockup is only visible on md and above screens
     await page.setViewportSize({ width: 1280, height: 800 });

--- a/src/components/homepage/homepage-content.tsx
+++ b/src/components/homepage/homepage-content.tsx
@@ -8,19 +8,43 @@ import { Sponsors } from "@/components/homepage/sponsors";
 import { Button } from "@/components/ui/button";
 import links from "@/data/links.json";
 import Link from "@docusaurus/Link";
+import { useHistory, useLocation } from "@docusaurus/router";
 import Translate, { translate } from "@docusaurus/Translate";
 import { ArrowRight, Download, FileText, Radio, X } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { SocialSidebar } from "./social-sidebar";
+
+// Deep link for the devices overlay, e.g. https://meshtastic.org/#hardware
+const HARDWARE_HASH = "#hardware";
 
 export function HomePageContent() {
   const [showDevices, setShowDevices] = useState(false);
+  const history = useHistory();
+  const location = useLocation();
+
+  // Keep the overlay in sync with the URL hash so it can be opened via a
+  // direct link and closed with the browser back button.
+  useEffect(() => {
+    setShowDevices(location.hash === HARDWARE_HASH);
+  }, [location.hash]);
+
+  const openDevices = () => {
+    history.push({ ...location, hash: HARDWARE_HASH });
+  };
+
+  const closeDevices = useCallback(() => {
+    if (location.hash === HARDWARE_HASH) {
+      history.replace({ ...location, hash: "" });
+    } else {
+      setShowDevices(false);
+    }
+  }, [history, location]);
 
   useEffect(() => {
     if (showDevices) {
       document.body.style.overflow = "hidden";
       const handleEscape = (e: KeyboardEvent) => {
-        if (e.key === "Escape") setShowDevices(false);
+        if (e.key === "Escape") closeDevices();
       };
       document.addEventListener("keydown", handleEscape);
       return () => {
@@ -31,7 +55,7 @@ export function HomePageContent() {
     return () => {
       document.body.style.overflow = "";
     };
-  }, [showDevices]);
+  }, [showDevices, closeDevices]);
 
   return (
     <div className="relative min-h-screen overflow-hidden">
@@ -51,17 +75,21 @@ export function HomePageContent() {
                 <Translate id="homepage.hero.offGrid">Off-Grid</Translate>
                 <br />
                 <span className="text-primary dark:text-[hsl(var(--btn-primary))]">
-                  <Translate id="homepage.hero.communication">Communication</Translate>
+                  <Translate id="homepage.hero.communication">
+                    Communication
+                  </Translate>
                 </span>
                 <br />
-                <Translate id="homepage.hero.forEveryone">For Everyone</Translate>
+                <Translate id="homepage.hero.forEveryone">
+                  For Everyone
+                </Translate>
               </h2>
 
               <div className="mt-6 rounded-xl border border-border/50 bg-card/95 py-6 md:p-6 backdrop-blur-xl">
                 <p className="max-w-lg text-lg m-auto text-foreground lg:max-w-none">
                   <Translate id="homepage.hero.tagline">
-                    An open source, off-grid, decentralized mesh network built to
-                    run on affordable, low-power devices. No cell towers. No
+                    An open source, off-grid, decentralized mesh network built
+                    to run on affordable, low-power devices. No cell towers. No
                     internet. Just pure peer-to-peer connectivity.
                   </Translate>
                 </p>
@@ -75,18 +103,22 @@ export function HomePageContent() {
                     className="w-full border-0 bg-[hsl(var(--btn-primary))] p-5 font-mono text-base text-white dark:text-black shadow-none transition-colors hover:bg-[hsl(var(--btn-primary-hover))] sm:w-auto"
                   >
                     <Download className="mr-2 size-6" />
-                    <Translate id="homepage.hero.getStarted">Get Started</Translate>
+                    <Translate id="homepage.hero.getStarted">
+                      Get Started
+                    </Translate>
                     <ArrowRight className="ml-2 size-6" />
                   </Button>
                 </Link>
                 <Button
                   size="lg"
                   variant="ghost"
-                  onClick={() => setShowDevices(true)}
+                  onClick={openDevices}
                   className="w-full border-0 bg-transparent p-5 font-mono text-base text-foreground !shadow-none transition-colors hover:bg-[hsl(var(--btn-primary)/0.2)] hover:text-[hsl(var(--btn-primary))] sm:w-auto"
                 >
                   <Radio className="mr-2 size-6" />
-                  <Translate id="homepage.hero.needHardware">Need Hardware?</Translate>
+                  <Translate id="homepage.hero.needHardware">
+                    Need Hardware?
+                  </Translate>
                 </Button>
                 <Link to={links.docs}>
                   <Button
@@ -95,7 +127,9 @@ export function HomePageContent() {
                     className="w-full border-0 bg-transparent p-5 font-mono text-base text-foreground !shadow-none transition-colors hover:bg-[hsl(var(--btn-primary)/0.2)] hover:text-[hsl(var(--btn-primary))] sm:w-auto"
                   >
                     <FileText className="mr-2 size-6" />
-                    <Translate id="homepage.hero.readTheDocs">Read the Docs</Translate>
+                    <Translate id="homepage.hero.readTheDocs">
+                      Read the Docs
+                    </Translate>
                   </Button>
                 </Link>
               </div>
@@ -139,7 +173,7 @@ export function HomePageContent() {
           >
             <button
               type="button"
-              onClick={() => setShowDevices(false)}
+              onClick={closeDevices}
               className="absolute right-4 top-4 z-20 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
               aria-label={translate({
                 id: "homepage.devices.close",


### PR DESCRIPTION
## Why

The apps need to link users directly to the hardware/devices modal on the homepage. Previously the modal that opens when clicking **Need Hardware?** was component state only — there was no URL that could open it.

## What changed

The modal is now driven by the URL hash via the Docusaurus router:

- **`https://meshtastic.org/#hardware` opens the devices modal directly** — this is the URL to use from the apps
- Clicking **Need Hardware?** pushes `#hardware` onto the URL, so the open modal is shareable/bookmarkable
- Closing the modal (X button or Escape) removes the hash from the URL
- The browser back button also closes the modal

## Testing

- Added 4 e2e tests covering the deep link, the URL update on open, and both close paths (dismiss + back button)
- Full Playwright suite passes locally (42/42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Devices overlay can now be opened directly using the `#hardware` URL hash.
  * Browser navigation, the Escape key, and the overlay controls now open or close the overlay consistently.
  * Closing the overlay automatically removes the URL hash.

* **Tests**
  * Added end-to-end coverage for opening, dismissing, and navigating the Devices overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->