### PR TITLE
docs: resolve six verified documentation gaps

### DIFF
--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -265,9 +265,7 @@ Navigate to: Settings >  Channels > LongFast: Turn on the sliders for **Uplink e
 
 #### 3. Configure Network Settings
 
-:::note
-This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
-:::
+Requires a node with WiFi or Ethernet. nRF52 and RP2040 boards have no **Network** section — use **MQTT Client Proxy** instead and skip this step.
 
 Navigate to: Settings >  Network: Turn on the slider for **WiFi enabled**, Enter the **SSID** and **PSK** for your network, then tap **Send**.
 
@@ -297,9 +295,7 @@ Navigate to Settings > Channels > Primary Channel: Turn on the sliders for **Upl
 
 #### 3. Configure Network Settings
 
-:::note
-This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
-:::
+Requires a node with WiFi or Ethernet. nRF52 and RP2040 boards have no **Network** section — use **MQTT Client Proxy** instead and skip this step.
 
 Navigate to Settings > Network: Turn on the slider for **WiFi enabled** - Enter your **SSID** and **PSK** for your network - Tap **Save**
 
@@ -331,9 +327,7 @@ meshtastic --ch-set uplink_enabled true --ch-index 0 --ch-set downlink_enabled t
 
 #### 3. Configure Network Settings
 
-:::note
-This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
-:::
+Requires a node with WiFi or Ethernet. nRF52 and RP2040 boards have no **Network** section — use **MQTT Client Proxy** instead and skip this step.
 
 ```shell
 meshtastic --set network.wifi_enabled true
@@ -376,9 +370,7 @@ Navigate to Channels > Primary: Turn on the sliders for **Uplink Enabled** and *
 
 #### 3. Configure Network Settings
 
-:::note
-This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
-:::
+Requires a node with WiFi or Ethernet. nRF52 and RP2040 boards have no **Network** section — use **MQTT Client Proxy** instead and skip this step.
 
 Navigate to Radio Config > Device > Network: Turn on the slider for **Enabled** - Enter your **SSID** and **PSK** for your network - Click the **Save** icon.
 

--- a/docs/configuration/module/mqtt.mdx
+++ b/docs/configuration/module/mqtt.mdx
@@ -265,6 +265,10 @@ Navigate to: Settings >  Channels > LongFast: Turn on the sliders for **Uplink e
 
 #### 3. Configure Network Settings
 
+:::note
+This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
+:::
+
 Navigate to: Settings >  Network: Turn on the slider for **WiFi enabled**, Enter the **SSID** and **PSK** for your network, then tap **Send**.
 
 [![Network Settings](/img/modules/mqtt/android_network_sm.webp)](/img/modules/mqtt/android_network.webp)
@@ -292,6 +296,10 @@ Navigate to Settings > Channels > Primary Channel: Turn on the sliders for **Upl
 [![Channel Settings](/img/modules/mqtt/apple_channel_sm.webp)](/img/modules/mqtt/apple_channel.webp)
 
 #### 3. Configure Network Settings
+
+:::note
+This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
+:::
 
 Navigate to Settings > Network: Turn on the slider for **WiFi enabled** - Enter your **SSID** and **PSK** for your network - Tap **Save**
 
@@ -322,6 +330,10 @@ meshtastic --ch-set uplink_enabled true --ch-index 0 --ch-set downlink_enabled t
 ```
 
 #### 3. Configure Network Settings
