### PR TITLE
docs: add AS3935 lightning sensor to telemetry table

### DIFF
--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -59,9 +59,9 @@ Supported sensors connected to the I2C bus of the device will be automatically d
 | DFROBOT_RAIN |          0x1d          |                            Tip Bucket Rain counter                            |
 |    AS3935    |    0x01, 0x02, 0x03    |           Lightning strike count (1h) and estimated storm distance            |
 |   RadSens    |          0x66          |                                Radio Dosimeter                                |
-|   MAX30102   |          0x57          | Heart Rate, Oxygen Saturation, and body temperature |
-|   MLX90614   |          0x5A          |                  Body temperature                   |
-|   MLX90632   |          0x3A          |                  Body temperature                   |
+|   MAX30102   |          0x57          |              Heart Rate, Oxygen Saturation, and body temperature              |
+|   MLX90614   |          0x5A          |                               Body temperature                                |
+|   MLX90632   |          0x3A          |                               Body temperature                                |
 |   NAU7802    |          0x2A          |                 24-Bit differential ADC for Wheatstone bridge                 |
 
 :::note

--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -57,11 +57,16 @@ Supported sensors connected to the I2C bus of the device will be automatically d
 |   PMSA003I   |          0x12          |            Concentration units by size and particle counts by size            |
 | DFROBOT_LARK |          0x42          |    Temperature, barometric pressure, humidity, wind direction, wind speed     |
 | DFROBOT_RAIN |          0x1d          |                            Tip Bucket Rain counter                            |
+|    AS3935    |    0x01, 0x02, 0x03    |           Lightning strike count (1h) and estimated storm distance            |
 |   RadSens    |          0x66          |                                Radio Dosimeter                                |
 |   MAX30102   |          0x57          | Heart Rate, Oxygen Saturation, and body temperature |
 |   MLX90614   |          0x5A          |                  Body temperature                   |
 |   MLX90632   |          0x3A          |                  Body temperature                   |
 |   NAU7802    |          0x2A          |                 24-Bit differential ADC for Wheatstone bridge                 |
+
+:::note
+For the AS3935, wiring its IRQ pin and defining `AS3935_IRQ` in the variant avoids polling the sensor over I2C every second.
+:::
 
 ## Module Config Values
 


### PR DESCRIPTION
<!-- Add or remove sections as needed -->
## What did you change
Added the AS3935 lightning sensor to the "Currently Supported Sensor Types" table, with its I2C addresses and reported data points, plus a note that `AS3935_IRQ` avoids polling the sensor over I2C every second.

Fixed column padding on the MAX30102/MLX90614/MLX90632 rows to match the rest of the table.

## Why did you change it
meshtastic/firmware#10931 added AS3935 lightning-detection sensor support to the Environment Telemetry module.

## Screenshots
None provided, change is small.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AS3935 to the supported sensor list.
  * Documented its I²C addresses and lightning telemetry fields.
  * Added wiring guidance for the IRQ pin to reduce unnecessary polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->