### PR TITLE
docs(stm32): RAK3172, Wio-E5, Nucleo-WL55JC device pages

### DIFF
--- a/docs/getting-started/flashing-firmware/stm32/index.mdx
+++ b/docs/getting-started/flashing-firmware/stm32/index.mdx
@@ -46,9 +46,10 @@ without using BOOT0 or the ROM bootloader.
 STM32WL has no USB peripheral, so there is no USB DFU mode. A UART flash (through
 the ROM bootloader) and an SWD flash are the only options.
 
-Any USB port which connects to an internal USB-to-UART bridge and can be used
-for UART flashing, unless that bridge is not wired to a bootloader UART (as on
-the Wio-E5).
+Any USB port connects to an internal USB-to-UART bridge and can be used for UART
+flashing, unless that bridge is not wired to a bootloader UART. On the Wio-E5 it
+is not, though two jumper wires can bridge it to one; see the
+[Wio-E5 page](/docs/hardware/devices/community-supported/seeed-studio/wio-series/seeed-wio-e5?e5=wio-e5-dev).
 
 ### Removing Readout Protection
 

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -161,6 +161,35 @@ The RP2040 and RP2350 are dual-core chips developed by Raspberry Pi. Cost-effect
 
 - Raspberry Pi Pico + Waveshare LoRa Module (Note: **Bluetooth on the Pico W is not yet supported by Meshtastic**)
 
