### PR TITLE
docs: split T-Deck keyboard shortcuts by UI

### DIFF
--- a/docs/hardware/devices/lilygo/tdeck/index.mdx
+++ b/docs/hardware/devices/lilygo/tdeck/index.mdx
@@ -9,7 +9,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { DeviceImage } from "/src/components/DeviceImage";
 
-The T-Deck series is a family of compact handheld keyboard devices that pair a physical keyboard with different touchscreen displays. Variants include the original LCD T-Deck (and Plus) with support for MUI, and the new T-Deck Pro e-ink model for low-power, sunlight-readable operation.
+The T-Deck series is a family of compact handheld keyboard devices that pair a physical keyboard with different touchscreen displays. Variants include the original LCD T-Deck (and Plus) with support for [MUI](/docs/configuration/device-uis/meshtasticui/), and the new T-Deck Pro e-ink model for low-power, sunlight-readable operation.
 
 <Tabs
 groupId="t-deck"
@@ -53,19 +53,20 @@ T-Deck Plus variant also comes with a GPS module and a 2000 mAh battery
 
 ## Keyboard Shortcuts
 
-| Shortcut          | Function                                            |
-| ----------------- | --------------------------------------------------- |
-| `alt` & `b`       | Toggle keyboard backlight on/off.                   |
-| `alt` & `c`       | Toggle modifier function. `Fn` displayed on screen. |
-| `alt` & `c` + `m` | Disable/Enable notifications.                       |
-| `alt` & `c` + `q` | Quit/Cancel (message, canned message, etc.)         |
-| `alt` & `c` + `t` | Tab Key (once for dm recipient, twice for channel)  |
-| `alt` & `c` + `i` | Decrease screen brightness.                         |
-| `alt` & `c` + `o` | Increase screen brightness.                         |
-| `alt` & `c` + `g` | Toggle GPS.                                         |
-| `alt` & `c` + `⎵` | Send network ping.                                  |
+These shortcuts belong to [Base UI](/docs/configuration/device-uis/baseui/). Selecting [MUI](/docs/configuration/device-uis/meshtasticui/) replaces the input path, so none of the modifier shortcuts are available there.
 
-As of firmware version 2.3.9, there is a newly added modifier function key combo which allows additional shortcuts to be added. To enable the function key, you will press `alt` and `c` together; a small `Fn` will be displayed in the lower right of the screen. After the function key is enabled, you can press the key for the function you wish to execute. For example, to disable/enable notifications, you would press `alt` and `c` followed by `m`.
+| Shortcut          | [Base UI](/docs/configuration/device-uis/baseui/)   | [MUI](/docs/configuration/device-uis/meshtasticui/) |
+| ----------------- | --------------------------------------------------- | --------------------------------------------------- |
+| `alt` & `b`       | Toggle keyboard backlight on/off.                   | Toggle keyboard backlight on/off.                   |
+| `alt` & `c`       | Toggle the modifier function.                       | Not available.                                      |
+| `alt` & `c` + `m` | Disable/Enable notifications.                       | Not available.                                      |
+| `alt` & `c` + `q` | Quit/Cancel (message, canned message, etc.)         | Not available.                                      |
+| `alt` & `c` + `t` | Tab Key (once for dm recipient, twice for channel)  | Not available.                                      |
+| `alt` & `c` + `g` | Toggle GPS.                                         | Not available.                                      |
+
+`alt` & `b` works under both because the keyboard's own controller handles it. The Meshtastic firmware never sees that combination.
+
+To enable the function key, press `alt` and `c` together. Then press the key for the function to run. For example, to disable or enable notifications, press `alt` and `c` followed by `m`.
 
 ## Flashing
 


### PR DESCRIPTION
Closes #2311.

Adds all three things the issue asked for: MUI linked from the intro, the Keyboard Shortcuts table split into Base UI and MUI columns, and both UI pages linked from the table header.

## Why the shortcuts differ

Selecting MUI sets `display.displaymode` to `COLOR`. The I2C keyboard driver is created at `src/input/InputBroker.cpp:465`, inside the guard that skips input setup when `displaymode` is `COLOR`, so none of the modifier shortcuts are registered under MUI.

`alt` & `b` is the exception the reporter noticed. It has no handler in `kbI2cBase.cpp` at all, because the keyboard's own controller implements it, so it is independent of the UI.

## Two stale claims removed

Both found while testing this on a T-Deck Plus running 2.8:

- The page said a small `Fn` appears in the lower right while the modifier is active. **No such indicator exists.** `INPUT_BROKER_MSG_FN_SYMBOL_ON`/`OFF` are consumed only by `SystemCommandsModule.cpp:33-35`, which returns without acting, and no `Fn` string is drawn anywhere. The modifier itself still works, which is why the shortcuts function with no visible feedback.
- The brightness (`i`, `o`) and network ping (`⎵`) shortcuts did not work on hardware and are removed rather than left as published claims. `MenuHandler.cpp:2705` notes the T-Deck "doesn't seem to support brightness at all, at least not reliably", and the Brightness entry is excluded from its screen options menu for that reason.

## Confirmed on hardware

Every retained shortcut was tested on a T-Deck Plus running 2.8: `alt` & `b`, `alt` & `c`, and `alt` & `c` with `m`, `q`, `t` and `g`.

Four further shortcuts exist in `kbI2cBase.cpp` (`fn`+`s` shutdown, `fn`+`r` reboot, `fn`+`b` Bluetooth, `fn`+`e` emote list) with working consumers, but they arrive as single pre-composed key codes on a different path and could not be confirmed on hardware. They are deliberately left undocumented.

## Testing

`pnpm lint:mdx` and `pnpm build` pass. Written to section 11 of the standards in meshtastic/design#150: no admonitions, imperative instructions, no second person, sentences under 25 words, table columns consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the T-Deck introduction to link directly to the MUI documentation.
  * Clarified that keyboard shortcuts apply to Base UI and added a comparison of shortcut support across Base UI and MUI.
  * Removed documentation for brightness and ping shortcuts.
  * Added clarification about the `alt`+`b` shortcut and how it operates across both interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->