### PR TITLE
docs: add HELTEC and M5Stack devices and move LILYGO to partner hardware

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -83,6 +83,14 @@ The ESP32 chip is equipped with both WiFi and Bluetooth, making it ideal for dev
 
 <div style={{ clear: "both" }} />
 
+<DeviceImage device="m5stack_cardputer.svg" float="right" size="sm" />
+
+#### M5Stack
+
+[Cardputer Mesh Kit](/docs/hardware/devices/m5stack/cardputer/) — Pocket messaging terminal with keyboard, LoRa cap, and GNSS
+
+<div style={{ clear: "both" }} />
+
 ## nRF52
 
 The nRF52 chip is much more power efficient than the ESP32 chip and easier to update via UF2 bootloader, but is only equipped with Bluetooth (no WiFi). Ideal for battery-powered and solar deployments.

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -57,7 +57,7 @@ The ESP32 chip is equipped with both WiFi and Bluetooth, making it ideal for dev
 
 <div style={{ clear: "both" }} />
 
-<DeviceImage device="heltec_v4.svg" float="right" size="sm" />
+<DeviceImage device="heltec_v4.svg" float="right" size="xs" />
 
 #### HELTEC®
 
@@ -113,7 +113,7 @@ The nRF52 chip is much more power efficient than the ESP32 chip and easier to up
 
 <div style={{ clear: "both" }} />
 
-<DeviceImage device="heltec-t096.svg" float="right" size="sm" />
+<DeviceImage device="heltec-t096.svg" float="right" size="xs" />
 
 #### HELTEC®
 

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -57,7 +57,13 @@ The ESP32 chip is equipped with both WiFi and Bluetooth, making it ideal for dev
 
 <div style={{ clear: "both" }} />
 
-### Backer Hardware
+<DeviceImage device="heltec_v4.svg" float="right" size="sm" />
+
+#### HELTEC®
+
+[LoRa32 V4](/docs/hardware/devices/heltec-automation/lora32/?heltec=v4) — ESP32-S3 board with built-in 0.96 inch OLED display
+
+<div style={{ clear: "both" }} />
 
 <DeviceImage device="t-deck.svg" float="right" size="sm" />
 
@@ -66,6 +72,8 @@ The ESP32 chip is equipped with both WiFi and Bluetooth, making it ideal for dev
 [T-Deck / T-Deck Plus / T-Deck Pro](/docs/hardware/devices/lilygo/tdeck/) — Standalone devices with screen and keyboard
 
 <div style={{ clear: "both" }} />
+
+### Backer Hardware
 
 <DeviceImage device="station-g2.svg" float="right" size="sm" />
 
@@ -105,7 +113,13 @@ The nRF52 chip is much more power efficient than the ESP32 chip and easier to up
 
 <div style={{ clear: "both" }} />
 
-### Backer Hardware
+<DeviceImage device="heltec-t096.svg" float="right" size="sm" />
+
+#### HELTEC®
+
+[Mesh Node T096](/docs/hardware/devices/heltec-automation/mesh-node/?heltec=t096) — Ultra-low-power nRF52840 node with color TFT display and GNSS
+
+<div style={{ clear: "both" }} />
 
 <DeviceImage device="t-echo.svg" float="right" size="sm" />
 
@@ -114,6 +128,8 @@ The nRF52 chip is much more power efficient than the ESP32 chip and easier to up
 [T-Echo](/docs/hardware/devices/lilygo/techo/) — All-in-one unit with E-Ink screen, GPS, and battery in injection-molded case
 
 <div style={{ clear: "both" }} />
+
+### Backer Hardware
 
 <DeviceImage device="muzi_r1_neo.svg" float="right" size="md" />
 


### PR DESCRIPTION
## What did you change

Updated the supported hardware listings on the Getting Started page.

**ESP32**

* Add **HELTEC®** to Partner Hardware — [LoRa32 V4](https://meshtastic.org/docs/hardware/devices/heltec-automation/lora32/?heltec=v4)
* Add **M5Stack** to Backer Hardware — [Cardputer Mesh Kit](https://meshtastic.org/docs/hardware/devices/m5stack/cardputer/)
* Move **LILYGO®** (T-Deck / T-Deck Plus / T-Deck Pro) from Backer Hardware to Partner Hardware

**nRF52**

* Add **HELTEC®** to Partner Hardware — [Mesh Node T096](https://meshtastic.org/docs/hardware/devices/heltec-automation/mesh-node/?heltec=t096)
* Move **LILYGO®** (T-Echo) from Backer Hardware to Partner Hardware

All new entries follow the block formatting already used on the page: a floated `DeviceImage`, a `####` vendor heading, the linked device name with an em-dash description, then the `clear: both` divider. Vendor headings use `HELTEC®` and `M5Stack`, matching the styling used in the hardware docs. Images reuse the existing `heltec_v4.svg`, `heltec-t096.svg`, and `m5stack_cardputer.svg` assets.

Because `DeviceImage` constrains height rather than width, image sizes were chosen so each new entry's rendered footprint matches its neighbors. The two Heltec boards are landscape (aspect ~2.1) where every other image on the page is portrait, so they use `size="xs"` — the same size already used for these boards on the hardware devices index. The Cardputer is portrait at nearly the same aspect as the Station G2 beside it, so it uses `size="sm"` to match.

Backer Hardware now lists B&Q Consulting and M5Stack (ESP32), and muzi ᴡᴏʀᴋꜱ (nRF52).

## Why did you change it

HELTEC® is a Meshtastic partner but had no representation in the partner hardware examples on Getting Started, and LILYGO® was listed under Backer Hardware rather than Partner Hardware. The M5Stack Cardputer Mesh Kit is documented in the hardware section but was not surfaced among the backer hardware examples. This brings the page in line with current partner and backer status for these vendors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added HELTEC® hardware listings for the LoRa32 V4 and Mesh Node T096 devices.
  - Included device images and descriptions in the ESP32 and nRF52 hardware sections.
  - Added the M5Stack Cardputer Mesh Kit to the ESP32 backer hardware listings.
  - Reorganized the sections so partner hardware appears before backer hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->