### PR TITLE
docs: use the @site alias for imports

### DIFF
--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -6,8 +6,8 @@ sidebar_position: 3
 description: "Find answers to your Meshtastic questions: from getting started, device setup, to advanced features. Learn about app compatibility, channel sharing, and ham license benefits. Dive into our comprehensive FAQ."
 ---
 
-import { FaqAccordion } from "/src/components/FaqAccordion";
-import { FaqStructuredData } from "/src/components/FaqStructuredData";
+import { FaqAccordion } from "@site/src/components/FaqAccordion";
+import { FaqStructuredData } from "@site/src/components/FaqStructuredData";
 import QRCode from "@site/docs/blocks/_qr-code.mdx";
 
 export const Faq = {

--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 description: "Maximize your Meshtastic device's potential with detailed radio settings instructions, including frequency bands, data rates, and encryption options."
 ---
 
-import { FrequencyCalculator } from "/src/components/tools/FrequencyCalculator";
+import { FrequencyCalculator } from "@site/src/components/tools/FrequencyCalculator";
 import { LinkBudgetChart } from "@site/src/components/LinkBudgetChart";
 import QRCode from "@site/docs/blocks/_qr-code.mdx";
 

--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import LoRaRegions from "../blocks/_lora-regions.mdx";
+import LoRaRegions from "@site/docs/blocks/_lora-regions.mdx";
 import Link from "@docusaurus/Link";
 
 Below is a list of groups that have been actively organizing Meshtastic networks in their regions. Feel free to contact

--- a/docs/configuration/device-uis/baseui/index.mdx
+++ b/docs/configuration/device-uis/baseui/index.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 description: BaseUI is a standalone interface for supported Meshtastic devices, enabling direct interaction without requiring a phone for common functions. It runs alongside the firmware, providing messaging and configuration options.
 ---
 
-import { Dark, Light } from "/src/components/ColorMode";
+import { Dark, Light } from "@site/src/components/ColorMode";
 
 ## What is BaseUI?
 

--- a/docs/configuration/device-uis/meshtasticui/index.mdx
+++ b/docs/configuration/device-uis/meshtasticui/index.mdx
@@ -8,7 +8,7 @@ description: Meshtastic UI (MUI) is a standalone interface for supported Meshtas
 image: "/img/software/meshtastic-ui/mui_link_preview.png"
 ---
 
-import { Dark, Light } from "/src/components/ColorMode";
+import { Dark, Light } from "@site/src/components/ColorMode";
 
 <Dark>
   <img

--- a/docs/configuration/radio/lora.mdx
+++ b/docs/configuration/radio/lora.mdx
@@ -8,7 +8,7 @@ description: Understanding the LoRa configuration settings on your Meshtastic de
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { Icon } from "@iconify/react";
-import LoRaRegions from "../../blocks/_lora-regions.mdx";
+import LoRaRegions from "@site/docs/blocks/_lora-regions.mdx";
 
 The LoRa config options are: Region, Use Preset, Modem Preset, Max Hops, Transmit Power, Bandwidth, Spread Factor, Coding Rate, Frequency Offset, Transmit Enabled, Frequency Slot, Ignore Incoming Array, Ignore MQTT, Override Duty Cycle Limit, SX126x RX Boosted Gain, Override Frequency, and PA Fan Disabled. LoRa config uses an admin message sending a `Config.LoRa` protobuf.
 

--- a/docs/configuration/radio/power.mdx
+++ b/docs/configuration/radio/power.mdx
@@ -9,7 +9,7 @@ import Admonition from "@theme/Admonition";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { Icon } from "@iconify/react";
-import calculateADC from "/src/utils/calculateADC";
+import calculateADC from "@site/src/utils/calculateADC";
 
 :::info Use Device Config first
 Power settings are advanced configuration, most users should choose a role under [Device Config](/docs/configuration/radio/device) to manage power for their device and shouldn't ever need to adjust these settings.

--- a/docs/development/documentation/style-guides/markdown-features.mdx
+++ b/docs/development/documentation/style-guides/markdown-features.mdx
@@ -4,7 +4,7 @@ title: Markdown Features
 sidebar_label: Markdown Features
 ---
 
-import { Dark, Light } from "/src/components/ColorMode";
+import { Dark, Light } from "@site/src/components/ColorMode";
 
 ## Overview
 
@@ -17,7 +17,7 @@ We have developed several [React](https://reactjs.org/) components for assisting
 #### Usage
 
 ```jsx
-import { Dark, Light } from '/src/components/ColorMode';
+import { Dark, Light } from '@site/src/components/ColorMode';
 <Dark>
   <p>Dark</p>
 </Dark>

--- a/docs/getting-started/initial-config.mdx
+++ b/docs/getting-started/initial-config.mdx
@@ -10,7 +10,7 @@ description: Getting started with the initial configuration of your Meshtastic d
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { Icon } from "@iconify/react";
-import LoRaRegions from "../blocks/_lora-regions.mdx";
+import LoRaRegions from "@site/docs/blocks/_lora-regions.mdx";
 import Link from "@docusaurus/Link";
 
 ## Supported Clients per Connection Type

--- a/docs/hardware/devices/b-and-q-consulting/index.mdx
+++ b/docs/hardware/devices/b-and-q-consulting/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: B&Q Consulting
 sidebar_position: 5
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 <DeviceSection device="nano-g2-ultra.svg" />
 

--- a/docs/hardware/devices/b-and-q-consulting/nano/index.mdx
+++ b/docs/hardware/devices/b-and-q-consulting/nano/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="nano-g2-ultra.svg" alt="Nano G2 Ultra" size="lg" center />
 

--- a/docs/hardware/devices/b-and-q-consulting/station-series/index.mdx
+++ b/docs/hardware/devices/b-and-q-consulting/station-series/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 The Station series of devices, designed by Neil Hao from B&Q Consulting and powered by Meshtastic, are compact and durable LoRa devices designed for high-performance radio frequency communication. They feature a powerful PA for LoRa communication, a rugged SMA antenna socket, and a variety of external IO interfaces.
 

--- a/docs/hardware/devices/elecrow/crowpanel/index.mdx
+++ b/docs/hardware/devices/elecrow/crowpanel/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: CrowPanel
 sidebar_position: 2
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="crowpanel_5_0.svg" alt="CrowPanel Advance" size="lg" center />
 

--- a/docs/hardware/devices/elecrow/index.mdx
+++ b/docs/hardware/devices/elecrow/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: Elecrow
 sidebar_position: 6
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 <DeviceSection device="thinknode_m1.svg" />
 

--- a/docs/hardware/devices/elecrow/thinknode/index.mdx
+++ b/docs/hardware/devices/elecrow/thinknode/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 The ThinkNode Series, designed by Elecrow and powered by Meshtastic, offers a set of compact and dependable devices built for off-grid communication and mesh networking. Designed for portability, long battery life, and reliable wireless performance, they are well-suited for outdoor and remote use.
 

--- a/docs/hardware/devices/heltec-automation/index.mdx
+++ b/docs/hardware/devices/heltec-automation/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: HELTEC®
 sidebar_position: 4
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 <DeviceSection device="heltec_v4.svg" size="sm" />
 

--- a/docs/hardware/devices/heltec-automation/lora32/index.mdx
+++ b/docs/hardware/devices/heltec-automation/lora32/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <Tabs
 groupId="heltec"

--- a/docs/hardware/devices/heltec-automation/mesh-node/index.mdx
+++ b/docs/hardware/devices/heltec-automation/mesh-node/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <Tabs
 groupId="heltec"

--- a/docs/hardware/devices/heltec-automation/meshpocket/index.mdx
+++ b/docs/hardware/devices/heltec-automation/meshpocket/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: MeshPocket
 sidebar_position: 5
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="heltec_mesh_pocket.svg" alt="Heltec MeshPocket" size="xl" center />
 

--- a/docs/hardware/devices/heltec-automation/vision-master/index.mdx
+++ b/docs/hardware/devices/heltec-automation/vision-master/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="heltec-vision-master-e213.svg" alt="Heltec Vision Master" size="lg" center />
 

--- a/docs/hardware/devices/lilygo/index.mdx
+++ b/docs/hardware/devices/lilygo/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: LILYGO®
 sidebar_position: 2
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 <DeviceSection device="tbeam-s3-core.svg" />
 

--- a/docs/hardware/devices/lilygo/lora/index.mdx
+++ b/docs/hardware/devices/lilygo/lora/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 Further information on the LILYGO® LoRa devices can be found on LILYGO®'s [GitHub page](https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series).
 

--- a/docs/hardware/devices/lilygo/tbeam/index.mdx
+++ b/docs/hardware/devices/lilygo/tbeam/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 All T-beam models (with the exception of the S3-Core) have an 18650 size battery holder on the rear of the device. This is designed to the original specification of the 18650 and only fits unprotected flat top 18650 cells. Button top and protected cells are typically longer than 65mm, often approaching 70mm.
 

--- a/docs/hardware/devices/lilygo/tdeck/index.mdx
+++ b/docs/hardware/devices/lilygo/tdeck/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 The T-Deck series is a family of compact handheld keyboard devices that pair a physical keyboard with different touchscreen displays. Variants include the original LCD T-Deck (and Plus) with support for MUI, and the new T-Deck Pro e-ink model for low-power, sunlight-readable operation.
 

--- a/docs/hardware/devices/lilygo/techo/index.mdx
+++ b/docs/hardware/devices/lilygo/techo/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: T-Echo
 sidebar_position: 3
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="t-echo.svg" alt="LILYGO T-Echo" size="lg" center />
 

--- a/docs/hardware/devices/lilygo/tpager/index.mdx
+++ b/docs/hardware/devices/lilygo/tpager/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="lilygo-tlora-pager.svg" alt="LILYGO T-Lora Pager" size="lg" center />
 

--- a/docs/hardware/devices/muziworks/index.mdx
+++ b/docs/hardware/devices/muziworks/index.mdx
@@ -5,8 +5,8 @@ sidebar_position: 7
 hide_title: true
 ---
 
-import { Dark, Light } from "/src/components/ColorMode";
-import { DeviceSection } from "/src/components/DeviceImage";
+import { Dark, Light } from "@site/src/components/ColorMode";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 <div style={{ textAlign: "center", margin: "2rem 0" }}>
   <a href="https://muzi.works" target="_blank" rel="noopener noreferrer">

--- a/docs/hardware/devices/muziworks/muzi-base/index.mdx
+++ b/docs/hardware/devices/muziworks/muzi-base/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="muzi_base.svg" alt="muzi BASE System" size="lg" center />
 

--- a/docs/hardware/devices/muziworks/r1-neo.mdx
+++ b/docs/hardware/devices/muziworks/r1-neo.mdx
@@ -5,7 +5,7 @@ sidebar_label: R1 Neo
 sidebar_position: 1
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="muzi_r1_neo.svg" alt="muzi works R1 Neo" size="lg" center />
 

--- a/docs/hardware/devices/rak-wireless/index.mdx
+++ b/docs/hardware/devices/rak-wireless/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: RAK®
 sidebar_position: 1
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 RAKwireless offers a variety of Meshtastic-compatible hardware, including modular starter kits and ready-to-use prebuilt devices. The [RAK Meshtastic Collection](https://msh.to/rak-collection) showcases both options, making it easy to find the right solution for your needs. If you're assembling a Meshtastic device using RAK hardware, the [RAK Meshtastic Designer](https://www.rakwireless.com/en-us/meshtastic-designer/?utm_source=website_partner&utm_medium=referral&utm_campaign=rak_meshtastic_collab) helps you select the right modules to match your use case.
 

--- a/docs/hardware/devices/rak-wireless/wisblock/index.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="rak4631.svg" alt="RAK WisBlock" size="lg" center />
 

--- a/docs/hardware/devices/rak-wireless/wismesh/index.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: WisMesh
 sidebar_position: 2
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 RAK WisMesh is a series of ready-to-use Meshtastic devices designed for seamless deployment. Unlike the WisBlock modular system, which allows users to build and customize their own devices, WisMesh devices provide pre-built, purpose-driven solutions that eliminate the need for assembly or additional configuration.
 

--- a/docs/hardware/devices/rak-wireless/wismesh/pocket.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/pocket.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="rak4631.svg" alt="RAK WisMesh Pocket" size="lg" center />
 

--- a/docs/hardware/devices/rak-wireless/wismesh/repeater.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/repeater.mdx
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="rak2560.svg" alt="RAK WisMesh Repeater" size="lg" center />
 

--- a/docs/hardware/devices/rak-wireless/wismesh/tag.mdx
+++ b/docs/hardware/devices/rak-wireless/wismesh/tag.mdx
@@ -5,7 +5,7 @@ sidebar_label: Tag
 sidebar_position: 6
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="rak_wismesh_tag.svg" alt="RAK WisMesh Tag" size="lg" center />
 

--- a/docs/hardware/devices/seeed-studio/index.mdx
+++ b/docs/hardware/devices/seeed-studio/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: Seeed Studio®
 sidebar_position: 3
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 Seeed Studio is a tech company focused on Edge AI and IoT. With the mission of "making technology accessible for all", Seeed Studio has been embracing open source since DAY 1. Seeed works closely with the Meshtastic community to bring easy-to-use, affordable products to community members. By listening to the voices, communicating and collaborating closely with innovators in this community, iterations of products and new services are brought to life.
 

--- a/docs/hardware/devices/seeed-studio/sensecap/card-tracker.mdx
+++ b/docs/hardware/devices/seeed-studio/sensecap/card-tracker.mdx
@@ -5,7 +5,7 @@ sidebar_label: Card Tracker T1000-E
 sidebar_position: 2
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="tracker-t1000-e.svg" alt="Seeed SenseCAP Card Tracker T1000-E" size="lg" center />
 

--- a/docs/hardware/devices/seeed-studio/sensecap/index.mdx
+++ b/docs/hardware/devices/seeed-studio/sensecap/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: SenseCAP
 sidebar_position: 1
 ---
 
-import { DeviceSection } from "/src/components/DeviceImage";
+import { DeviceSection } from "@site/src/components/DeviceImage";
 
 <DeviceSection device="tracker-t1000-e.svg" />
 

--- a/docs/hardware/devices/seeed-studio/sensecap/indicator.mdx
+++ b/docs/hardware/devices/seeed-studio/sensecap/indicator.mdx
@@ -5,7 +5,7 @@ sidebar_label: SenseCAP Indicator
 sidebar_position: 3
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="seeed-sensecap-indicator.svg" alt="SenseCAP Indicator" size="lg" center />
 

--- a/docs/hardware/devices/seeed-studio/sensecap/solar-node.mdx
+++ b/docs/hardware/devices/seeed-studio/sensecap/solar-node.mdx
@@ -5,7 +5,7 @@ sidebar_label: Solar Node
 sidebar_position: 3
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="seeed_solar.svg" alt="SenseCAP Solar Node" size="lg" center />
 

--- a/docs/hardware/devices/seeed-studio/wio-series/wio-tracker-l1.mdx
+++ b/docs/hardware/devices/seeed-studio/wio-series/wio-tracker-l1.mdx
@@ -5,7 +5,7 @@ sidebar_label: Wio Tracker L1
 sidebar_position: 1
 ---
 
-import { DeviceImage } from "/src/components/DeviceImage";
+import { DeviceImage } from "@site/src/components/DeviceImage";
 
 <DeviceImage device="wio_tracker_l1_case.svg" alt="Wio Tracker L1" size="lg" center />
 

--- a/docs/meshtasticd/index.mdx
+++ b/docs/meshtasticd/index.mdx
@@ -6,7 +6,7 @@ sidebar_label: MeshtasticD
 sidebar_position: 7
 description: Set up and configure Meshtastic on Linux/MacOS devices using the meshtasticd binary.
 ---
-import { Dark, Light } from "/src/components/ColorMode";
+import { Dark, Light } from "@site/src/components/ColorMode";
 
 <Dark>
   <img

--- a/src/components/DeviceImage.tsx
+++ b/src/components/DeviceImage.tsx
@@ -45,7 +45,7 @@ const BASE_URL = "https://flasher.meshtastic.org/img/devices/";
  *
  * @example
  * ```mdx
- * import { DeviceImage } from "/src/components/DeviceImage";
+ * import { DeviceImage } from "@site/src/components/DeviceImage";
  *
  * <DeviceImage device="heltec-v3.svg" alt="Heltec V3" size="lg" />
  * <DeviceImage device="t-deck.svg" alt="LilyGO T-Deck" center />
@@ -95,7 +95,7 @@ export function DeviceImage({
  *
  * @example
  * ```mdx
- * import { DeviceImageRow } from "/src/components/DeviceImage";
+ * import { DeviceImageRow } from "@site/src/components/DeviceImage";
  *
  * <DeviceImageRow
  *   devices={[
@@ -128,7 +128,7 @@ export function DeviceImageRow({
  *
  * @example
  * ```mdx
- * import { DeviceShowcase } from "/src/components/DeviceImage";
+ * import { DeviceShowcase } from "@site/src/components/DeviceImage";
  *
  * <DeviceShowcase
  *   devices={[
@@ -218,7 +218,7 @@ export function DeviceShowcase({
  *
  * @example
  * ```mdx
- * import { DeviceSection } from "/src/components/DeviceImage";
+ * import { DeviceSection } from "@site/src/components/DeviceImage";
  *
  * <DeviceSection device="t-deck.svg" />
  *


### PR DESCRIPTION
## What did you change

Converted every relative import in `docs/` to the canonical Docusaurus `@site` alias. 45 imports across 42 files:

- `/src/components/DeviceImage` and the other `/src/...` paths become `@site/src/...` (42 imports)
- the three relative `_lora-regions.mdx` includes become `@site/docs/blocks/_lora-regions.mdx`, matching how `_qr-code.mdx` and the other blocks are already imported

No other changes. Nothing outside import lines was touched.

## Why did you change it

`docs-review.yml` flags relative import paths and asks for the `@site/src/` alias. Six files came up on #2667, but only because that PR happened to touch them — the same pattern was present in 42 files. Converting all of them now means the remaining ones don't get flagged one PR at a time as people edit unrelated things.

Verified with `docusaurus build`: server and client both compiled successfully, so every converted path resolves.

Note this overlaps #2667 on some of the same files, but on different lines — that PR changes prose, this one changes import statements. Whichever merges second may want a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation component references to use the site’s standardized path aliases.
  - Improved consistency across FAQ, configuration, getting-started, development, Meshtasticd, and hardware documentation pages.
  - Replaced the static link-budget image with an interactive chart in the radio settings documentation.
  - Updated formatting for improved readability.
  - No other user-facing documentation content or functionality was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->