### PR TITLE
Radio Settings: make the link budget plot live

### DIFF
--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -8,7 +8,7 @@ description: "Maximize your Meshtastic device's potential with detailed radio se
 ---
 
 import { FrequencyCalculator } from "/src/components/tools/FrequencyCalculator";
-import { LinkBudgetChart } from "/src/components/LinkBudgetChart";
+import { LinkBudgetChart } from "@site/src/components/LinkBudgetChart";
 import QRCode from "@site/docs/blocks/_qr-code.mdx";
 
 :::info
@@ -82,17 +82,17 @@ Various data-rate options are available when configuring a frequency slot and ar
 
 We have eight primary LoRa radio presets. These are the most common settings and have been proven to work well:
 
-|    Radio Preset          | Alt Preset Name  | Data-Rate  | SF / Symbols | Coding Rate |  Bandwidth   | Link Budget |
-| :--------------------:   | :--------------: | :--------: | :----------: | :---------: | :----------: | :---------: |
-|   Short Range / Turbo    |   Short Turbo    | 21.88 kbps |   7 / 128    |     4/5     |  500 kHz[^1] |    140dB    |
-|    Short Range / Fast    |    Short Fast    | 10.94 kbps |   7 / 128    |     4/5     |    250 kHz   |    143dB    |
-|    Short Range / Slow    |    Short Slow    | 6.25 kbps  |   8 / 256    |     4/5     |    250 kHz   |   145.5dB   |
-|   Medium Range / Fast    |   Medium Fast    | 3.52 kbps  |   9 / 512    |     4/5     |    250 kHz   |    148dB    |
-|   Medium Range / Slow    |   Medium Slow    | 1.95 kbps  |  10 / 1024   |     4/5     |    250 kHz   |   150.5dB   |
-|    Long Range / Turbo    |    Long Turbo    | 1.34 kbps  |  11 / 2048   |     4/8     |    500 kHz   |    150dB    |
-|    Long Range / Fast     |    Long Fast     | 1.07 kbps  |  11 / 2048   |     4/5     |    250 kHz   |    153dB    |
-|  Long Range / Moderate   |  Long Moderate   | 0.34 kbps  |  11 / 2048   |     4/8     |    125 kHz   |    156dB    |
-| Long Range / Slow (depr.)|    Long Slow     | 0.18 kbps  |  12 / 4096   |     4/8     |    125 kHz   |   158.5dB   |
+|       Radio Preset        | Alt Preset Name | Data-Rate  | SF / Symbols | Coding Rate |  Bandwidth  | Link Budget |
+| :-----------------------: | :-------------: | :--------: | :----------: | :---------: | :---------: | :---------: |
+|    Short Range / Turbo    |   Short Turbo   | 21.88 kbps |   7 / 128    |     4/5     | 500 kHz[^1] |    140dB    |
+|    Short Range / Fast     |   Short Fast    | 10.94 kbps |   7 / 128    |     4/5     |   250 kHz   |    143dB    |
+|    Short Range / Slow     |   Short Slow    | 6.25 kbps  |   8 / 256    |     4/5     |   250 kHz   |   145.5dB   |
+|    Medium Range / Fast    |   Medium Fast   | 3.52 kbps  |   9 / 512    |     4/5     |   250 kHz   |    148dB    |
+|    Medium Range / Slow    |   Medium Slow   | 1.95 kbps  |  10 / 1024   |     4/5     |   250 kHz   |   150.5dB   |
+|    Long Range / Turbo     |   Long Turbo    | 1.34 kbps  |  11 / 2048   |     4/8     |   500 kHz   |    150dB    |
+|     Long Range / Fast     |    Long Fast    | 1.07 kbps  |  11 / 2048   |     4/5     |   250 kHz   |    153dB    |
+|   Long Range / Moderate   |  Long Moderate  | 0.34 kbps  |  11 / 2048   |     4/8     |   125 kHz   |    156dB    |
+| Long Range / Slow (depr.) |    Long Slow    | 0.18 kbps  |  12 / 4096   |     4/8     |   125 kHz   |   158.5dB   |
 
 :::note
 The link budget used by these calculations assumes a transmit power of 22dBm and an antenna with 0dB gain. Adjust your link budget assumptions based on your actual devices. Data-rate in this table is the theoretical max but doesn't account for packet headers, hops and re-transmissions. Calculations based on data from the official [Semtech LoRa calculator](https://www.semtech.com/design-support/lora-calculator).
@@ -113,16 +113,16 @@ Some example settings:
 
 | Data-rate  | SF / Symbols | Coding Rate | Bandwidth | Link Budget | Note                                                                     |
 | :--------: | :----------: | :---------: | :-------: | :---------: | :----------------------------------------------------------------------- |
