### PR TITLE
docs: correct device button behavior for BaseUI

### DIFF
--- a/docs/configuration/radio/device.mdx
+++ b/docs/configuration/radio/device.mdx
@@ -9,7 +9,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { Icon } from "@iconify/react";
 
-The device config options are: Role, Rebroadcast Mode, GPIO for User Button, GPIO for PWM Buzzer, Node Info Broadcast Seconds, Double Tap as Button Press, Disable Triple Click, Timezone Definition, and LED Heartbeat Disabled. Device config uses an admin message sending a `Config.Device` protobuf.
+The device config options are: Role, Rebroadcast Mode, GPIO for User Button, GPIO for PWM Buzzer, Node Info Broadcast Seconds, Double Tap as Button Press, Timezone Definition, and LED Heartbeat Disabled. Device config uses an admin message sending a `Config.Device` protobuf.
 
 ## Device Config Values
 
@@ -105,10 +105,6 @@ This is the number of seconds between NodeInfo message (containing i.a. long and
 
 This option will enable a double tap, when a supported accelerometer is attached to the device, to be treated as a button press.
 
-## Disable Triple Click
-
-Disables the triple-press of user button to enable or disable GPS.
-
 ## TZDEF (Timezone Definition)
 
 The `tzdef` setting allows the local offset to be defined for the device. It uses the TZ Database format to display the correct local time on the device display and in its logs.
@@ -200,7 +196,6 @@ All device config options are available in the python CLI. Example commands are 
 | device.buzzer_gpio                | `0` - `34`                                                         | `0`               |
 | device.node_info_broadcast_secs   | `3600` - `UINT MAX`                                                | `10800` (3 hours) |
 | device.double_tap_as_button_press | `false`, `true`                                                    | `false`           |
-| device.disable_triple_click       | `false`, `true`                                                    | `false`           |
 
 :::tip
 

--- a/docs/hardware/devices/b-and-q-consulting/nano/buttons.mdx
+++ b/docs/hardware/devices/b-and-q-consulting/nano/buttons.mdx
@@ -21,26 +21,28 @@ values={[
 
 ### Nano G2 Ultra
 
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
 #### Buttons
 
-- **User/Program Button:**
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Long press:** Will signal the device to shutdown after 5 seconds (_soft off_).
-- **Message Read Button:**
-  - **Single press:** Clears the New Message LED.
+- **User button:**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+- **Message read button:**
+  - **Short press:** Clear the new message LED.
 
 #### Switches
 
 - **Power:**
-  - **Toggle Up:** Turns on the device.
-  - **Toggle Down:** Turns off the device.
-- **Location Pin:**
-  - **Toggle Up:** Sets GPS to operating mode.
-  - **Toggle Down:** Sets GPS to low power mode.
+  - **Toggle up:** Turn the device on.
+  - **Toggle down:** Turn the device off.
+- **Location pin:**
+  - **Toggle up:** Set the GPS to operating mode.
+  - **Toggle down:** Set the GPS to low power mode.
 - **Bell:**
-  - **Toggle Up:** Selects Buzzer for Enhanced Message Notification Circuit.
-  - **Toggle Down:** Selects LED for Enhanced Message Notification Circuit.
+  - **Toggle up:** Select the buzzer for the enhanced message notification circuit.
+  - **Toggle down:** Select the LED for the enhanced message notification circuit.
 
 </TabItem>
 

--- a/docs/hardware/devices/b-and-q-consulting/station-series/buttons.mdx
+++ b/docs/hardware/devices/b-and-q-consulting/station-series/buttons.mdx
@@ -20,16 +20,18 @@ values={[
 
 ## Functionality
 
-- **User/Program Button:**
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-- **Firmware Download Button:** Places device into Firmware Download Mode.
-  1. Press and hold Firmware Download Button.
-  2. Then single press Reset Button.
-  3. Finally release the Firmware Download Button.
-- **Reset Button:**
-  - **Single press:** Resets the device.
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+- **User button (program button):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+- **Firmware download button:** Places the device into firmware download mode.
+  1. Press and hold the firmware download button.
+  2. Short press the reset button.
+  3. Release the firmware download button.
+- **Reset button:**
+  - **Short press:** Reset the device.
 
 </TabItem>
 

--- a/docs/hardware/devices/community-supported/b-and-q-consulting/nano/buttons.mdx
+++ b/docs/hardware/devices/community-supported/b-and-q-consulting/nano/buttons.mdx
@@ -22,28 +22,42 @@ values={[
 
 ### Nano G1 Explorer
 
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
 #### Buttons
 
-- **User/Program Button:**
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-- **Message Read Button:**
-  - **Single press:** Clears the New Message LED.
+- **User button (information button):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+- **Message read button:**
+  - **Short press:** Clear the new message LED.
 
-### Switches
+#### Switches
 
 - **Power:**
-  - **Toggle Up:** Turns on the device.
-  - **Toggle Down:** Turns off the device.
-- **Location Pin:**
-  - **Toggle Up:** Sets GPS to operating mode.
-  - **Toggle Down:** Sets GPS to low power mode.
+  - **Toggle up:** Turn the device on.
+  - **Toggle down:** Turn the device off.
+- **Location pin:**
+  - **Toggle up:** Set the GPS to operating mode.
+  - **Toggle down:** Set the GPS to low power mode.
 - **Bell:**
-  - **Toggle Up:** Selects Buzzer for Enhanced Message Notification Circuit.
-  - **Toggle Down:** Selects LED for Enhanced Message Notification Circuit.
+  - **Toggle up:** Select the buzzer for the enhanced message notification circuit.
+  - **Toggle down:** Select the LED for the enhanced message notification circuit.
 
 </TabItem>
 <TabItem value="g1">
+
+### Nano G1
+
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+#### Buttons
+
+- **User button (middle):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
 
 </TabItem>
 </Tabs>

--- a/docs/hardware/devices/community-supported/b-and-q-consulting/station-series/buttons.mdx
+++ b/docs/hardware/devices/community-supported/b-and-q-consulting/station-series/buttons.mdx
@@ -7,6 +7,9 @@ sidebar_position: 1
 
 ## Functionality
 
-- **User/Program Button:**
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+- **User button (program button):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.

--- a/docs/hardware/devices/community-supported/chatter/buttons.mdx
+++ b/docs/hardware/devices/community-supported/chatter/buttons.mdx
@@ -11,12 +11,11 @@ The layout is the one printed on the Chatter sticker
 
 ![Chatter Keypad](/img/hardware/chatter_keypad.webp)
 
-Each button can be pressed up to 4 times in quick succession to access the second third and fourth character listed under it.
-The shift button cycle between lowercase letters, uppercase, and numbers.
+Each button can be pressed up to 4 times in quick succession to reach the second, third and fourth character listed under it. The shift button cycles between lowercase letters, uppercase, and numbers.
 
-The top/left button (labelled UP/LEFT) is assigned to UP and allows the user to access preregistered canned messages (SELECT to send and CANCEL to go back).
+The top/left button (labelled UP/LEFT) is assigned to UP and opens the preregistered canned messages. Press SELECT to send, or CANCEL to go back.
 The next button (labelled DOWN/RIGHT) is assigned to RIGHT.
 The BACKSPACE button is assigned to the TAB function when SHIFT has been pressed once.
-To select a destination, use the TAB button (press SHIFT once then BACKSPACE) to highlight the destination field. Then use the RIGHT key to cycle through available destinations. (Press SHIFT again to return the first function of each key)
+To select a destination, press TAB (SHIFT once, then BACKSPACE) to highlight the destination field, then press RIGHT to cycle through the available destinations. Press SHIFT again to return each key to its first function.
 
-Simply starting to type a text using the letter key will automatically open a free text input panel and allow the user to write the message to send using the SELECT key.
+Typing with any letter key opens a free text input panel. Press SELECT to send the message.

--- a/docs/hardware/devices/community-supported/heltec-automation/sensor/buttons.mdx
+++ b/docs/hardware/devices/community-supported/heltec-automation/sensor/buttons.mdx
@@ -7,5 +7,9 @@ sidebar_position: 1
 
 ## Capsule Sensor V3
 
-- **Long press 3 seconds:** Power on or shutdown.
-- **Long press 8/16 seconds:** Long press for 8~16 seconds in the shutdown state until the blue indicator lights up. At this time, the device enters the WirelessBoot mode, which can be used to upload firmware.
+The Capsule Sensor V3 has no screen, so its button uses the press gestures rather than a menu.
+
+- **Hold 3 seconds:** Power on, or shut down.
+- **Double press:** Send the device position to the mesh.
+- **Triple press:** Turn the GPS off. Triple press again to turn it back on.
+- **Hold 8 to 16 seconds while shut down:** Enter WirelessBoot mode for uploading firmware. The blue indicator lights when the device is ready.

--- a/docs/hardware/devices/community-supported/lilygo/tbeam/buttons.mdx
+++ b/docs/hardware/devices/community-supported/lilygo/tbeam/buttons.mdx
@@ -19,15 +19,19 @@ values={[
 
 ## Functionality
 
-- **Power Button (left):**
-  - **Long press:** Powers the device on or off.
-- **Reset Button (right):**
-  - **Single press:** Resets the device.
-- **User/Program Button (middle):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Triple press:** Disables the device's GPS. Repeat to re-enable. (_This will be indicated on both information screen pages on the device's display as shown below_)
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+- **Power button (left):**
+  - **Long press:** Power the device on or off. The power management chip handles this directly.
+  - **Short press:** Close the open menu, or turn the screen off when no menu is open.
+- **Reset button (right):**
+  - **Short press:** Reset the device.
+- **User button (middle):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+
+Turn the GPS on or off from the GPS screen menu. While the GPS is off, the display shows this indicator.
 
 <img src="/img/hardware/GPS-disabled.webp" alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
 <img

--- a/docs/hardware/devices/heltec-automation/lora32/buttons.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/buttons.mdx
@@ -7,10 +7,21 @@ sidebar_position: 1
 
 ## Functionality
 
-- **Reset Button (bottom):**
-  - **Single press:** Resets the device.
-- **User/Program Button (top):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Triple press:** Enables/Disables the GPS Module on demand. If an NPN Transistor is added it will cut power to the GPS board. The NPN pin must be configured on the PIN_GPS_EN inside the Position module in the App for this switching to work.
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+The user button is silkscreened **PRG** on the LoRa32 V3 and **PROG** on the V4. Both are the same button.
+
+- **Reset button (bottom):**
+  - **Short press:** Reset the device.
+- **User button (top, PRG or PROG):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+
+The user button is also the ESP32 BOOT strap. Holding it while powering on enters the serial bootloader instead of starting Meshtastic.
+
+The V4 TFT firmware adds a second button. The OLED firmware does not.
+
+- **Second button (TFT firmware only):**
+  - **Short press:** Move to the previous screen. With a menu open, move the highlight up.
+  - **Hold about half a second:** Close the menu.

--- a/docs/hardware/devices/heltec-automation/mesh-node/buttons.mdx
+++ b/docs/hardware/devices/heltec-automation/mesh-node/buttons.mdx
@@ -7,11 +7,23 @@ sidebar_position: 1
 
 ## Mesh Node T114
 
-- **RST Button:**
-  - **Single press:** Resets the device.
-  - **Double press:** The device enters download mode.
-- **User Button:**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Triple press:** Enables/Disables the GPS Module on demand. If an NPN Transistor is added it will cut power to the GPS board. The NPN pin must be configured on the PIN_GPS_EN inside the Position module in the App for this switching to work.
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+The T114 has one user button. The pad silkscreened RESET is not wired as a second button in current firmware.
+
+- **RST button:**
+  - **Short press:** Reset the device.
+  - **Double press:** Enter download mode.
+- **User button:**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+
+### InkHUD firmware
+
+The T114 also ships an optional InkHUD firmware image, which handles the button differently.
+
+- **Short press:** Move to the next applet.
+- **Hold about half a second:** Open the menu. Inside the menu, a short press moves the cursor and a hold activates the highlighted item.
+
+InkHUD has no shutdown-by-holding gesture. Shut down from the menu instead.

--- a/docs/hardware/devices/heltec-automation/vision-master/buttons.mdx
+++ b/docs/hardware/devices/heltec-automation/vision-master/buttons.mdx
@@ -7,22 +7,22 @@ sidebar_position: 1
 
 ## Functionality
 
-### Vision Master E213/E290
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
 
-- **RST Button(side):**
-  - **Single press:** Resets the device.
-- **GPIO21 Button(side):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Triple press:** Enables/Disables the GPS Module on demand. If an NPN Transistor is added it will cut power to the GPS board. The NPN pin must be configured on the PIN_GPS_EN inside the Position module in the App for this switching to work.
+The Vision Master E213, E290 and T190 all have two user buttons: the BOOT button and a second button on GPIO21.
 
-### Vision Master T190
+- **RST button (side):**
+  - **Short press:** Reset the device.
+- **BOOT button:**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+- **GPIO21 button:**
+  - **Short press:** Move to the previous screen. With a menu open, move the highlight up.
+  - **Hold about half a second:** Close the menu.
 
-- **RST Button(side):**
-  - **Single press:** Resets the device.
-- **BOOT Button(top):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Triple press:** Enables/Disables the GPS Module on demand. If an NPN Transistor is added it will cut power to the GPS board. The NPN pin must be configured on the PIN_GPS_EN inside the Position module in the App for this switching to work.
+The BOOT button is also the ESP32 boot strap. Holding it while powering on enters the serial bootloader instead of starting Meshtastic.
+
+### InkHUD firmware
+
+The E213 and E290 also ship an optional InkHUD firmware image. There, a short press moves to the next applet and a hold opens the menu. InkHUD has no shutdown-by-holding gesture.

--- a/docs/hardware/devices/lilygo/lora/buttons.mdx
+++ b/docs/hardware/devices/lilygo/lora/buttons.mdx
@@ -7,9 +7,11 @@ sidebar_position: 1
 
 ## Functionality
 
-- **Reset Button:**
-  - **Single press:** Resets the device.
-- **User/Program Button:**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+- **Reset button:**
+  - **Short press:** Reset the device.
+- **User button:**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.

--- a/docs/hardware/devices/lilygo/tbeam/buttons.mdx
+++ b/docs/hardware/devices/lilygo/tbeam/buttons.mdx
@@ -20,15 +20,19 @@ values={[
 
 ## Functionality
 
-- **Power Button (left):**
-  - **Long press:** Powers the device on or off.
-- **Reset Button (right):**
-  - **Single press:** Resets the device.
-- **User/Program Button (middle):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Triple press:** Disables the device's GPS. Repeat to re-enable. (_This will be indicated on both information screen pages on the device's display as shown below_)
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+- **Power button (left):**
+  - **Long press:** Power the device on or off. The power management chip handles this directly.
+  - **Short press:** Close the open menu, or turn the screen off when no menu is open.
+- **Reset button (right):**
+  - **Short press:** Reset the device.
+- **User button (middle):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+
+Turn the GPS on or off from the GPS screen menu. While the GPS is off, the display shows this indicator.
 
 <img src="/img/hardware/GPS-disabled.webp" alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
 <img
@@ -43,15 +47,19 @@ values={[
 
 ## Functionality
 
-- **Power Button (middle):**
-  - **Long press:** Powers the device on or off.
-- **Reset Button (right):**
-  - **Single press:** Resets the device.
-- **User/Program Button (left):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
-  - **Triple press:** Disables the device's GPS. Repeat to re-enable. (_This will be indicated on both information screen pages on the device's display as shown below_)
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+- **Power button (middle):**
+  - **Long press:** Power the device on or off. The power management chip handles this directly.
+  - **Short press:** Close the open menu, or turn the screen off when no menu is open.
+- **Reset button (right):**
+  - **Short press:** Reset the device.
+- **User button (left):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+
+Turn the GPS on or off from the GPS screen menu. While the GPS is off, the display shows this indicator.
 
 <img src="/img/hardware/GPS-disabled.webp" alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
 <img

--- a/docs/hardware/devices/lilygo/techo/buttons.mdx
+++ b/docs/hardware/devices/lilygo/techo/buttons.mdx
@@ -7,21 +7,31 @@ sidebar_position: 1
 
 ## Functionality
 
-- **Capacitive Touch Button (Top):**<br />
-  - **Touch:**
-    - Update the display
-    - _(at screensaver)_ Wake the display.
-- **Reset Button (Button 1):**
-  - **Single press:** Power-on / reboot.
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
+
+The T-Echo has three inputs: two physical buttons and a capacitive touch pad. What the touch pad does depends on which firmware is installed.
+
+- **Reset button (button 1):**
+  - **Short press:** Power on or reboot.
   - **Double press:** Enter bootloader mode, for firmware update.
-- **Program Button (Button 2):**
-  - **Single press:**
-    - Display next page of information.
-    - _(at screensaver)_ Wake the display.
-    - _(when off)_ Enter bootloader mode, for firmware update.
-  - **Double press:** Send an "adhoc ping": announce device to network.
-  - **3x press:** Enable / disable GPS.
-  - **4x press:** Enable / disable display's backlight.
-  - **Hold:** Shutdown.
+- **Program button (button 2):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+- **Second button:**
+  - **Short press:** Move to the previous screen. With a menu open, move the highlight up.
+  - **Hold about half a second:** Close the menu.
+
+This second button uses the pad silkscreened RESET, which the bootloader configures as a general purpose pin.
+
+### Capacitive touch pad
+
+On the standard firmware, holding the touch pad returns to the previous screen. On a build with a backlight, the touch pad controls the backlight instead and sends no navigation event.
+
+On the InkHUD firmware the touch pad is a backlight control: press for momentary light, hold about five seconds to latch it on, and press again to turn it off.
+
+### InkHUD firmware
+
+A short press of the program button moves to the next applet, and a hold opens the menu. Inside the menu, a short press moves the cursor and a hold activates the highlighted item. InkHUD has no shutdown-by-holding gesture; shut down from the menu.
 
 ![TechoButtons](/img/hardware/t-echo-lilygo.webp)

--- a/docs/hardware/devices/rak-wireless/wisblock/buttons.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/buttons.mdx
@@ -7,24 +7,19 @@ sidebar_position: 3
 
 ## Functionality
 
-Button functionality for RAK devices greatly depends on the device specific configuration. If your device has any of the following buttons, the functionality is generally the same for all RAK devices:
+Most device functions are menu items rather than dedicated button presses. Hold the user button to open the menu for the screen currently shown. Short presses move through the menu, and another hold activates an item.
 
-### RAK5005-O / RAK19007 / RAK19003
+The firmware treats every RAK4631 base board the same. It compiles in two user buttons, wired to base board pins IO5 and P0.12, but neither is populated on a bare base board. They exist only if a button module such as the RAK14002 is fitted, or a button is wired to those pins.
 
-- **Reset Button:**
-  - **Single press:** Resets the device.
-  - **Double press:** Put device into bootloader mode.
-- **User/Program(if configured):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
+### RAK5005-O / RAK19007 / RAK19003 / RAK19001
 
-### RAK19001
-
-- **Reset Button:**
-  - **Single press:** Resets the device.
-  - **Double press:** Put device into bootloader mode.
-- **User/Program Button (if configured):**
-  - **Long press:** Will signal the device to shutdown after 5 seconds.
-  - **Single press:** Changes the information page displayed on the device's screen.
-  - **Double press:** Sends an adhoc ping of the device's position to the network.
+- **Reset button:**
+  - **Short press:** Reset the device.
+  - **Double press:** Put the device into bootloader mode.
+- **User button (if fitted):**
+  - **Short press:** Move to the next screen. With a menu open, move to the next item.
+  - **Hold about half a second:** Open the menu for the current screen. With a menu open, activate the highlighted item.
+  - **Hold about four seconds, then release:** Shut the device down. A rising four-note tone signals that shutdown is arming. This works only more than 30 seconds after boot.
+- **Second button (if fitted):**
+  - **Short press:** Move to the previous screen. With a menu open, move the highlight up.
+  - **Hold about half a second:** Close the menu.


### PR DESCRIPTION
Closes #2336. Closes #1932. Closes #1874.

One firmware answer resolves all three issues, so they are fixed together. Every claim is verified against firmware 2.8.1 — `src/input/ButtonThread.cpp`, `src/input/InputBroker.cpp`, `src/graphics/Screen.cpp`, `src/graphics/draw/MenuHandler.cpp`, and `variants/`. Written to section 11 of the standards in meshtastic/design#150.

## What changed

Most device functions became menu items when BaseUI landed. On a device with a screen:

| Gesture | Behavior |
|---|---|
| Short press | Next screen; next item when a menu is open |
| Hold ~0.5 s | Open the menu for the current screen; activate the highlighted item when a menu is open |
| Hold ~4 s, release | Shut down |

The published pages described the pre-BaseUI behavior, and the same paragraph had been copy-pasted to 14 device pages.

## Multi-press gestures are conditional, not gone

This is the part the pages got wrong in both directions.

On a device **with a screen**, the double and triple click callbacks are never attached (`ButtonThread.cpp:75-94`), so those gestures do nothing.

On a device with **no screen and a user button**, they still apply (`InputBroker.cpp:412-438`):

- **Double press** sends the device position.
- **Triple press** turns the GPS off, and turns it back on when pressed again. `toggleGpsMode()` moves between `ENABLED` and `DISABLED` only.

Those claims now appear only on pages for screenless devices, such as the Heltec Capsule Sensor V3.

## Other corrections

- **`disable_triple_click` no longer exists**, so its section, its entry in the device config options list, and its settings-table row are removed. The gesture it used to gate still exists on screenless devices, as above.
- **"4x press: backlight"** no longer exists in any form. The only 4-click path is external-notification mute, compiled `#if !HAS_SCREEN`. Backlight moved to the Home menu.
- **"shutdown after 5 seconds"** is 3.9 s, fires on release, and is gated on more than 30 s of uptime plus the completed lead-up tone (`ButtonThread.cpp:285-286`).

Per-device, from `variants/`:

| Device | Correction |
|---|---|
| Vision Master E213/E290/T190 | Two buttons, not one (`BUTTON_PIN 0` + `ALT_BUTTON_PIN 21`) |
| T114 | One button; the RESET-silkscreened pad is not wired as a second button |
| T-Echo | Three inputs; the touch pad differs between standard and InkHUD firmware |
| T-Beam | Power button short press cancels, or turns the screen off |
| RAK WisBlock | Two buttons compiled in, neither populated on a bare base board |
| Heltec Capsule Sensor V3 | No screen, so it keeps double press for position and triple press for the GPS toggle |

Adds the PRG/PROG silkscreen cross-reference asked for in #2336, and notes InkHUD button behavior where a device ships an InkHUD image. InkHUD uses a separate input stack with no multi-press gestures at all.

## Not included

- **HT-CT62 and M5Stack Unit C6L** are named in #2336 but have no button pages to edit. Both are worth adding: HT-CT62 is headless (`HAS_SCREEN 0`, so it keeps double and triple press), and the Unit C6L front button is an I2C expander button with a reduced gesture set and no shutdown, ping, or GPS toggle.
- The corrected paragraph is now repeated across 14 files, four of which are near-duplicates under `community-supported/`. The next firmware change re-breaks all of them. Consolidating onto one page with links would fit 11.5, but was out of scope here.

## Testing

`pnpm lint:mdx` and `pnpm build` pass. Audited against section 11: no admonitions, no minimizing words, no second person, all sentences under 25 words, sentence-case headings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated button guides across supported devices to describe menu-based navigation, screen selection, menu activation, and shutdown controls.
  - Documented four-second shutdown gestures, arming tones, and post-boot timing restrictions where applicable.
  - Added or clarified firmware-specific controls, bootloader access, reset behavior, touch controls, and device switches.
  - Removed outdated documentation for legacy multi-press actions and the triple-click configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->