### PR TITLE
Change touchscreen type from capacitive to resistive

### DIFF
--- a/docs/hardware/devices/community-supported/unPhone/index.mdx
+++ b/docs/hardware/devices/community-supported/unPhone/index.mdx
@@ -29,7 +29,7 @@ For more comprehensive information on the unPhone, please visit the project's we
 ## Features
 
 - 8MB flash and 8MB PSRAM
-- 3.5" (320x480) LCD capacitive touchscreen
+- 3.5" (320x480) LCD resistive touchscreen
 - IR LEDs
 - 1200mAh LiPo battery with USB-C charging
 - Vibration motor


### PR DESCRIPTION
https://shop.pimoroni.com/products/unphone?variant=40829810311251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the unPhone feature specification to identify its touchscreen as resistive rather than capacitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->