+
+:::note
+This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
+:::
 
 ```shell
 meshtastic --set network.wifi_enabled true
@@ -363,6 +375,10 @@ Navigate to Channels > Primary: Turn on the sliders for **Uplink Enabled** and *
 [![Channel Settings](/img/modules/mqtt/web_channel_sm.webp)](/img/modules/mqtt/web_channel.webp)
 
 #### 3. Configure Network Settings
+
+:::note
+This step applies only to nodes with built-in WiFi or Ethernet (for example ESP32-based boards). Devices without a network interface — such as nRF52 and RP2040 boards — have no **Network** section to configure. Connect those nodes to MQTT with **MQTT Client Proxy** instead, which routes MQTT traffic through the internet connection of the connected client app, and skip this step.
+:::
 
 Navigate to Radio Config > Device > Network: Turn on the slider for **Enabled** - Enter your **SSID** and **PSK** for your network - Click the **Save** icon.
 

--- a/docs/configuration/radio/position.mdx
+++ b/docs/configuration/radio/position.mdx
@@ -33,7 +33,7 @@ Acceptable values: `true` or `false`
 
 False by default
 
-If set, this node is at a fixed position. The device will generate GPS updates at the regular GPS update interval, but use whatever the last lat/lon/alt it saved for the node. The lat/lon/alt can be set by an internal GPS, with the help of the mobile device's GPS, or entered manually in the client apps or via the CLI.
+If set, this node is at a fixed position. The device will generate GPS updates at the regular GPS update interval, but use whatever the last lat/lon/alt it saved for the node. The lat/lon/alt can be set by an internal GPS, by the mobile device's GPS, or entered manually.
 
 ### Smart Broadcast
 
@@ -65,12 +65,7 @@ Default of `0` is 15 minutes
 
 If smart broadcast is off we should send our position this often.
 
-A position will be sent out every broadcast interval. What it contains depends on how the node is set up:
-
-- **GPS enabled and a fix acquired:** the current GPS location.
-- **GPS enabled but no fix yet:** an empty location.
-- **Fixed position set:** the saved lat/lon/alt, sent regardless of GPS state.
-- **No GPS and no fixed position:** an empty location.
+A position is sent every broadcast interval: the GPS location once a fix is acquired, the saved lat/lon/alt if fixed position is set, otherwise an empty location.
 
 ### Position Flags
 

--- a/docs/configuration/radio/position.mdx
+++ b/docs/configuration/radio/position.mdx
@@ -33,7 +33,7 @@ Acceptable values: `true` or `false`
 
 False by default
 
-If set, this node is at a fixed position. The device will generate GPS updates at the regular GPS update interval, but use whatever the last lat/lon/alt it saved for the node. The lat/lon/alt can be set by an internal GPS or with the help of the mobile device's GPS.
+If set, this node is at a fixed position. The device will generate GPS updates at the regular GPS update interval, but use whatever the last lat/lon/alt it saved for the node. The lat/lon/alt can be set by an internal GPS, with the help of the mobile device's GPS, or entered manually in the client apps or via the CLI.
 
 ### Smart Broadcast
 
@@ -65,7 +65,12 @@ Default of `0` is 15 minutes
 
 If smart broadcast is off we should send our position this often.
 
-The GPS updates will be sent out every broadcast interval, either with the actual GPS location or an empty location if no GPS fix was achieved.
+A position will be sent out every broadcast interval. What it contains depends on how the node is set up:
+
+- **GPS enabled and a fix acquired:** the current GPS location.
+- **GPS enabled but no fix yet:** an empty location.
+- **Fixed position set:** the saved lat/lon/alt, sent regardless of GPS state.
+- **No GPS and no fixed position:** an empty location.
 
 ### Position Flags
 

--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -146,6 +146,25 @@ Legacy admin is enabled using the Legacy Admin channel option in [Security Confi
    ```
 6. You may add up to 3 Admin Keys, enabling control from up to 3 different nodes.
 
+:::info Adding, replacing, and removing Admin Keys
+`--set security.admin_key` is **additive** — each use appends a key to the list rather than replacing it. To manage the list:
+
+```bash
+# Add a single key to the existing list
+meshtastic --set security.admin_key "base64:PASTEPUBLICKEYHERE"
+
+# Clear the entire list
+meshtastic --set security.admin_key 0
+
+# Replace the list: clear first, then add, in one command
+meshtastic --set security.admin_key 0 \
+           --set security.admin_key "base64:FIRSTPUBLICKEY" \
+           --set security.admin_key "base64:SECONDPUBLICKEY"
+```
+
+There is no command to remove one individual key — clear the list and re-add the keys you want to keep.
+:::
+
 #### Setting up Remote Admin Using the Legacy Method
 
 To use the legacy method, set up an Admin channel as a secondary channel with the name `admin` by following the instructions in the [Channels](/docs/configuration/radio/channels/) section.

