### PR TITLE
docs: separate device display units from app locale units

### DIFF
--- a/docs/configuration/radio/display.mdx
+++ b/docs/configuration/radio/display.mdx
@@ -45,6 +45,8 @@ Acceptable values:
 
 Switch between `METRIC` (default) and `IMPERIAL` units
 
+This setting applies to the screen on the device only. The apps take their units from the phone locale — see [Android](/docs/software/android/user/units-and-locale) and [Apple](/docs/software/apple/user/units-and-locale) — and are unaffected by it.
+
 ### Flip Screen
 
 If enabled, the screen will be rotated 180 degrees, for cases that mount the screen upside down

--- a/docs/configuration/radio/display.mdx
+++ b/docs/configuration/radio/display.mdx
@@ -45,7 +45,7 @@ Acceptable values:
 
 Switch between `METRIC` (default) and `IMPERIAL` units
 
-This setting applies to the screen on the device only. The apps take their units from the phone locale — see [Android](/docs/software/android/user/units-and-locale) and [Apple](/docs/software/apple/user/units-and-locale) — and are unaffected by it.
+This setting applies to the screen on the device only. The apps take their units from the client's locale (phone, desktop, or browser) — see [Android](/docs/software/android/user/units-and-locale) and [Apple](/docs/software/apple/user/units-and-locale) — and are unaffected by it.
 
 ### Flip Screen
 

--- a/docs/software/android/user/units-and-locale.md
+++ b/docs/software/android/user/units-and-locale.md
@@ -1,7 +1,7 @@
 ---
 title: Units, Measurement & Locale
 sidebar_position: 16
-last_updated: 2026-08-26
+last_updated: 2026-08-19
 description: How the app formats temperature, distance, speed, and other measurements based on your device locale.
 parent: User Guide
 ---
@@ -21,12 +21,6 @@ On Android, your measurement preferences are determined by your system **Languag
 > 💡 **Tip:** You never need to toggle units inside the app. Change your system measurement preferences and every screen in Meshtastic updates automatically — node details, telemetry charts, weather, altitude, and more.
 
 ---
-
-## The Radio's Own Screen Is Separate
-
-**Device → Display → Units** configures the screen on the radio, not the app. So do **Use 12-Hour Clock** and **Always Point North** — all three apply to the node's display only. Temperature on that screen has its own setting, **Telemetry → Environment Display Fahrenheit**.
-
-If your node list shows miles while the radio's screen shows kilometres, this is why: the two are set in different places. Changing the device setting will never alter what the app displays. See [Display Config](/docs/configuration/radio/display) for the device-side options.
 
 ## Temperature
 
@@ -124,10 +118,6 @@ On Android, your measurement system (metric vs imperial) is tied to your region 
 3. On Android 14+, temperature can be overridden on its own under **Regional preferences → Temperature**
 4. Return to Meshtastic — values update immediately
 
-Not every English region is fully metric. **English (United Kingdom)** uses miles and feet for distance, so the node list shows miles and altitude in feet. For metric distances, choose a fully metric region such as English (Canada), English (Ireland), or English (New Zealand).
-
-Some phones do not offer the **Regional preferences** menu at all and list only English (United States). On those devices there is currently no way to select metric units for the app.
-
 > 💡 **Tip:** All measurement formatting is handled centrally and respects your platform's locale, so units stay consistent everywhere in the app.
 
 ## Related Topics
@@ -136,7 +126,6 @@ Some phones do not offer the **Regional preferences** menu at all and list only 
 - [Telemetry & Sensors](telemetry-and-sensors.md) — the sensors that produce these measurements
 - [Measurement & Formatting](../developer/measurement.md) — developer reference for the formatting utilities
 - [Settings — Radio & User](settings-radio-user.md) — region setting that drives unit selection
-- [Display Config](/docs/configuration/radio/display) — units, clock, and compass settings for the radio's own screen
 
 ---
 

--- a/docs/software/android/user/units-and-locale.md
+++ b/docs/software/android/user/units-and-locale.md
@@ -1,7 +1,7 @@
 ---
 title: Units, Measurement & Locale
 sidebar_position: 16
-last_updated: 2026-08-19
+last_updated: 2026-08-26
 description: How the app formats temperature, distance, speed, and other measurements based on your device locale.
 parent: User Guide
 ---
@@ -21,6 +21,12 @@ On Android, your measurement preferences are determined by your system **Languag
 > 💡 **Tip:** You never need to toggle units inside the app. Change your system measurement preferences and every screen in Meshtastic updates automatically — node details, telemetry charts, weather, altitude, and more.
 
 ---
+
+## The Radio's Own Screen Is Separate
+
+**Device → Display → Units** configures the screen on the radio, not the app. So do **Use 12-Hour Clock** and **Always Point North** — all three apply to the node's display only. Temperature on that screen has its own setting, **Telemetry → Environment Display Fahrenheit**.
+
+If your node list shows miles while the radio's screen shows kilometres, this is why: the two are set in different places. Changing the device setting will never alter what the app displays. See [Display Config](/docs/configuration/radio/display) for the device-side options.
 
 ## Temperature
 
@@ -118,6 +124,10 @@ On Android, your measurement system (metric vs imperial) is tied to your region 
 3. On Android 14+, temperature can be overridden on its own under **Regional preferences → Temperature**
 4. Return to Meshtastic — values update immediately
 
+Not every English region is fully metric. **English (United Kingdom)** uses miles and feet for distance, so the node list shows miles and altitude in feet. For metric distances, choose a fully metric region such as English (Canada), English (Ireland), or English (New Zealand).
+
+Some phones do not offer the **Regional preferences** menu at all and list only English (United States). On those devices there is currently no way to select metric units for the app.
+
 > 💡 **Tip:** All measurement formatting is handled centrally and respects your platform's locale, so units stay consistent everywhere in the app.
 
 ## Related Topics
@@ -126,6 +136,7 @@ On Android, your measurement system (metric vs imperial) is tied to your region 
 - [Telemetry & Sensors](telemetry-and-sensors.md) — the sensors that produce these measurements
 - [Measurement & Formatting](../developer/measurement.md) — developer reference for the formatting utilities
 - [Settings — Radio & User](settings-radio-user.md) — region setting that drives unit selection
+- [Display Config](/docs/configuration/radio/display) — units, clock, and compass settings for the radio's own screen
 
 ---
 


### PR DESCRIPTION
Display config's Units setting only drives the radio's own screen, but it's the first thing people find when the app shows the wrong units.

- Display config: note that the apps follow the phone locale instead.
- Android Units & Locale: new section on the device-screen settings, plus the regions Android treats as imperial (English UK) and phones with no Regional preferences menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that preferred display units affect only the device screen.
  * Explained that apps use the client’s locale, such as phone, desktop, or browser settings, and are not affected by this preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->