### PR TITLE
chore(deps): update @meshtastic/protobufs to version 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mdx-js/react": "^3.1.1",
     "@mermaid-js/layout-elk": "^0.2.3",
     "@meshtastic/core": "jsr:^2.6.6",
-    "@meshtastic/protobufs": "jsr:^2.7.26",
+    "@meshtastic/protobufs": "jsr:^2.8.0",
     "@radix-ui/react-popover": "^1.1.23",
     "@radix-ui/react-slot": "^1.3.3",
     "@radix-ui/react-tooltip": "^1.2.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: jsr:^2.6.6
         version: '@jsr/meshtastic__core@2.6.6'
       '@meshtastic/protobufs':
-        specifier: jsr:^2.7.26
-        version: '@jsr/meshtastic__protobufs@2.7.26'
+        specifier: jsr:^2.8.0
+        version: '@jsr/meshtastic__protobufs@2.8.0'
       '@radix-ui/react-popover':
         specifier: ^1.1.23
         version: 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1683,11 +1683,8 @@ packages:
   '@jsr/meshtastic__core@2.6.6':
     resolution: {integrity: sha512-f9c/HV6d7fGg+FtsnnC6DSomdGQ7Hr96JiT3epTUduwClYFdi/ftKEadfV55cMhCrp1QK9y6lkPG2S+X1AwN5Q==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__core/2.6.6.tgz}
 
-  '@jsr/meshtastic__protobufs@2.7.20':
-    resolution: {integrity: sha512-GrHWfOzi9i7xk2Br3MkKWLxbzreZuwgjZKNooednYpa1V/abnSj9e4twNTtKyqXYaAOzthY3Cdk4IXouBN9dbA==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.7.20.tgz}
-
-  '@jsr/meshtastic__protobufs@2.7.26':
-    resolution: {integrity: sha512-NxqJDr8kRgeFv0YzkIn97n9zLQYz75lMZAxTFQKFI4NcFH11ijVczQXRRmbNlj9gtXKQAnuGKJIaFm6nODiS6g==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.7.26.tgz}
+  '@jsr/meshtastic__protobufs@2.8.0':
+    resolution: {integrity: sha512-FiyUe1AYhD4Plt0hiewx8s+Q+icZA58MZyTWLwOusb5yNWQHX5oJ7EK8EQt82N7hrgSYU0MZyPyYliQuTUkLaw==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.8.0.tgz}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -10607,18 +10604,14 @@ snapshots:
   '@jsr/meshtastic__core@2.6.6':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
-      '@jsr/meshtastic__protobufs': 2.7.20
+      '@jsr/meshtastic__protobufs': 2.8.0
       crc: 4.3.2
       ste-simple-events: 3.0.11
       tslog: 4.10.2
     transitivePeerDependencies:
       - buffer
 
-  '@jsr/meshtastic__protobufs@2.7.20':
-    dependencies:
-      '@bufbuild/protobuf': 2.11.0
-
-  '@jsr/meshtastic__protobufs@2.7.26':
+  '@jsr/meshtastic__protobufs@2.8.0':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
 


### PR DESCRIPTION
Update protobufs package to v2.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Meshtastic protobuf dependency to version 2.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->