+## STM32
+
+The STM32WL from STMicroelectronics puts an Arm Cortex-M4 and a Semtech SX126x radio on one chip &mdash; the lowest part count and power draw of any Meshtastic target, with no WiFi or Bluetooth.
+
+Due to low flash memory and RAM, a number of features have been excluded from STM32WL firmware by default (specific variants may re-enable specific features).
+
+<details>
+  <summary>Features excluded from STM32WL firmware by default</summary>
+
+- ATAK/TAK forwarding
+- Codec2 audio
+- MQTT
+- Remote Hardware module
+- Waypoints
+- On-device display and menu UI
+- Input peripherals (rotary encoders, trackballs, buttons/keyboards) and buzzer
+- Power monitoring and power-metrics telemetry
+- Timezone database
+- RTTTL ringtones
+- Signed-packet authenticity policy
+
+</details>
+
+### Community Supported
+
+- [RAK3172/RAK3372 Core module](/docs/hardware/devices/community-supported/rakwireless/wisblock/?rakcore=RAK3172) — STM32WLE5 WisBlock module for embedding into custom hardware
+- [Seeed Wio-E5](/docs/hardware/devices/community-supported/seeed-studio/wio-series/seeed-wio-e5/) — STM32WLE5 wireless module, mini dev board, and dev kit
+- [STMicroelectronics Nucleo-WL55JC](/docs/hardware/devices/community-supported/stmicroelectronics/nucleo-wl55jc) — Official STM32WL evaluation board with onboard ST-LINK
+
 :::info
 
 If your device is not listed above, please review our [supported devices](/docs/hardware/devices/index.mdx) to determine which MCU your device has or contact us in [Discord](https://discord.gg/ktMAKGBnBs) with any questions.

--- a/docs/hardware/devices/community-supported/index.mdx
+++ b/docs/hardware/devices/community-supported/index.mdx
@@ -77,12 +77,13 @@ Boards complete with GPS, 18650 battery holder, and optional screen.
 
 A lineup of development boards and modules for hobbyists and prototyping, with a variety of MCU and sensor options. Most models are intended for integration into custom projects, while the Tracker L1 has a "Pro" variant that is available as a ready-to-go handheld device with a pre-installed case and battery.
 
-| Name                                                                                         | MCU         | Radio      |     WiFi     | BT  |   GPS    |
-| :------------------------------------------------------------------------------------------- | :---------- | :--------- | :----------: | :-: | :------: |
-| [Seeed Wio-WM1110 Dev Kit](./seeed-studio/wio-series/seeed-wm1110/?wm1110=wio-sdk-wm1110)    | nRF52840    | LR1110     |     YES      | 5.3 |   YES    |
-| [Seeed Wio Tracker 1110](./seeed-studio/wio-series/seeed-wm1110/?wm1110=wio-tracker-wm1110)  | nRF52840    | LR1110     |     YES      | 5.3 |   YES    |
-| [Wio-E5 mini Dev Board](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-mini)              | STM32WLE5JC | SX126X     |      NO      | NO  |    NO    |
-| [Wio-E5 Dev Kit](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-dev)                      | STM32WLE5JC | SX126X     |      NO      | NO  |    NO    |
+| Name                                                                                        | MCU         | Radio  | WiFi | BT  | GPS |
+| :------------------------------------------------------------------------------------------ | :---------- | :----- | :--: | :-: | :-: |
+| [Seeed Wio-WM1110 Dev Kit](./seeed-studio/wio-series/seeed-wm1110/?wm1110=wio-sdk-wm1110)   | nRF52840    | LR1110 | YES  | 5.3 | YES |
+| [Seeed Wio Tracker 1110](./seeed-studio/wio-series/seeed-wm1110/?wm1110=wio-tracker-wm1110) | nRF52840    | LR1110 | YES  | 5.3 | YES |
+| [Wio-E5 mini Dev Board](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 Dev Kit](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 Wireless Module](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
 
 ## [B&Q Consulting](./b-and-q-consulting/)
 

--- a/docs/hardware/devices/community-supported/index.mdx
+++ b/docs/hardware/devices/community-supported/index.mdx
@@ -17,9 +17,10 @@ Modular hardware system with Base, Core and Peripheral modules including the low
 
 [**WisBlock Core Modules**](./rakwireless/wisblock/)
 
-| Name                                                | MCU   | Radio  |     WiFi     | BT  |  GPS   |
-| :-------------------------------------------------- | :---- | :----- | :----------: | :-: | :----: |
-| [RAK11200](./rakwireless/wisblock?rakcore=RAK11200) | ESP32 | ADD-ON | 2.4GHz b/g/n | 4.2 | ADD-ON |
+| Name                                                       | MCU       | Radio  |     WiFi     | BT  |  GPS   |
+| :--------------------------------------------------------- | :-------- | :----- | :----------: | :-: | :----: |
+| [RAK3172/RAK3372](./rakwireless/wisblock?rakcore=RAK3172)  | STM32WLE5 | SX1262 |      NO      | NO  |   NO   |
+| [RAK11200](./rakwireless/wisblock?rakcore=RAK11200)        | ESP32     | ADD-ON | 2.4GHz b/g/n | 4.2 | ADD-ON |
 
 ## LILYGO®
 

--- a/docs/hardware/devices/community-supported/index.mdx
+++ b/docs/hardware/devices/community-supported/index.mdx
@@ -19,7 +19,7 @@ Modular hardware system with Base, Core and Peripheral modules including the low
 
 | Name                                                       | MCU       | Radio  |     WiFi     | BT  |  GPS   |
 | :--------------------------------------------------------- | :-------- | :----- | :----------: | :-: | :----: |
-| [RAK3172/RAK3372](./rakwireless/wisblock?rakcore=RAK3172)  | STM32WLE5 | SX1262 |      NO      | NO  |   NO   |
+| [RAK3172/RAK3372](./rakwireless/wisblock?rakcore=RAK3172)  | STM32WLE5 | SX126x |      NO      | NO  |   NO   |
 | [RAK11200](./rakwireless/wisblock?rakcore=RAK11200)        | ESP32     | ADD-ON | 2.4GHz b/g/n | 4.2 | ADD-ON |
 
 ## LILYGO®
@@ -81,9 +81,9 @@ A lineup of development boards and modules for hobbyists and prototyping, with a
 | :------------------------------------------------------------------------------------------ | :---------- | :----- | :--: | :-: | :-: |
 | [Seeed Wio-WM1110 Dev Kit](./seeed-studio/wio-series/seeed-wm1110/?wm1110=wio-sdk-wm1110)   | nRF52840    | LR1110 | YES  | 5.3 | YES |
 | [Seeed Wio Tracker 1110](./seeed-studio/wio-series/seeed-wm1110/?wm1110=wio-tracker-wm1110) | nRF52840    | LR1110 | YES  | 5.3 | YES |
-| [Wio-E5 mini Dev Board](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
-| [Wio-E5 Dev Kit](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
-| [Wio-E5 Wireless Module](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 mini Dev Board](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX126x |  NO  | NO  | NO  |
+| [Wio-E5 Dev Kit](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX126x |  NO  | NO  | NO  |
+| [Wio-E5 Wireless Module](./seeed-studio/wio-series/seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX126x |  NO  | NO  | NO  |
 
 ## [B&Q Consulting](./b-and-q-consulting/)
 
@@ -142,4 +142,4 @@ Evaluation boards for the STM32WL LoRa microcontroller.
 
 | Name                                                | MCU       | Radio  | WiFi | BT  | GPS |
 | :-------------------------------------------------- | :-------- | :----- | :--: | :-: | :-: |
-| [Nucleo-WL55JC](./stmicroelectronics/nucleo-wl55jc) | STM32WL55 | SX1262 |  NO  | NO  | NO  |
+| [Nucleo-WL55JC](./stmicroelectronics/nucleo-wl55jc) | STM32WL55 | SX126x |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/index.mdx
+++ b/docs/hardware/devices/community-supported/index.mdx
@@ -135,3 +135,11 @@ DIY kit with ESP32, LoRa chip, and optional GPS. Designed for STEM education.
 | Name                       | MCU   | Radio                                         | WiFi | BT  | GPS |
 | :------------------------- | :---- | :-------------------------------------------- | :--: | :-: | :-: |
 | Bandit Nano ExpressLRS 900 | ESP32 | SX1276 + SKY66122 PA/LNA +30db TX, +16db RX ) |  ?   | YES | NO  |
+
+## [STMicroelectronics®](./stmicroelectronics/)
+
+Evaluation boards for the STM32WL LoRa microcontroller.
+
+| Name                                                | MCU       | Radio  | WiFi | BT  | GPS |
+| :-------------------------------------------------- | :-------- | :----- | :--: | :-: | :-: |
+| [Nucleo-WL55JC](./stmicroelectronics/nucleo-wl55jc) | STM32WL55 | SX1262 |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/rakwireless/index.mdx
+++ b/docs/hardware/devices/community-supported/rakwireless/index.mdx
@@ -10,6 +10,7 @@ sidebar_position: 1
 
 [**WisBlock Core Modules**](./wisblock/)
 
-| Name                                    | MCU   | Radio  |     WiFi     | BT  |  GPS   |
-| :-------------------------------------- | :---- | :----- | :----------: | :-: | :----: |
-| [RAK11200](./wisblock?rakcore=RAK11200) | ESP32 | ADD-ON | 2.4GHz b/g/n | 4.2 | ADD-ON |
+| Name                                            | MCU       | Radio  |     WiFi     | BT  |  GPS   |
+| :---------------------------------------------- | :-------- | :----- | :----------: | :-: | :----: |
+| [RAK3172/RAK3372](./wisblock?rakcore=RAK3172)   | STM32WLE5 | SX1262 |      NO      | NO  |   NO   |
+| [RAK11200](./wisblock?rakcore=RAK11200)         | ESP32     | ADD-ON | 2.4GHz b/g/n | 4.2 | ADD-ON |

--- a/docs/hardware/devices/community-supported/rakwireless/index.mdx
+++ b/docs/hardware/devices/community-supported/rakwireless/index.mdx
@@ -12,5 +12,5 @@ sidebar_position: 1
 
 | Name                                            | MCU       | Radio  |     WiFi     | BT  |  GPS   |
 | :---------------------------------------------- | :-------- | :----- | :----------: | :-: | :----: |
-| [RAK3172/RAK3372](./wisblock?rakcore=RAK3172)   | STM32WLE5 | SX1262 |      NO      | NO  |   NO   |
+| [RAK3172/RAK3372](./wisblock?rakcore=RAK3172)   | STM32WLE5 | SX126x |      NO      | NO  |   NO   |
 | [RAK11200](./wisblock?rakcore=RAK11200)         | ESP32     | ADD-ON | 2.4GHz b/g/n | 4.2 | ADD-ON |

--- a/docs/hardware/devices/community-supported/rakwireless/wisblock/index.mdx
+++ b/docs/hardware/devices/community-supported/rakwireless/wisblock/index.mdx
@@ -31,7 +31,7 @@ values={[
   - STM32WLE5CCU6
     - Arm Cortex-M4, 256 kB flash, 64 kB RAM
 - **LoRa Transceiver:**
-  - SX1262 (integrated into the STM32WL)
+  - STM32WL integrated sub-GHz radio (Semtech SX126x-based)
 - **Frequency Options:**
   - 433 MHz
   - 470 MHz

--- a/docs/hardware/devices/community-supported/rakwireless/wisblock/index.mdx
+++ b/docs/hardware/devices/community-supported/rakwireless/wisblock/index.mdx
@@ -5,9 +5,99 @@ sidebar_label: WisBlock
 sidebar_position: 1
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+groupId="rakcore"
+queryString="rakcore"
+defaultValue="RAK3172"
+values={[
+{label: 'RAK3172/RAK3372', value: 'RAK3172'},
+{label: 'RAK11200', value: 'RAK11200'}
+]}>
+
+<TabItem value="RAK3172">
+
+## RAK3172/RAK3372 - STM32WLE5
+
+:::info
+
+**This core module does not include BLE or Wi-Fi.**
+
+:::
+
+- **MCU:**
+  - STM32WLE5CCU6
+    - Arm Cortex-M4, 256 kB flash, 64 kB RAM
+- **LoRa Transceiver:**
+  - SX1262 (integrated into the STM32WL)
+- **Frequency Options:**
+  - 433 MHz
+  - 470 MHz
+  - 868 MHz
+  - 915 MHz
+  - 923 MHz
+- **Connectors:**
+  - U.FL/IPEX (MHF1) antenna connector for LoRa
+  - On `-SM-NI` modules the connector is replaced by an RF solder pad
+
+The **RAK3172** is a castellated SMD module for embedding an STM32WL node into a product. The **RAK3372** is the same module on a WisBlock Core form factor, and requires a [base board](/docs/hardware/devices/rak-wireless/wisblock/base-board/).
+
+### Ordering information
+
+RAK3172 part numbers follow the pattern `RAK3172[-T | -TE | -F]-<band>-SM-<I | NI>`.
+
+| Field      | Value    | Meaning                                         |
+| ---------- | -------- | ----------------------------------------------- |
+| Oscillator | _(none)_ | 32 MHz crystal only                             |
+|            | `-T`     | ±2.5 ppm TCXO, wider temperature range          |
+|            | `-TE`    | ±0.5 ppm TCXO                                   |
+|            | `-F`     | TCXO plus 512 kB external SPI flash             |
+| Band       | `-8`     | EU868, RU864, IN865                             |
+|            | `-9`     | US915, AU915, KR920, AS923                      |
+|            | `-43`    | EU433                                           |
+|            | `-47`    | CN470                                           |
+| Antenna    | `-SM-I`  | U.FL/IPEX (MHF1) connector                      |
+|            | `-SM-NI` | RF solder pad only                              |
+
+Representative orderable variants:
+
+| Part number       | Band  | Oscillator    | Antenna    |
+| ----------------- | ----- | ------------- | ---------- |
+| RAK3172-8-SM-I    | EU868 | Crystal       | IPEX       |
+| RAK3172-9-SM-I    | US915 | Crystal       | IPEX       |
+| RAK3172-T-8-SM-I  | EU868 | ±2.5 ppm TCXO | IPEX       |
+| RAK3172-T-9-SM-NI | US915 | ±2.5 ppm TCXO | Solder pad |
+| RAK3172-TE-8-SM-I | EU868 | ±0.5 ppm TCXO | IPEX       |
+| RAK3172-43-SM-I   | EU433 | Crystal       | IPEX       |
+
+Meshtastic builds with `TCXO_OPTIONAL`, so both TCXO (`-T`/`-TE`/`-F`) and crystal-only modules work. Whether a module ships with RAK's RUI3 firmware or bare LoRaWAN firmware does not matter once Meshtastic is flashed.
+
+### Flashing
+
+- [Flashing over SWD](/docs/getting-started/flashing-firmware/stm32/flashing-over-swd)
+- [Flashing over UART](/docs/getting-started/flashing-firmware/stm32/flashing-over-uart)
+
+### Resources
+
+- Firmware file: `firmware-rak3172-X.X.X.xxxxxxx.bin` (the RAK3372 uses the same `rak3172` firmware)
+- Further information on the RAK3172 can be found on the [RAK Documentation Center](https://docs.rakwireless.com/product-categories/wisduo/rak3172-module/).
+- Purchase Links:
+  - International
+    - [RAKwireless Store](https://store.rakwireless.com/products/wisduo-lpwan-module-rak3172)
+
+</TabItem>
+
+<TabItem value="RAK11200">
+
 ## RAK11200 - ESP32
 
-The RAK11200 does not contain a LoRa transceiver, and thus needs to be added separately in the form of the [RAK13300 LPWAN module](https://msh.to/rak13300). This occupies the IO Port of the base board.
+:::info
+
+**This core module does not contain a LoRa transceiver**, which needs to be added separately in the form of the [RAK13300 LPWAN module](https://msh.to/rak13300). This occupies the IO Port of the base board.
+
+:::
 
 - RAK11200
   - **MCU:**
@@ -31,7 +121,7 @@ The following process will manually place the device into Espressif Firmware Dow
 1. Ensure the device is powered on and connected via USB.
 2. Locate the **BOOT** pin on the J10 header of the WisBlock Base Board ([RAK19007](/docs/hardware/devices/rak-wireless/wisblock/base-board/?rakbase=RAK19007) / [RAK5005-O](/docs/hardware/devices/rak-wireless/wisblock/base-board/?rakbase=RAK5005-O)).
 3. Connect **BOOT** to **GND** (the GND pin is adjacent to BOOT on the J10 header).
-   <div class="no-print">
+   <div className="no-print">
      <details>
        <summary>Diagram</summary>
        <div>
@@ -62,3 +152,7 @@ If the device does not enter download mode, double-check the BOOT to GND connect
   src="/img/hardware/rak11200.webp"
   style={{ zoom: "50%" }}
 />
+
+</TabItem>
+
+</Tabs>

--- a/docs/hardware/devices/community-supported/seeed-studio/index.mdx
+++ b/docs/hardware/devices/community-supported/seeed-studio/index.mdx
@@ -12,6 +12,6 @@ sidebar_position: 3
 | :----------------------------------------------------------------------------- | :---------- | :----- | :--: | :-: | :-: |
 | [Seeed Wio-WM1110 Dev Kit](./wio-series/seeed-wm1110/?wm1110=wio-sdk-wm1110)   | nRF52840    | LR1110 | YES  | 5.3 | YES |
 | [Seeed Wio Tracker 1110](./wio-series/seeed-wm1110/?wm1110=wio-tracker-wm1110) | nRF52840    | LR1110 | YES  | 5.3 | YES |
-| [Wio-E5 mini Dev Board](./wio-series/seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
-| [Wio-E5 Dev Kit](./wio-series/seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
-| [Wio-E5 Wireless Module](./wio-series/seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 mini Dev Board](./wio-series/seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX126x |  NO  | NO  | NO  |
+| [Wio-E5 Dev Kit](./wio-series/seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX126x |  NO  | NO  | NO  |
+| [Wio-E5 Wireless Module](./wio-series/seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX126x |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/seeed-studio/index.mdx
+++ b/docs/hardware/devices/community-supported/seeed-studio/index.mdx
@@ -8,9 +8,10 @@ sidebar_position: 3
 
 ### [Wio Series](./wio-series/)
 
-| Name                                                                            | MCU         | Radio      |     WiFi     | BT  |   GPS    |
-| :------------------------------------------------------------------------------ | :---------- | :--------- | :----------: | :-: | :------: |
-| [Seeed Wio-WM1110 Dev Kit](./wio-series/seeed-wm1110/?wm1110=wio-sdk-wm1110)    | nRF52840    | LR1110     |     YES      | 5.3 |   YES    |
-| [Seeed Wio Tracker 1110](./wio-series/seeed-wm1110/?wm1110=wio-tracker-wm1110)  | nRF52840    | LR1110     |     YES      | 5.3 |   YES    |
-| [Wio-E5 mini Dev Board](./wio-series/seeed-wio-e5/?e5=wio-e5-mini)              | STM32WLE5JC | SX126X     |      NO      | NO  |    NO    |
-| [Wio-E5 Dev Kit](./wio-series/seeed-wio-e5/?e5=wio-e5-dev)                      | STM32WLE5JC | SX126X     |      NO      | NO  |    NO    |
+| Name                                                                           | MCU         | Radio  | WiFi | BT  | GPS |
+| :----------------------------------------------------------------------------- | :---------- | :----- | :--: | :-: | :-: |
+| [Seeed Wio-WM1110 Dev Kit](./wio-series/seeed-wm1110/?wm1110=wio-sdk-wm1110)   | nRF52840    | LR1110 | YES  | 5.3 | YES |
+| [Seeed Wio Tracker 1110](./wio-series/seeed-wm1110/?wm1110=wio-tracker-wm1110) | nRF52840    | LR1110 | YES  | 5.3 | YES |
+| [Wio-E5 mini Dev Board](./wio-series/seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 Dev Kit](./wio-series/seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 Wireless Module](./wio-series/seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/seeed-studio/wio-series/index.mdx
+++ b/docs/hardware/devices/community-supported/seeed-studio/wio-series/index.mdx
@@ -10,6 +10,6 @@ sidebar_position: 2
 | :------------------------------------------------------------------ | :---------- | :----- | :--: | :-: | :-: |
 | [Seeed Wio-WM1110 Dev Kit](./seeed-wm1110/?wm1110=wio-sdk-wm1110)   | nRF52840    | LR1110 | YES  | 5.3 | YES |
 | [Seeed Wio Tracker 1110](./seeed-wm1110/?wm1110=wio-tracker-wm1110) | nRF52840    | LR1110 | YES  | 5.3 | YES |
-| [Wio-E5 mini Dev Board](./seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
-| [Wio-E5 Dev Kit](./seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
-| [Wio-E5 Wireless Module](./seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 mini Dev Board](./seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX126x |  NO  | NO  | NO  |
+| [Wio-E5 Dev Kit](./seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX126x |  NO  | NO  | NO  |
+| [Wio-E5 Wireless Module](./seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX126x |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/seeed-studio/wio-series/index.mdx
+++ b/docs/hardware/devices/community-supported/seeed-studio/wio-series/index.mdx
@@ -6,9 +6,10 @@ sidebar_key: wio-series-community
 sidebar_position: 2
 ---
 
-| Name                                                                 | MCU         | Radio      |     WiFi     | BT  |   GPS    |
-| :------------------------------------------------------------------- | :---------- | :--------- | :----------: | :-: | :------: |
-| [Seeed Wio-WM1110 Dev Kit](./seeed-wm1110/?wm1110=wio-sdk-wm1110)    | nRF52840    | LR1110     |     YES      | 5.3 |   YES    |
-| [Seeed Wio Tracker 1110](./seeed-wm1110/?wm1110=wio-tracker-wm1110)  | nRF52840    | LR1110     |     YES      | 5.3 |   YES    |
-| [Wio-E5 mini Dev Board](./seeed-wio-e5/?wio-e5=wio-e5-mini)          | STM32WLE5JC | SX126X     |      NO      | NO  |    NO    |
-| [Wio-E5 Dev Kit](./seeed-wio-e5/?wio-e5=wio-e5-dev)                  | STM32WLE5JC | SX126X     |      NO      | NO  |    NO    |
+| Name                                                                | MCU         | Radio  | WiFi | BT  | GPS |
+| :------------------------------------------------------------------ | :---------- | :----- | :--: | :-: | :-: |
+| [Seeed Wio-WM1110 Dev Kit](./seeed-wm1110/?wm1110=wio-sdk-wm1110)   | nRF52840    | LR1110 | YES  | 5.3 | YES |
+| [Seeed Wio Tracker 1110](./seeed-wm1110/?wm1110=wio-tracker-wm1110) | nRF52840    | LR1110 | YES  | 5.3 | YES |
+| [Wio-E5 mini Dev Board](./seeed-wio-e5/?e5=wio-e5-mini)             | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 Dev Kit](./seeed-wio-e5/?e5=wio-e5-dev)                     | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |
+| [Wio-E5 Wireless Module](./seeed-wio-e5/?e5=wio-e5)                 | STM32WLE5JC | SX1262 |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/seeed-studio/wio-series/wio-e5.mdx
+++ b/docs/hardware/devices/community-supported/seeed-studio/wio-series/wio-e5.mdx
@@ -25,7 +25,7 @@ values={[
 - **MCU**
   - STM32WLE5JC
 - **LoRa Transceiver**
-  - Semtech SX1262
+  - STM32WL integrated sub-GHz radio (Semtech SX126x-based)
 - **Frequency options**
   - 868 MHz
   - 915 MHz
@@ -105,7 +105,7 @@ The STM32WL bootloader does not support the pins that the USB-C serial converter
 - **MCU**
   - STM32WLE5JC
 - **LoRa Transceiver**
-  - Semtech SX1262
+  - STM32WL integrated sub-GHz radio (Semtech SX126x-based)
 - **Frequency options**
   - 868 MHz
   - 915 MHz
@@ -156,7 +156,7 @@ The STM32WL bootloader does not support the pins that the USB-C serial converter
 - **MCU**
   - STM32WLE5JC
 - **LoRa Transceiver**
-  - Semtech SX1262
+  - STM32WL integrated sub-GHz radio (Semtech SX126x-based)
 - **Frequency options**
   - 868 MHz
   - 915 MHz

--- a/docs/hardware/devices/community-supported/seeed-studio/wio-series/wio-e5.mdx
+++ b/docs/hardware/devices/community-supported/seeed-studio/wio-series/wio-e5.mdx
@@ -13,13 +13,14 @@ groupId="e5"
 queryString="e5"
 defaultValue="wio-e5-dev"
 values={[
-{label: 'Wio-E5 Dev Kit', value:'wio-e5-dev'},
+{label: 'Wio-E5 Dev Kit', value: 'wio-e5-dev'},
 {label: 'Wio-E5 mini Dev Board', value: 'wio-e5-mini'},
+{label: 'Wio-E5 Wireless Module', value: 'wio-e5'}
 ]}>
 
 <TabItem value="wio-e5-dev">
 
-## Seeed Wio-E5 Dev Kit
+## Wio-E5 Dev Kit
 
 - **MCU**
   - STM32WLE5JC
@@ -32,19 +33,66 @@ values={[
 - **Connectors**
   - USB-C
   - LoRa Antenna: SMA antenna connector and U.FL/IPEX
-  - GPIO
-  - I2C x2
-  - UART x1
-  - RS 485
+  - 2.54 mm breakout header (all 28 module pins)
+  - 2x Grove I2C (same bus) + 1x Grove UART
+  - RS-485 screw terminal
   - Battery
-  - SWDIO
+  - SWD header
 
 ### Features
 
 - Temperature and Humidity Sensor (NXP LM75ADP)
 - Reset switch, power jumpers, button
 
+### Pinout
+
+| Interface                              | Pin(s)                   | Arduino |             Grove              | 2.54 mm header | Meshtastic `wio-e5`                                              |
+| -------------------------------------- | ------------------------ | :-----: | :----------------------------: | :------------: | ---------------------------------------------------------------- |
+| `UART` (`TX` / `RX`)                   | PB6 / PB7                |   ✅    |               ✅               |       ✅       | `Serial` console                                                 |
+| `USART` (`TX2` / `RX2`)                | PA2 / PA3                |   ✅    |               -                |       ✅       | `Serial2` &rarr; GPS (shared with RS-485); ROM bootloader USART2 |
+| `LPUART` (`TX1` / `RX1`)               | PC1 / PC0                |   ✅    |               -                |       ✅       | unused                                                           |
+| `IIC` (`SDA` / `SCL`)                  | PA15 / PB15              |   ✅    | ✅<br />(&times;2 in parallel) |       ✅       | I2C bus (`PIN_WIRE_SDA` / `PIN_WIRE_SCL`); onboard LM75 sensor   |
+| `SWIM/SWD` (`DIO` / `CLK` / `RST`)     | PA13 / PA14 / NRST       |   ✅    |               -                |       ✅       | first flash and debugging                                        |
+| `SPI` (`MOSI` / `MISO` / `CS` / `SCK`) | PA10 / PB14 / PB9 / PB13 |   ✅    |               -                |       ✅       | unused                                                           |
+| `BOOT` button                          | PB13                     |   ✅    |               -                |       ✅       | unused                                                           |
+| `D5`                                   | PB5                      |   ✅    |               -                |       -        | `LED_POWER` (active low; jumper J16)                             |
+| `D0`                                   | PA0                      |   ✅    |               -                |       -        | unused (button; jumper J14)                                      |
+| `D9`                                   | PA9                      |   ✅    |               -                |       -        | unused (3V3 peripheral-rail enable; jumper J15)                  |
+| `D10`                                  | PB10                     |   ✅    |               -                |       -        | unused (5V rail enable; jumper J6)                               |
+| `A4`                                   | PB4                      |   ✅    |               -                |       -        | unused (RS-485 driver enable; jumper J17)                        |
+| GPIO / ADC                             | PB3                      |   ✅    |               -                |       -        | unused                                                           |
+
+**Connecting a GPS**
+
+Meshtastic looks for a GPS module on `Serial2` (USART2, PA2 / PA3). Connect a supported TTL-level serial GPS to the `USART` pins (`TX2`/`RX2`) on either the 4-pin `USART` header or the Arduino socket.
+
+If using a Grove GPS module, do not connect it to the Grove UART connector as it is connected in hardware to the same USART port of the USB-C serial converter, which is used for the Meshtastic serial console and wired client link. Instead, connect the Grove GPS module to the male 2.54mm header instead (the pinout is the same, but check the polarity is correct before connecting).
+
+:::note
+
+Ensure the jumper labelled RS485(A4) is open to avoid the RS-485 driver coming online on the same USART.
+
+:::
+
+### Flashing
+
+- [Flashing over SWD](/docs/getting-started/flashing-firmware/stm32/flashing-over-swd)
+- [Flashing over UART](/docs/getting-started/flashing-firmware/stm32/flashing-over-uart) — needs an external USB-TTL serial adapter unless the USB-C workaround below is used
+
+**Flashing over USB-C**
+
+The STM32WL bootloader does not support the pins that the USB-C serial converter is wired to, so this workaround must be used:
+
+1. Rebooting the Wio-E5 into bootloader from the Meshtastic client (or `meshtastic --enter-dfu`)
+2. Make these temporary connections:
+   - `UART` `TX` &harr; `USART` `TX2`
+   - `UART` `RX` &harr; `USART` `RX2`
+3. [Flash over UART](/docs/getting-started/flashing-firmware/stm32/flashing-over-uart)
+4. Remove the temporary connections (to prevent the GPS probing from interfering with USB console/client connections)
+
 ### Resources
+
+- [Wio-E5 Development Kit | Seeed Studio Wiki](https://wiki.seeedstudio.com/LoRa_E5_Dev_Board/)
 
 ![wio-e5-dev](/img/hardware/seeed/sku113990934_0.webp)
 
@@ -52,7 +100,7 @@ values={[
 
 <TabItem value="wio-e5-mini">
 
-## Wio E5 mini Dev Board
+## Wio-E5 mini Dev Board
 
 - **MCU**
   - STM32WLE5JC
@@ -65,15 +113,98 @@ values={[
 - **Connectors**
   - USB-C
   - LoRa Antenna: SMA antenna connector and U.FL/IPEX
-  - GPIO
+  - 2x14 castellated/through-hole header (all 28 module pins)
 
 ### Features
 
 - Reset switch, power jumpers, button
 
+### Pinout
+
+The mini breaks out all 28 module pins on a 2x14 castellated/through-hole header with no onboard peripherals other than the USB-C serial bridge (USART1, PB6 / PB7), the active-low user LED (PB5), and the active-low `BOOT` and `D0` buttons (PB13 GPIO &mdash; **not** BOOT0 &mdash; and PA0). The LoRa RF pin (RFIO) goes to the SMA and U.FL/IPEX connectors.
+
+The Meshtastic `wio-e5` pin assignment is the same as the bare module &mdash; see the [Wio-E5 Wireless Module pinout](/docs/hardware/devices/community-supported/seeed-studio/wio-series/seeed-wio-e5?e5=wio-e5#wio-e5-module-pinout).
+
+### Flashing
+
+- [Flashing over SWD](/docs/getting-started/flashing-firmware/stm32/flashing-over-swd)
+- [Flashing over UART](/docs/getting-started/flashing-firmware/stm32/flashing-over-uart) — needs an external USB-TTL serial adapter unless the USB-C workaround below is used
+
+**Flashing over USB-C**
+
+The STM32WL bootloader does not support the pins that the USB-C serial converter is wired to, so this workaround must be used:
+
+1. Rebooting the Wio-E5 into bootloader from the Meshtastic client (or `meshtastic --enter-dfu`)
+2. Make these temporary connections:
+   - `UART` `TX` &harr; `USART` `TX2`
+   - `UART` `RX` &harr; `USART` `RX2`
+3. [Flash over UART](/docs/getting-started/flashing-firmware/stm32/flashing-over-uart)
+4. Remove the temporary connections (to prevent the GPS probing from interfering with USB console/client connections)
+
 ### Resources
+
+- [Wio-E5 mini | Seeed Studio Wiki](https://wiki.seeedstudio.com/LoRa_E5_mini/)
 
 ![wio-e5-mini](/img/hardware/seeed/4041615358935_.pic_hd.webp)
 
 </TabItem>
+
+<TabItem value="wio-e5">
+
+## Wio-E5 Wireless Module
+
+- **MCU**
+  - STM32WLE5JC
+- **LoRa Transceiver**
+  - Semtech SX1262
+- **Frequency options**
+  - 868 MHz
+  - 915 MHz
+  - 923 MHz
+
+The Wio-E5 is a 12 x 12 mm castellated SMD module for embedding an STM32WL node into a product. It is sold as the Wio-E5-HF (up to 22 dBm) and Wio-E5-LE (up to 14 dBm), and exposes UART, I2C, SPI, ADC, GPIO and SWD. BOOT0 is not brought out (pin 24 `BOOT` is an ordinary GPIO). The ROM bootloader's UART pins are USART1 on module pins 21 (PA9, TX) / 27 (PA10, RX) and USART2 on pins 19 (PA2, TX) / 18 (PA3, RX); route one pair to the host for UART flashing.
+
+### Features
+
+- Integrated 32.768 kHz and 32 MHz crystals
+- Single RF I/O (RFIO) pin
+
+### Pinout {#wio-e5-module-pinout}
+
+Every Wio-E5 board (module, mini, Dev Kit) runs the single Meshtastic `wio-e5` variant, so the STM32WLE5JC pin assignment below is the same on all of them. The middle column is the raw STM32WL function; each board wires connectors, buttons and LEDs to these pins differently.
+
+| STM32WLE5JC pin | STM32WL function                        | Meshtastic `wio-e5`                         |
+| --------------- | --------------------------------------- | ------------------------------------------- |
+| PB6 / PB7       | USART1 TX / RX                          | `Serial` console (not a bootloader UART)    |
+| PA15 / PB15     | I2C2 SDA / SCL                          | I2C bus (`PIN_WIRE_SDA` / `PIN_WIRE_SCL`)   |
+| PA2 / PA3       | USART2 TX / RX                          | `Serial2` &rarr; GPS; ROM bootloader USART2 |
+| PC1 / PC0       | LPUART1 TX / RX                         | unused                                      |
+| PB5             | GPIO (boards wire an active-low LED)    | `LED_POWER`                                 |
+| PA13 / PA14     | SWDIO / SWCLK                           | first flash and debugging                   |
+| PB13            | GPIO / SPI2 SCK &mdash; **not** BOOT0   | unused                                      |
+| PA0             | GPIO (boards wire an active-low button) | unused                                      |
+| RFIO            | LoRa RF                                 | LoRa antenna                                |
+| NRST            | Reset                                   | &mdash;                                     |
+
+Remaining pins (PB3/PB4, PB9/PB14/PA10 SPI2, PB10, PA9, PB0) are broken out but unused by the firmware.
+
+### Flashing
+
+- [Flashing over SWD](/docs/getting-started/flashing-firmware/stm32/flashing-over-swd)
+- [Flashing over UART](/docs/getting-started/flashing-firmware/stm32/flashing-over-uart)
+
+### Resources
+
+- [Wio-E5 STM32WLE5JC Module | Seeed Studio Wiki](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module/)
+
+</TabItem>
+
 </Tabs>
+
+:::caution
+
+BOOT0 is not exposed on any Wio-E5 board (module, mini, or Dev Kit &mdash; the `BOOT` button is an ordinary GPIO, not BOOT0), so the first flash of Meshtastic firmware requires an SWD programmer. Meshtastic clients can reboot the board into the bootloader (`meshtastic --enter-dfu`) once Meshtastic firmware has been flashed.
+
+Wio-E5 boards also ship with flash readout protection (RDP level 1) enabled. If STM32CubeProgrammer cannot read or write flash, see [Removing readout protection](/docs/getting-started/flashing-firmware/stm32/removing-readout-protection).
+
+:::

--- a/docs/hardware/devices/community-supported/stmicroelectronics/index.mdx
+++ b/docs/hardware/devices/community-supported/stmicroelectronics/index.mdx
@@ -10,4 +10,4 @@ STMicroelectronics produces the STM32WL, a microcontroller with an integrated Se
 
 | Name                             | MCU       | Radio  | WiFi | BT  | GPS |
 | :------------------------------- | :-------- | :----- | :--: | :-: | :-: |
-| [Nucleo-WL55JC](./nucleo-wl55jc) | STM32WL55 | SX1262 |  NO  | NO  | NO  |
+| [Nucleo-WL55JC](./nucleo-wl55jc) | STM32WL55 | SX126x |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/stmicroelectronics/index.mdx
+++ b/docs/hardware/devices/community-supported/stmicroelectronics/index.mdx
@@ -1,0 +1,13 @@
+---
+id: stmicroelectronics
+title: STMicroelectronics® Devices
+sidebar_label: STMicroelectronics®
+sidebar_key: stmicroelectronics-community
+sidebar_position: 13
+---
+
+STMicroelectronics produces the STM32WL, a microcontroller with an integrated Semtech SX126x sub-GHz radio, along with evaluation boards for it.
+
+| Name                             | MCU       | Radio  | WiFi | BT  | GPS |
+| :------------------------------- | :-------- | :----- | :--: | :-: | :-: |
+| [Nucleo-WL55JC](./nucleo-wl55jc) | STM32WL55 | SX1262 |  NO  | NO  | NO  |

--- a/docs/hardware/devices/community-supported/stmicroelectronics/nucleo-wl55jc.mdx
+++ b/docs/hardware/devices/community-supported/stmicroelectronics/nucleo-wl55jc.mdx
@@ -1,0 +1,60 @@
+---
+id: nucleo-wl55jc
+title: STMicroelectronics® Nucleo-WL55JC
+sidebar_label: Nucleo-WL55JC
+sidebar_position: 1
+---
+
+The [ST Nucleo-WL55JC](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html) (board reference MB1389) is STMicroelectronics' official evaluation board for the STM32WL. `NUCLEO-WL55JC1` is built for the high frequency band (approximately 865&ndash;928 MHz) and `NUCLEO-WL55JC2` for the low band (approximately 433&ndash;510 MHz). The two share a board design but wire out different RF paths and matching networks, so they are not interchangeable. It carries an onboard ST-LINK, so no external programmer is needed.
+
+## Specifications
+
+- **MCU**
+  - STM32WL55JC (Arm Cortex-M4 application core, 256 kB flash, 64 kB RAM)
+- **LoRa Transceiver**
+  - Semtech SX1262 (integrated into the STM32WL), 32 MHz TCXO
+- **Frequency options**
+  - `NUCLEO-WL55JC1`: high band (~865&ndash;928 MHz)
+  - `NUCLEO-WL55JC2`: low band (~433&ndash;510 MHz)
+- **Antenna**
+  - Single band-specific SMA connector
+- **Connectors**
+  - USB Micro-B (ST-LINK)
+  - Arduino UNO V3 headers
+  - ST morpho headers
+- **Debug**
+  - Onboard STLINK-V3E: SWD debug, Virtual COM Port, and drag-and-drop mass-storage programming
+- **Controls**
+  - 3 user LEDs (green/blue/red)
+  - 3 user buttons (B1/B2/B3) and a reset button
+  - BOOT0 button
+
+## Meshtastic pin mapping
+
+Taken from the Meshtastic `nucleo_wl55jc` firmware variant. The Arduino UNO V3 headers (CN5 / CN8 / CN9) bring out a subset of the MCU pins; the ST morpho headers (CN7 / CN10) bring out every MCU pin.
+
+| Function   | Pin(s)                                                    | Arduino | Morpho | Meshtastic role                                                                                |
+| ---------- | --------------------------------------------------------- | :-----: | :----: | ---------------------------------------------------------------------------------------------- |
+| Console    | ST-LINK Virtual COM Port (PA2 / PA3)                      |    -    |    -   | Default `Serial` (debug output and CLI)                                                        |
+| GPS UART   | PB6 (TX), PB7 (RX) &mdash; D1 / D0                        |   ✅    |   ✅   | `Serial2` (`GPS_SERIAL_PORT=Serial2`)                                                          |
+| I2C        | PA11 (SDA), PA12 (SCL) &mdash; D14 / D15                  |   ✅    |   ✅   | Sensors                                                                                        |
+| SPI        | PA7 (MOSI), PA6 (MISO), PA5 (SCK) &mdash; D11 / D12 / D13 |   ✅    |   ✅   | Spare SPI bus                                                                                  |
+| Green LED  | PB9                                                       |    -    |   ✅   | `LED_POWER`                                                                                    |
+| Red LED    | PB11                                                      |    -    |   ✅   | LoRa activity                                                                                  |
+| Blue LED   | PB15                                                      |    -    |   ✅   | Notification                                                                                   |
+| Button B1  | PA0 (WKUP-capable)                                        |    -    |   ✅   | Main button                                                                                    |
+| Button B2  | PA1                                                       |    -    |   ✅   | Alternate button                                                                               |
+| Button B3  | PC6                                                       |    -    |   ✅   | Cancel button                                                                                  |
+| VBAT sense | AVBAT (internal ADC channel)                              |    -    |    -   | `BATTERY_PIN`, but VBAT is tied to 3V3 by default (SB21) so this reads the rail, not a battery |
+
+## Flashing
+
+Everything runs through the onboard ST-LINK, including drag-and-drop of `firmware-nucleo_wl55jc-X.X.X.xxxxxxx.bin` onto the board's USB mass-storage drive.
+
+- [Flashing over SWD](/docs/getting-started/flashing-firmware/stm32/flashing-over-swd)
+
+## Resources
+
+- Firmware file: `firmware-nucleo_wl55jc-X.X.X.xxxxxxx.bin`
+- [NUCLEO-WL55JC product page](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html)
+- [UM2592: STM32WL Nucleo-64 board (MB1389) user manual](https://www.st.com/resource/en/user_manual/um2592-stm32wl-nucleo64-board-mb1389-stmicroelectronics.pdf)

--- a/docs/hardware/devices/community-supported/stmicroelectronics/nucleo-wl55jc.mdx
+++ b/docs/hardware/devices/community-supported/stmicroelectronics/nucleo-wl55jc.mdx
@@ -12,7 +12,7 @@ The [ST Nucleo-WL55JC](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html
 - **MCU**
   - STM32WL55JC (Arm Cortex-M4 application core, 256 kB flash, 64 kB RAM)
 - **LoRa Transceiver**
-  - Semtech SX1262 (integrated into the STM32WL), 32 MHz TCXO
+  - STM32WL integrated sub-GHz radio (Semtech SX126x-based), 32 MHz TCXO
 - **Frequency options**
   - `NUCLEO-WL55JC1`: high band (~865&ndash;928 MHz)
   - `NUCLEO-WL55JC2`: low band (~433&ndash;510 MHz)
@@ -27,7 +27,7 @@ The [ST Nucleo-WL55JC](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html
 - **Controls**
   - 3 user LEDs (green/blue/red)
   - 3 user buttons (B1/B2/B3) and a reset button
-  - BOOT0 button
+  - BOOT0 jumper (JP3)
 
 ## Meshtastic pin mapping
 


### PR DESCRIPTION
## What did you change

- **RAK3172/RAK3372 WisBlock core module** (firmware v2.4.1+)
  - New tabbed section covering the STM32WLE5 MCU, integrated SX1262, frequency options, and part-number decoding
  - Flashing section linking the SWD and UART guides
  - Added to the WisBlock core tables on the RAKwireless and landing pages.
- **Wio-E5 Wireless Module** (firmware v1.3.39+)
  - New tab beside the mini and Dev Kit with a shared STM32WLE5JC pinout table and GPS wiring notes
  - Gave each of the three boards a Flashing section (SWD + UART links) with a USB-C jumper-wire workaround
  - Corrected the radio from SX126X to SX1262
  - Renamed "Wio-E5 Module" to "Wio-E5 Wireless Module" (the Seeed SKU name) across the tables
- **STMicroelectronics Nucleo-WL55JC** (firmware v2.8.0+)
  - New vendor section and board page covering the WL55JC1/WL55JC2 band split, board specs
  - Meshtastic `nucleo_wl55jc` pin mapping
  - ST-LINK flashing (USB mass storage plus SWD/UART links)

## Why did you change it

- These STM32WL boards are supported by Meshtastic firmware but were not fully documented compared to other boards.
- The community-supported device page had grown long and unordered.

**Prerequisite: #2628**

- These pages link to the STM32 flashing guide added in #2628, and this branch is stacked on it. Until #2628 merges the PR diff includes its two commits; once it merges, this branch should be rebased onto `master` to drop them.

## Screenshots

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added STM32WL flashing guides for bootloader entry, UART, SWD, and readout-protection removal.
  * Added an STM32WL flashing overview covering available methods and platform limitations.
  * Added documentation for RAK3172/RAK3372, Wio-E5 variants, and the Nucleo-WL55JC board.
  * Expanded Wio-E5 guidance with pinouts, flashing instructions, and hardware resources.
  * Added STMicroelectronics device listings and improved hardware tables, navigation, vendor listings, and radio details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->