-| 37.50 kbps |    6 / 64    |     4/5     |    500 kHz    |    129dB    | Fastest possible speed                                                   |
-| 3.125 kbps |   8 / 256    |     4/5     |    125 kHz    |    143dB    |                                                                          |
-| 1.953 kbps |   8 / 256    |     4/8     |    125 kHz    |    143dB    |                                                                          |
-| 1.343 kbps |  11 / 2048   |     4/8     |    500 kHz    |    145dB    |                                                                          |
-| 1.099 kbps |   9 / 512    |     4/8     |    125 kHz    |    146dB    |                                                                          |
-| 0.814 kbps |  10 / 1024   |     4/6     |    125 kHz    |    149dB    |                                                                          |
-| 0.610 kbps |  10 / 1024   |     4/8     |    125 kHz    |    149dB    |                                                                          |
-| 0.488 kbps |  11 / 2048   |     4/6     |    125 kHz    |    152dB    |                                                                          |
-| 0.073 kbps |  12 / 4096   |     4/5     |    31 kHz     |    160dB    | Twice the range and/or coverage of "Long Slow", low resilience to noise  |
-| 0.046 kbps |  12 / 4096   |     4/8     |    31 kHz     |    160dB    | Twice the range and/or coverage of "Long Slow", high resilience to noise |
+| 37.50 kbps |    6 / 64    |     4/5     |  500 kHz  |    129dB    | Fastest possible speed                                                   |
+| 3.125 kbps |   8 / 256    |     4/5     |  125 kHz  |    143dB    |                                                                          |
+| 1.953 kbps |   8 / 256    |     4/8     |  125 kHz  |    143dB    |                                                                          |
+| 1.343 kbps |  11 / 2048   |     4/8     |  500 kHz  |    145dB    |                                                                          |
+| 1.099 kbps |   9 / 512    |     4/8     |  125 kHz  |    146dB    |                                                                          |
+| 0.814 kbps |  10 / 1024   |     4/6     |  125 kHz  |    149dB    |                                                                          |
+| 0.610 kbps |  10 / 1024   |     4/8     |  125 kHz  |    149dB    |                                                                          |
+| 0.488 kbps |  11 / 2048   |     4/6     |  125 kHz  |    152dB    |                                                                          |
+| 0.073 kbps |  12 / 4096   |     4/5     |  31 kHz   |    160dB    | Twice the range and/or coverage of "Long Slow", low resilience to noise  |
+| 0.046 kbps |  12 / 4096   |     4/8     |  31 kHz   |    160dB    | Twice the range and/or coverage of "Long Slow", high resilience to noise |
 
 The link budget used by these calculations assumes a transmit power of 17dBm and an antenna with 0dB gain. Adjust your link budget assumptions based on your actual devices.
 

--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -8,6 +8,7 @@ description: "Maximize your Meshtastic device's potential with detailed radio se
 ---
 
 import { FrequencyCalculator } from "/src/components/tools/FrequencyCalculator";
+import { LinkBudgetChart } from "/src/components/LinkBudgetChart";
 import QRCode from "@site/docs/blocks/_qr-code.mdx";
 
 :::info