--- a/docs/configuration/remote-admin.mdx
+++ b/docs/configuration/remote-admin.mdx
@@ -146,24 +146,20 @@ Legacy admin is enabled using the Legacy Admin channel option in [Security Confi
    ```
 6. You may add up to 3 Admin Keys, enabling control from up to 3 different nodes.
 
-:::info Adding, replacing, and removing Admin Keys
-`--set security.admin_key` is **additive** — each use appends a key to the list rather than replacing it. To manage the list:
+`--set security.admin_key` appends rather than replaces. Setting it to `0` clears the list; individual keys cannot be removed.
 
 ```bash
-# Add a single key to the existing list
+# Add a key
 meshtastic --set security.admin_key "base64:PASTEPUBLICKEYHERE"
 
-# Clear the entire list
+# Clear all keys
 meshtastic --set security.admin_key 0
 
-# Replace the list: clear first, then add, in one command
+# Replace the list
 meshtastic --set security.admin_key 0 \
-           --set security.admin_key "base64:FIRSTPUBLICKEY" \
-           --set security.admin_key "base64:SECONDPUBLICKEY"
+           --set security.admin_key "base64:FIRSTKEY" \
+           --set security.admin_key "base64:SECONDKEY"
 ```
-
-There is no command to remove one individual key — clear the list and re-add the keys you want to keep.
-:::
 
 #### Setting up Remote Admin Using the Legacy Method
 

--- a/docs/development/firmware/building.mdx
+++ b/docs/development/firmware/building.mdx
@@ -17,7 +17,8 @@ Meshtastic uses [PlatformIO](https://platformio.org), a development environment 
    ```
 4. Update the repository's [submodules](https://github.com/meshtastic/firmware/blob/master/.gitmodules)
    ```shell
-   cd firmware && git submodule update --init
+   cd firmware
+   git submodule update --init
    ```
    :::info
    If you want to build the RP2040 targets and get a 'Filename too long' error on Windows, please refer to [the Platformio documentation for this toolchain](https://arduino-pico.readthedocs.io/en/latest/platformio.html#important-steps-for-windows-users-before-installing)

--- a/docs/software/integrations/mqtt/home-assistant.mdx
+++ b/docs/software/integrations/mqtt/home-assistant.mdx
@@ -178,7 +178,11 @@ sensor:
 
 ### Maps & Device Tracker
 
-To make it possible for your nodes to appear in maps within Home Assistant, you will need to set up a [device_tracker](https://www.home-assistant.io/integrations/device_tracker/) entity. Luckily, Home Assistant allows them to be created ad-hoc, simply by calling the `device_tracker.see` service from a script or automation.
+To make it possible for your nodes to appear in maps within Home Assistant, you will need to set up a [device_tracker](https://www.home-assistant.io/integrations/device_tracker/) entity. Luckily, Home Assistant allows them to be created ad-hoc, simply by calling the `device_tracker.see` action from a script or automation.
+
+:::warning Deprecated in Home Assistant
+`device_tracker.see` is deprecated and is scheduled for removal in **Home Assistant Core 2027.5**. The example below still works on current releases, but it will need to be migrated before then — see [Device tracker changes in 2027.5](https://community.home-assistant.io/t/device-tracker-changes-in-2027-5-what-to-do/1009691) for the recommended replacements.
+:::
 
 To do this, create a new automation and use the three-dots menu to change to the "Edit in YAML" mode, and set it up like the following:
 
@@ -195,7 +199,7 @@ trigger:
             value_json.payload.longitude_i is defined %}on{% endif %}
 condition: []
 action:
-  - service: device_tracker.see
+  - action: device_tracker.see
     metadata: {}
     data:
       dev_id: node_1
@@ -206,7 +210,7 @@ action:
 mode: single
 ```
 
-The `dev_id` within the service call determines what the `device_tracker` entity will be called, for example `device_tracker.node_1` for the above. Make sure that you have different names in this field for your different nodes, or they will all show up under the same tracker! Meshtastic represents latitude and longitude in integers, which is why they must be multiplied by `1e-7` to produce the real location.
+The `dev_id` within the action determines what the `device_tracker` entity will be called, for example `device_tracker.node_1` for the above. Make sure that you have different names in this field for your different nodes, or they will all show up under the same tracker! Meshtastic represents latitude and longitude in integers, which is why they must be multiplied by `1e-7` to produce the real location.
 
 Device trackers can also support a few different additional fields, but the one most relevant to Meshtastic usage is the battery level, which can be pulled in from the previously-created sensors as shown.
 

--- a/docs/software/integrations/mqtt/home-assistant.mdx
+++ b/docs/software/integrations/mqtt/home-assistant.mdx
@@ -178,11 +178,7 @@ sensor:
 
 ### Maps & Device Tracker
 
-To make it possible for your nodes to appear in maps within Home Assistant, you will need to set up a [device_tracker](https://www.home-assistant.io/integrations/device_tracker/) entity. Luckily, Home Assistant allows them to be created ad-hoc, simply by calling the `device_tracker.see` action from a script or automation.
-
-:::warning Deprecated in Home Assistant
-`device_tracker.see` is deprecated and is scheduled for removal in **Home Assistant Core 2027.5**. The example below still works on current releases, but it will need to be migrated before then — see [Device tracker changes in 2027.5](https://community.home-assistant.io/t/device-tracker-changes-in-2027-5-what-to-do/1009691) for the recommended replacements.
-:::
+To make it possible for your nodes to appear in maps within Home Assistant, you will need to set up a [device_tracker](https://www.home-assistant.io/integrations/device_tracker/) entity. Luckily, Home Assistant allows them to be created ad-hoc, simply by calling the `device_tracker.see` action from a script or automation. Note that `device_tracker.see` is deprecated and will be removed in Home Assistant Core 2027.5; see [Device tracker changes in 2027.5](https://community.home-assistant.io/t/device-tracker-changes-in-2027-5-what-to-do/1009691) for replacements.
 
 To do this, create a new automation and use the three-dots menu to change to the "Edit in YAML" mode, and set it up like the following:
 

--- a/docs/software/python-cli/usage.mdx
+++ b/docs/software/python-cli/usage.mdx
@@ -63,7 +63,7 @@ meshtastic --set network.wifi_ssid mywifissid --set network.wifi_psk mywifipsw -
 ```
 
 :::note
-For a full list of preferences which can be set (and their documentation) can be found in the [protobufs](https://buf.build/meshtastic/protobufs/docs/main:meshtastic#meshtastic.User).
+Every setting is documented under [Configuration](/docs/configuration/), which lists the accepted values for each one alongside its CLI name. The underlying field definitions can also be read directly from the [protobufs](https://buf.build/meshtastic/protobufs/docs/main:meshtastic#meshtastic.User).
 :::
 
 ### Changing channel settings
@@ -236,3 +236,26 @@ There is a problem with Big Sur and pyserial. The workaround is to install a new
 ```shell
 pip3 install -U --pre pyserial
 ```
+
+### `[Errno -2] Name or service not known` / `[Errno -3] Temporary failure in name resolution`
+
+Both are DNS failures: the hostname you passed to `--host` could not be resolved. `-2` means the name does not
+resolve, `-3` means the lookup itself failed (no DNS server reachable).
+
+Things to check:
+
+- Confirm the spelling of the hostname, and that the node is powered on and joined to your network.
+- If you are using an mDNS name such as `meshtastic.local`, confirm your platform resolves `.local` names —
+  this often fails on Windows and inside containers. Use the node's IP address instead.
+- Confirm the machine running the CLI has working DNS (`ping example.com`).
+- If the node is reachable by IP but not by name, pass the IP directly: `meshtastic --host 192.168.1.50 --info`.
+
+### `Warning: Error processing received packet: 'NoneType' object has no attribute 'get'`
+
+This warning is emitted when the CLI receives a packet it cannot decode — most commonly a packet encrypted with
+a channel key your node does not have. Internally the decoded payload is `None`, and reading a field from it
+raises this error, which is caught and printed as a warning.
+
+It is **non-fatal**: the packet is skipped and the CLI keeps running. It most often appears while a long-running
+command such as `--sendtext` is waiting, and can normally be ignored. If you see it constantly, it usually means
+nearby traffic is on channels your node cannot decrypt.

--- a/docs/software/python-cli/usage.mdx
+++ b/docs/software/python-cli/usage.mdx
@@ -62,9 +62,7 @@ Or to configure an ESP32 based board to join a Wifi network as a station:
 meshtastic --set network.wifi_ssid mywifissid --set network.wifi_psk mywifipsw --set network.wifi_enabled 1
 ```
 
-:::note
-Every setting is documented under [Configuration](/docs/configuration/), which lists the accepted values for each one alongside its CLI name. The underlying field definitions can also be read directly from the [protobufs](https://buf.build/meshtastic/protobufs/docs/main:meshtastic#meshtastic.User).
-:::
+Settings and their accepted values are listed under [Configuration](/docs/configuration/); field definitions are in the [protobufs](https://buf.build/meshtastic/protobufs/docs/main:meshtastic#meshtastic.User).
 
 ### Changing channel settings
 
@@ -239,23 +237,8 @@ pip3 install -U --pre pyserial
 
 ### `[Errno -2] Name or service not known` / `[Errno -3] Temporary failure in name resolution`
 
-Both are DNS failures: the hostname you passed to `--host` could not be resolved. `-2` means the name does not
-resolve, `-3` means the lookup itself failed (no DNS server reachable).
-
-Things to check:
-
-- Confirm the spelling of the hostname, and that the node is powered on and joined to your network.
-- If you are using an mDNS name such as `meshtastic.local`, confirm your platform resolves `.local` names —
-  this often fails on Windows and inside containers. Use the node's IP address instead.
-- Confirm the machine running the CLI has working DNS (`ping example.com`).
-- If the node is reachable by IP but not by name, pass the IP directly: `meshtastic --host 192.168.1.50 --info`.
+DNS failures: the `--host` name did not resolve (`-2`) or the lookup itself failed (`-3`). `.local` mDNS names often fail on Windows and in containers — use the node's IP instead, for example `meshtastic --host 192.168.1.50 --info`.
 
 ### `Warning: Error processing received packet: 'NoneType' object has no attribute 'get'`
 
-This warning is emitted when the CLI receives a packet it cannot decode — most commonly a packet encrypted with
-a channel key your node does not have. Internally the decoded payload is `None`, and reading a field from it
-raises this error, which is caught and printed as a warning.
-
-It is **non-fatal**: the packet is skipped and the CLI keeps running. It most often appears while a long-running
-command such as `--sendtext` is waiting, and can normally be ignored. If you see it constantly, it usually means
-nearby traffic is on channels your node cannot decrypt.
+A packet the CLI cannot decode, usually one encrypted with a channel key your node does not have. Non-fatal — the packet is skipped and the CLI continues.


### PR DESCRIPTION
Six documentation fixes, each verified against current docs content before writing. `pnpm lint:mdx` and a full `pnpm build` both pass.

| Issue | Change | File |
|---|---|---|
| #1812 | `--set security.admin_key` is additive; `... admin_key 0` clears the list | `configuration/remote-admin.mdx` |
| #2299 | Nodes without WiFi/Ethernet have no **Network** section — use MQTT Client Proxy | `configuration/module/mqtt.mdx` (all 4 tabs) |
| #2319 | What a position broadcast contains per GPS/fixed-position combination | `configuration/radio/position.mdx` |
| #2504 | Explain the two DNS `Errno` failures and the `NoneType` packet warning | `software/python-cli/usage.mdx` |
| #2005 | Point the settings admonition at Configuration instead of buf.build | `software/python-cli/usage.mdx` |
| #2463 | Split the compound `cd firmware && git submodule update --init` step | `development/firmware/building.mdx` |

### Notes on accuracy

- **#1812** was verified against the CLI source rather than the issue thread. In `meshtastic/__main__.py`, a repeated field with `val == 0` takes the "Clearing {pref} list" branch; otherwise it appends. That same code now has an `if val not in cur_vals` guard, so the duplicate-key bug in the original report appears to be fixed.
- **#2504**'s `NoneType` warning is documented from the source: `packet.get("decoded")` returns `None` for an undecryptable packet, and the subsequent `.get("portnum")` raises inside a `try` that prints the warning and continues — hence "non-fatal".
- **#2646** (Home Assistant) is only **partially** addressed here: `service:` → `action:` plus a deprecation warning for `device_tracker.see`. The full migration off `device_tracker.see` needs validating against a live Home Assistant instance, so that issue stays open.

### Deliberately not included

- **#2034** (deb822 apt sources) — mechanical but untestable here, and @vidplace7 sign-off was requested on the issue. Worth doing as its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified network configuration requirements and when to use MQTT Client Proxy.
  * Clarified position sources and broadcast packet behavior.
  * Documented how administrative keys are added, replaced, and cleared.
  * Improved firmware build setup instructions.
  * Updated Home Assistant integration guidance, including the device-tracker migration timeline.
  * Streamlined CLI configuration guidance and troubleshooting information for DNS failures and non-fatal packet decryption warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->