@@ -18,7 +19,7 @@ Meshtastic is **not** LoRaWAN, Helium or TTN (TheThingsNetwork). Meshtastic uses
 Power limits will generally be lifted in the software if `is_licensed` is set to `true`. See [Ham Mode](/docs/faq#amateur-radio-ham) for more information.
 :::
 
-<div class="no-print">
+<div className="no-print">
   ## Frequency Slot Calculator
 
   <FrequencyCalculator />
@@ -97,7 +98,7 @@ We have eight primary LoRa radio presets. These are the most common settings and
 The link budget used by these calculations assumes a transmit power of 22dBm and an antenna with 0dB gain. Adjust your link budget assumptions based on your actual devices. Data-rate in this table is the theoretical max but doesn't account for packet headers, hops and re-transmissions. Calculations based on data from the official [Semtech LoRa calculator](https://www.semtech.com/design-support/lora-calculator).
 :::
 
-![link budget vs data rate plot](/img/about/link-budget-vs-data-rate.webp)
+<LinkBudgetChart />
 
 ### Custom Settings
 

--- a/src/components/LinkBudgetChart.tsx
+++ b/src/components/LinkBudgetChart.tsx
@@ -1,0 +1,659 @@
+import { useId, useState } from "react";
+
+interface Preset {
+  name: string;
+  sf: number;
+  bw: number; // kHz, sub-GHz
+  wideBw: number; // kHz on the 2.4 GHz band
+  cr: number; // denominator of the 4/n coding rate
+  licensed?: boolean; // carried by a ham band profile
+  onWide?: boolean; // offered by the 2.4 GHz region profile
+}
+
+// Matches the modem preset table the firmware ships.
+const PRESETS: Preset[] = [
+  { name: "Short Turbo", sf: 7, bw: 500, wideBw: 1625, cr: 5, onWide: true },
+  { name: "Short Fast", sf: 7, bw: 250, wideBw: 812.5, cr: 5, onWide: true },
+  { name: "Short Slow", sf: 8, bw: 250, wideBw: 812.5, cr: 5, onWide: true },
+  { name: "Medium Turbo", sf: 9, bw: 500, wideBw: 1625, cr: 5, onWide: true },
+  { name: "Medium Fast", sf: 9, bw: 250, wideBw: 812.5, cr: 5, onWide: true },
+  { name: "Medium Slow", sf: 10, bw: 250, wideBw: 812.5, cr: 5, onWide: true },
+  { name: "Long Turbo", sf: 11, bw: 500, wideBw: 1625, cr: 8, onWide: true },
+  { name: "Long Fast", sf: 11, bw: 250, wideBw: 812.5, cr: 5, onWide: true },
+  {
+    name: "Long Moderate",
+    sf: 11,
+    bw: 125,
+    wideBw: 406.25,
+    cr: 8,
+    onWide: true,
+  },
+  { name: "Lite Fast", sf: 9, bw: 125, wideBw: 125, cr: 5 },
+  { name: "Lite Slow", sf: 10, bw: 125, wideBw: 125, cr: 5 },
+  { name: "Narrow Fast", sf: 7, bw: 62.5, wideBw: 62.5, cr: 6, licensed: true },
+  { name: "Narrow Slow", sf: 8, bw: 62.5, wideBw: 62.5, cr: 6, licensed: true },
+  { name: "Tiny Fast", sf: 7, bw: 15.6, wideBw: 15.6, cr: 5, licensed: true },
+  { name: "Tiny Slow", sf: 8, bw: 15.6, wideBw: 15.6, cr: 6, licensed: true },
+];
+
+// Chip rate over symbols, discounted by the coding rate.
+const dataRate = (sf: number, bw: number, cr: number): number =>
+  (sf * (bw * 1000)) / 2 ** sf / 1000 / (cr / 4);
+
+// 22 dBm transmit into 0 dB of antenna gain, against the thermal floor plus the
+// demodulator's 2.5 dB per spreading factor. Reproduces every value in the preset table.
+const linkBudget = (sf: number, bw: number): number =>
+  197 - 10 * Math.log10(bw * 1000) + 2.5 * (sf - 7);
+
+type FilterId = "all" | "ham" | "bw500" | "bw250" | "narrow" | "wide";
+
+const FILTERS: { id: FilterId; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "ham", label: "Licensed" },
+  { id: "bw500", label: "500 kHz" },
+  { id: "bw250", label: "250 kHz" },
+  { id: "narrow", label: "Narrow" },
+  { id: "wide", label: "2.4 GHz" },
+];
+
+type ShapeName =
+  | "triangleDown"
+  | "triangleUp"
+  | "diamond"
+  | "circle"
+  | "square";
+
+// Bandwidth keeps its own shape and ramp step in both bands, so the 2.4 GHz view reads
+// against the sub-GHz one even though the preset names are reused there.
+const BANDWIDTH_STYLE = new Map<number, { shape: ShapeName; slot: number }>([
+  [15.6, { shape: "triangleDown", slot: 0 }],
+  [62.5, { shape: "triangleUp", slot: 1 }],
+  [125, { shape: "diamond", slot: 2 }],
+  [250, { shape: "circle", slot: 3 }],
+  [500, { shape: "square", slot: 4 }],
+  [406.25, { shape: "diamond", slot: 2 }],
+  [812.5, { shape: "circle", slot: 3 }],
+  [1625, { shape: "square", slot: 4 }],
+]);
+
+interface Axes {
+  xMax: number;
+  xTicks: number[];
+  yMin: number;
+  yMax: number;
+  yTicks: number[];
+}
+
+// Fixed per band, so switching between the sub-GHz filters never moves the axes
+const SUB_AXES: Axes = {
+  xMax: 25,
+  xTicks: [0, 5, 10, 15, 20, 25],
+  yMin: 138,
+  yMax: 160,
+  yTicks: [140, 145, 150, 155, 160],
+};
+
+const WIDE_AXES: Axes = {
+  xMax: 90,
+  xTicks: [0, 15, 30, 45, 60, 75, 90],
+  yMin: 133,
+  yMax: 155,
+  yTicks: [135, 140, 145, 150, 155],
+};
+
+const WIDTH = 880;
+const HEIGHT = 528;
+const PAD = { top: 84, right: 90, bottom: 52, left: 62 };
+const PLOT_W = WIDTH - PAD.left - PAD.right;
+const PLOT_H = HEIGHT - PAD.top - PAD.bottom;
+
+const RADIUS = 6;
+const LABEL_SIZE = 12;
+
+const xScale = (kbps: number, axes: Axes): number =>
+  PAD.left + (kbps / axes.xMax) * PLOT_W;
+
+const yScale = (db: number, axes: Axes): number =>
+  PAD.top + ((axes.yMax - db) / (axes.yMax - axes.yMin)) * PLOT_H;
+
+interface Placement {
+  x: number;
+  y: number;
+  anchor: "start" | "end";
+}
+
+const CHAR_W = 6.1;
+
+// Rails above the smoothed line through the points, nearest first, so a label that cannot
+// fit close in steps further up rather than sliding far along the curve. Every stalk then
+// leaves its mark up and to the right, and stays short.
+// Hand-placed labels, as offsets from the mark. Positive dy points down the screen and a
+// dy of 4 reads as horizontal, since the text sits on its baseline; a negative dx puts the
+// label to the left of its mark. Anything not listed here is placed automatically below.
+const LABEL_HINTS = new Map<string, { dx: number; dy: number }>([
+  ["Short Turbo", { dx: 12, dy: -8 }],
+  ["Short Fast", { dx: 14, dy: 4 }],
+  ["Medium Turbo", { dx: 14, dy: 4 }],
+  ["Short Slow", { dx: 24, dy: -10 }],
+  ["Medium Fast", { dx: 20, dy: 4 }],
+  ["Narrow Fast", { dx: 20, dy: 1 }],
+  ["Long Turbo", { dx: 37, dy: -26 }],
+  ["Medium Slow", { dx: 25, dy: 4 }],
+  ["Long Fast", { dx: 26, dy: -25 }],
+  ["Narrow Slow", { dx: 30, dy: -34 }],
+  ["Lite Fast", { dx: 21, dy: -26 }],
+  ["Tiny Slow", { dx: 18, dy: -28 }],
+  ["Long Moderate", { dx: 20, dy: -30 }],
+  ["Tiny Fast", { dx: 22, dy: -30 }],
+  ["Lite Slow", { dx: 24, dy: -35 }],
+]);
+
+const BANDS = [-28, -50, -72, -94, -116, -138, -160];
+const SLIDES = [10, 30, 52, 76];
+const MARK_CLEARANCE = 10;
+// Labels stay clear of the title
+const TITLE_BAND = 70;
+
+interface Anchored {
+  name: string;
+  cx: number;
+  cy: number;
+}
+
+interface LabelBox {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+const hits = (a: LabelBox, b: LabelBox): boolean =>
+  a.x1 < b.x2 && a.x2 > b.x1 && a.y1 < b.y2 && a.y2 > b.y1;
+
+// Reads the rail at any x by walking the polyline it is built from
+const railAt = (xs: number[], ys: number[], x: number): number => {
+  const last = xs.length - 1;
+  if (x <= xs[0]) return ys[0];
+  if (x >= xs[last]) return ys[last];
+  for (let i = 1; i <= last; i++) {
+    if (x <= xs[i]) {
+      const span = xs[i] - xs[i - 1] || 1;
+      return ys[i - 1] + ((x - xs[i - 1]) / span) * (ys[i] - ys[i - 1]);
+    }
+  }
+  return ys[last];
+};
+
+const placeLabels = (points: Anchored[]): Placement[] => {
+  const marks: LabelBox[] = points.map((point) => ({
+    x1: point.cx - MARK_CLEARANCE,
+    y1: point.cy - MARK_CLEARANCE,
+    x2: point.cx + MARK_CLEARANCE,
+    y2: point.cy + MARK_CLEARANCE,
+  }));
+  const order = points
+    .map((point, index) => ({ point, index }))
+    .sort((a, b) => a.point.cx - b.point.cx);
+  const n = order.length;
+  const xs = order.map((entry) => entry.point.cx);
+  const smooth = order.map((entry, i) => {
+    const prev = order[Math.max(0, i - 1)].point.cy;
+    const next = order[Math.min(n - 1, i + 1)].point.cy;
+    return (prev + 2 * entry.point.cy + next) / 4;
+  });
+
+  const out: Placement[] = new Array(points.length);
+  const placed: LabelBox[] = [...marks];
+
+  // Hand-placed labels go down first, so the automatic ones have to work around them
+  for (const entry of order) {
+    const hint = LABEL_HINTS.get(entry.point.name);
+    if (!hint) continue;
+    const x = entry.point.cx + hint.dx;
+    const y = entry.point.cy + hint.dy;
+    const w = entry.point.name.length * CHAR_W;
+    const anchor = hint.dx < 0 ? "end" : "start";
+    const x1 = anchor === "end" ? x - w : x;
+    placed.push({ x1, y1: y - LABEL_SIZE, x2: x1 + w, y2: y + 3 });
+    out[entry.index] = { x, y, anchor };
+  }
+
+  for (const entry of order) {
+    if (LABEL_HINTS.has(entry.point.name)) continue;
+    const w = entry.point.name.length * CHAR_W;
+    let chosen: Placement | null = null;
+
+    for (const band of BANDS) {
+      if (chosen) break;
+      const railY = smooth.map((y) => y + band);
+      for (const slide of SLIDES) {
+        const x = entry.point.cx + slide;
+        // Never let the rail put a label level with or below its own mark
+        const y = Math.min(railAt(xs, railY, x), entry.point.cy - 14);
+        const box: LabelBox = {
+          x1: x,
+          y1: y - LABEL_SIZE,
+          x2: x + w,
+          y2: y + 3,
+        };
+        const onCanvas = box.x2 <= WIDTH - 4 && box.y1 >= TITLE_BAND;
+        if (onCanvas && !placed.some((other) => hits(box, other))) {
+          placed.push(box);
+          chosen = { x, y, anchor: "start" };
+          break;
+        }
+      }
+    }
+
+    out[entry.index] = chosen ?? {
+      x: entry.point.cx + SLIDES[0],
+      y: Math.max(12, entry.point.cy - 14),
+      anchor: "start",
+    };
+  }
+  return out;
+};
+
+const Mark = ({
+  shape,
+  cx,
+  cy,
+  r,
+}: {
+  shape: ShapeName;
+  cx: number;
+  cy: number;
+  r: number;
+}): JSX.Element => {
+  switch (shape) {
+    case "square":
+      return <rect x={cx - r} y={cy - r} width={r * 2} height={r * 2} />;
+    case "diamond":
+      return (
+        <polygon
+          points={`${cx},${cy - r * 1.25} ${cx + r * 1.25},${cy} ${cx},${cy + r * 1.25} ${cx - r * 1.25},${cy}`}
+        />
+      );
+    case "triangleUp":
+      return (
+        <polygon
+          points={`${cx},${cy - r * 1.3} ${cx + r * 1.2},${cy + r * 0.9} ${cx - r * 1.2},${cy + r * 0.9}`}
+        />
+      );
+    case "triangleDown":
+      return (
+        <polygon
+          points={`${cx},${cy + r * 1.3} ${cx + r * 1.2},${cy - r * 0.9} ${cx - r * 1.2},${cy - r * 0.9}`}
+        />
+      );
+    default:
+      return <circle cx={cx} cy={cy} r={r} />;
+  }
+};
+
+const formatRate = (kbps: number): string =>
+  kbps >= 10 ? kbps.toFixed(1) : kbps.toFixed(2);
+
+const formatBandwidth = (value: number): string => {
+  const bw = Number(value);
+  return `${Number.isInteger(bw) ? bw : Number(bw.toFixed(2))} kHz`;
+};
+
+const matchesFilter = (preset: Preset, filter: FilterId): boolean => {
+  switch (filter) {
+    case "ham":
+      return preset.licensed === true;
+    case "bw500":
+      return preset.bw === 500;
+    case "bw250":
+      return preset.bw === 250;
+    case "narrow":
+      return preset.bw < 250;
+    case "wide":
+      return preset.onWide === true;
+    default:
+      return true;
+  }
+};
+
+export const LinkBudgetChart = (): JSX.Element => {
+  const [selected, setSelected] = useState<FilterId[]>([]);
+  const [active, setActive] = useState<string | null>(null);
+  const titleId = useId();
+  const descId = useId();
+
+  const wide = selected.includes("wide");
+  const axes = wide ? WIDE_AXES : SUB_AXES;
+
+  // No selection means everything; otherwise a preset needs to match any one chip
+  const visible = (preset: Preset): boolean =>
+    selected.length === 0 ||
+    selected.some((filter) => matchesFilter(preset, filter));
+
+  // The 2.4 GHz set reuses the preset names at wide bandwidths, so it never mixes
+  const toggle = (id: FilterId) => {
+    setActive(null);
+    if (id === "all") {
+      setSelected([]);
+      return;
+    }
+    if (id === "wide" || selected.includes("wide")) {
+      setSelected(selected.includes(id) ? [] : [id]);
+      return;
+    }
+    setSelected(
+      selected.includes(id)
+        ? selected.filter((entry) => entry !== id)
+        : [...selected, id],
+    );
+  };
+
+  const points = PRESETS.filter(visible).map((preset) => {
+    const bw = wide ? preset.wideBw : preset.bw;
+    const kbps = dataRate(preset.sf, bw, preset.cr);
+    const db = linkBudget(preset.sf, bw);
+    const style = BANDWIDTH_STYLE.get(bw) ?? {
+      shape: "circle" as ShapeName,
+      slot: 3,
+    };
+    return {
+      ...preset,
+      bw,
+      kbps,
+      db,
+      style,
+      cx: xScale(kbps, axes),
+      cy: yScale(db, axes),
+    };
+  });
+
+  const placements = placeLabels(points);
+  const labelled = points.map((point, index) => ({
+    ...point,
+    label: placements[index],
+  }));
+
+  const legend = [...new Set(points.map((point) => point.bw))]
+    .filter((bw) => Number.isFinite(bw))
+    .sort((a, b) => a - b);
+  const hovered = points.find((point) => point.name === active);
+
+  return (
+    <figure className="lbc-root my-6 mx-0">
+      <style>{`
+        .lbc-root {
+          --lbc-surface: hsl(var(--background));
+          --lbc-ink: hsl(var(--foreground));
+          --lbc-ink-muted: hsl(var(--subtle));
+          --lbc-grid: #e1e0d9;
+          --lbc-axis: #c3c2b7;
+          --lbc-bw-0: #6da7ec;
+          --lbc-bw-1: #3987e5;
+          --lbc-bw-2: #256abf;
+          --lbc-bw-3: #184f95;
+          --lbc-bw-4: #0d366b;
+        }
+        @media (prefers-color-scheme: dark) {
+          :root:where(:not([data-theme="light"])) .lbc-root {
+            --lbc-grid: #2c2c2a;
+            --lbc-axis: #383835;
+            --lbc-bw-0: #256abf;
+            --lbc-bw-1: #3987e5;
+            --lbc-bw-2: #6da7ec;
+            --lbc-bw-3: #9ec5f4;
+            --lbc-bw-4: #cde2fb;
+          }
+        }
+        :root[data-theme="dark"] .lbc-root {
+          --lbc-grid: #2c2c2a;
+          --lbc-axis: #383835;
+          --lbc-bw-0: #256abf;
+          --lbc-bw-1: #3987e5;
+          --lbc-bw-2: #6da7ec;
+          --lbc-bw-3: #9ec5f4;
+          --lbc-bw-4: #cde2fb;
+        }
+        .lbc-mark { stroke: var(--lbc-surface); stroke-width: 2; }
+        .lbc-hit {
+          position: absolute;
+          width: 30px; height: 30px;
+          transform: translate(-50%, -50%);
+          background: none; border: 0; padding: 0;
+          border-radius: 50%; cursor: pointer;
+        }
+        .lbc-hit:focus-visible { outline: 2px solid var(--lbc-ink); outline-offset: 0; }
+        .lbc-chip {
+          border-radius: 9999px;
+          border: 1px solid hsl(var(--accent));
+          padding: 0.1rem 0.75rem;
+          font: inherit;
+          background: none;
+          color: inherit;
+          cursor: pointer;
+        }
+        .lbc-chip[aria-pressed="true"] {
+          background: hsl(var(--btn-primary));
+          color: hsl(var(--btn-primary-foreground));
+        }
+      `}</style>
+
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 list-none pl-0 mb-1 text-sm">
+        {legend.map((bw) => {
+          const style = BANDWIDTH_STYLE.get(bw);
+          return (
+            <li key={bw} className="flex items-center gap-1.5">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+              >
+                <g fill={`var(--lbc-bw-${style?.slot ?? 3})`}>
+                  <Mark shape={style?.shape ?? "circle"} cx={8} cy={8} r={5} />
+                </g>
+              </svg>
+              {formatBandwidth(bw)}
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="relative" onMouseLeave={() => setActive(null)}>
+        <svg
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          className="w-full h-auto"
+          aria-labelledby={`${titleId} ${descId}`}
+        >
+          <title id={titleId}>
+            Link budget versus data rate, by modem preset
+          </title>
+          <text
+            x={WIDTH / 2}
+            y={62}
+            textAnchor="middle"
+            fontSize={24}
+            fontWeight={700}
+            fill="var(--lbc-ink)"
+          >
+            Link budget VS data rate
+          </text>
+          <desc id={descId}>
+            A scatter plot of {points.length} modem presets
+            {wide ? " on the 2.4 GHz band" : ""}. Data rate in kilobits per
+            second runs along the horizontal axis and link budget in decibels up
+            the vertical axis. Point shape and colour give the bandwidth. Each
+            point carries its exact figures as a label for assistive technology.
+          </desc>
+
+          {axes.yTicks.map((db) => (
+            <g key={db}>
+              <line
+                x1={PAD.left}
+                y1={yScale(db, axes)}
+                x2={PAD.left + PLOT_W}
+                y2={yScale(db, axes)}
+                stroke="var(--lbc-grid)"
+                strokeWidth={1}
+              />
+              <text
+                x={PAD.left - 10}
+                y={yScale(db, axes) + 4}
+                textAnchor="end"
+                fontSize={15}
+                fill="var(--lbc-ink-muted)"
+              >
+                {db}
+              </text>
+            </g>
+          ))}
+
+          {axes.xTicks.map((kbps) => (
+            <g key={kbps}>
+              <line
+                x1={xScale(kbps, axes)}
+                y1={PAD.top}
+                x2={xScale(kbps, axes)}
+                y2={PAD.top + PLOT_H}
+                stroke="var(--lbc-grid)"
+                strokeWidth={1}
+              />
+              <text
+                x={xScale(kbps, axes)}
+                y={PAD.top + PLOT_H + 20}
+                textAnchor="middle"
+                fontSize={15}
+                fill="var(--lbc-ink-muted)"
+              >
+                {kbps}
+              </text>
+            </g>
+          ))}
+
+          <line
+            x1={PAD.left}
+            y1={PAD.top}
+            x2={PAD.left}
+            y2={PAD.top + PLOT_H}
+            stroke="var(--lbc-axis)"
+            strokeWidth={1}
+          />
+          <line
+            x1={PAD.left}
+            y1={PAD.top + PLOT_H}
+            x2={PAD.left + PLOT_W}
+            y2={PAD.top + PLOT_H}
+            stroke="var(--lbc-axis)"
+            strokeWidth={1}
+          />
+
+          <text
+            x={PAD.left + PLOT_W / 2}
+            y={HEIGHT - 8}
+            textAnchor="middle"
+            fontSize={15}
+            fill="var(--lbc-ink)"
+          >
+            Data rate (kbps)
+          </text>
+          <text
+            transform={`translate(16 ${PAD.top + PLOT_H / 2}) rotate(-90)`}
+            textAnchor="middle"
+            fontSize={15}
+            fill="var(--lbc-ink)"
+          >
+            Link budget (dB)
+          </text>
+
+          {labelled.map((point) => {
+            const dim = active !== null && active !== point.name;
+            const stalkX =
+              point.label.anchor === "start"
+                ? point.label.x - 4
+                : point.label.x + 4;
+            return (
+              <g key={point.name} opacity={dim ? 0.35 : 1}>
+                <line
+                  x1={point.cx}
+                  y1={point.cy}
+                  x2={stalkX}
+                  y2={point.label.y - 4}
+                  stroke="var(--lbc-axis)"
+                  strokeWidth={1}
+                />
+                <g
+                  className="lbc-mark"
+                  fill={`var(--lbc-bw-${point.style.slot})`}
+                >
+                  <Mark
+                    shape={point.style.shape}
+                    cx={point.cx}
+                    cy={point.cy}
+                    r={RADIUS}
+                  />
+                </g>
+                <text
+                  x={point.label.x}
+                  y={point.label.y}
+                  textAnchor={point.label.anchor}
+                  fontSize={LABEL_SIZE}
+                  fill="var(--lbc-ink)"
+                >
+                  {point.name}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+
+        {points.map((point) => (
+          <button
+            key={point.name}
+            type="button"
+            className="lbc-hit"
+            style={{
+              left: `${(point.cx / WIDTH) * 100}%`,
+              top: `${(point.cy / HEIGHT) * 100}%`,
+            }}
+            aria-label={`${point.name}: ${formatRate(point.kbps)} kbps, ${point.db.toFixed(1)} dB, SF${point.sf}, coding rate 4/${point.cr}, ${formatBandwidth(point.bw)}`}
+            onMouseEnter={() => setActive(point.name)}
+            onFocus={() => setActive(point.name)}
+            onBlur={() => setActive(null)}
+          />
+        ))}
+
+        {hovered ? (
+          <div
+            className="pointer-events-none absolute z-10 rounded-md border border-accent bg-secondary px-2 py-1 text-sm shadow-md"
+            style={{
+              left: `${((hovered.cx + (hovered.cx > WIDTH * 0.6 ? -150 : 14)) / WIDTH) * 100}%`,
+              top: `${(hovered.cy / HEIGHT) * 100}%`,
+            }}
+          >
+            <strong>{hovered.name}</strong>
+            <br />
+            {formatRate(hovered.kbps)} kbps · {hovered.db.toFixed(1)} dB
+            <br />
+            SF{hovered.sf} · 4/{hovered.cr} · {formatBandwidth(hovered.bw)}
+          </div>
+        ) : null}
+      </div>
+
+      <fieldset className="flex flex-wrap gap-2 border-0 m-0 p-0 min-w-0 mt-3">
+        <legend className="sr-only">Filter presets</legend>
+        {FILTERS.map(({ id, label }) => (
+          <button
+            key={id}
+            type="button"
+            className="lbc-chip"
+            aria-pressed={
+              id === "all" ? selected.length === 0 : selected.includes(id)
+            }
+            onClick={() => toggle(id)}
+          >
+            {label}
+          </button>
+        ))}
+      </fieldset>
+    </figure>
+  );
+};

--- a/src/components/LinkBudgetChart.tsx
+++ b/src/components/LinkBudgetChart.tsx
@@ -264,7 +264,7 @@ const Mark = ({
   cx: number;
   cy: number;
   r: number;
-}): JSX.Element => {
+}) => {
   switch (shape) {
     case "square":
       return <rect x={cx - r} y={cy - r} width={r * 2} height={r * 2} />;
@@ -316,7 +316,7 @@ const matchesFilter = (preset: Preset, filter: FilterId): boolean => {
   }
 };
 
-export const LinkBudgetChart = (): JSX.Element => {
+export const LinkBudgetChart = () => {
   const [selected, setSelected] = useState<FilterId[]>([]);
   const [active, setActive] = useState<string | null>(null);
   const titleId = useId();

--- a/src/components/LinkBudgetChart.tsx
+++ b/src/components/LinkBudgetChart.tsx
@@ -632,10 +632,16 @@ export const LinkBudgetChart = () => {
 
         {hovered ? (
           <div
-            className="pointer-events-none absolute z-10 rounded-md border border-accent bg-secondary px-2 py-1 text-sm shadow-md"
+            className="pointer-events-none absolute z-10 max-w-[min(16rem,90%)] rounded-md border border-accent bg-secondary px-2 py-1 text-sm shadow-md"
             style={{
-              left: `${((hovered.cx + (hovered.cx > WIDTH * 0.6 ? -150 : 14)) / WIDTH) * 100}%`,
+              left: `${(hovered.cx / WIDTH) * 100}%`,
               top: `${(hovered.cy / HEIGHT) * 100}%`,
+              // Offsetting by the tooltip's own rendered width keeps it on the chart at
+              // any scale; a viewBox-unit guess only holds at one rendered size.
+              transform:
+                hovered.cx > WIDTH * 0.6
+                  ? "translate(calc(-100% - 0.75rem), -50%)"
+                  : "translate(0.75rem, -50%)",
             }}
           >
             <strong>{hovered.name}</strong>

--- a/src/components/LinkBudgetChart.tsx
+++ b/src/components/LinkBudgetChart.tsx
@@ -422,18 +422,27 @@ export const LinkBudgetChart = () => {
           border-radius: 50%; cursor: pointer;
         }
         .lbc-hit:focus-visible { outline: 2px solid var(--lbc-ink); outline-offset: 0; }
+        /* Matches the frequency calculator's chips. That widget sets a larger root font,
+           so 0.875em here lands on the same 14px they render at. */
         .lbc-chip {
-          border-radius: 9999px;
-          border: 1px solid hsl(var(--accent));
-          padding: 0.1rem 0.75rem;
           font: inherit;
-          background: none;
+          font-size: 0.875em;
+          line-height: 1.5;
+          padding: 0.1em 0.55em;
+          border-radius: 0.25rem;
+          border: 1px solid hsl(var(--border));
+          background: transparent;
           color: inherit;
+          opacity: 0.75;
           cursor: pointer;
+          transition: opacity 0.15s ease, background-color 0.15s ease;
         }
+        .lbc-chip:hover { opacity: 1; }
         .lbc-chip[aria-pressed="true"] {
           background: hsl(var(--btn-primary));
           color: hsl(var(--btn-primary-foreground));
+          border-color: transparent;
+          opacity: 1;
         }
       `}</style>
 
@@ -638,7 +647,7 @@ export const LinkBudgetChart = () => {
         ) : null}
       </div>
 
-      <fieldset className="flex flex-wrap gap-2 border-0 m-0 p-0 min-w-0 mt-3">
+      <fieldset className="flex flex-wrap gap-1.5 border-0 m-0 p-0 min-w-0 mt-3">
         <legend className="sr-only">Filter presets</legend>
         {FILTERS.map(({ id, label }) => (
           <button


### PR DESCRIPTION
Replaces the link budget image on the Radio Settings page with a chart built from the preset data.

The old image had gone out of date: it showed Very Long Slow, which no longer exists, and was missing Long Turbo. Because the new chart works out both axes from the preset settings, it stays in step with the firmware on its own.

What's different:

- Includes the presets the image never had — Medium Turbo, Lite, Narrow and Tiny — and drops the deprecated Long Slow.
- Bandwidth is shown by the shape and shade of each point.
- Buttons under the chart filter by band plan. 2.4 GHz is separate, since those presets reuse the same names at different bandwidths.
- Scales with the page, works in light and dark mode, and hovering a point gives its exact figures.

Only the 2.8 page changes; 2.7 keeps the existing image.

Also fixes a `class` that should have been `className`, so the calculator section is now left out of print as originally intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive link budget chart for modem presets.
  - Supports sub-GHz and 2.4 GHz views, filtering, bandwidth legends, responsive layouts, and hover/focus interactions.
  - Improved chart accessibility with descriptive labels and automatic data-label placement.
  - Updated filter controls with clearer styling and interaction states.

- **Documentation**
  - Replaced the static link budget image with the interactive chart.
  - Corrected Frequency Slot Calculator markup for proper rendering.
  - Re-aligned LoRa preset and custom-settings tables without changing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->