### PR TITLE
Re-enable Docusaurus Faster

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -192,8 +192,10 @@ const config = {
   },
   themes: ["@docusaurus/theme-mermaid"],
   future: {
+    faster: true,
     v4: {
       useCssCascadeLayers: false,
+      removeLegacyPostBuildHeadAttribute: true,
     },
   },
 };


### PR DESCRIPTION
Turns Docusaurus Faster back on. A production build drops from **about 5m30s to 71s** on the same machine — roughly 4.6x.

```
webpack   server 1m28s + client 4m05s
faster    71s total
```

## Why it was off

It was enabled in #1966 (Aug 2025) and disappeared in #2117 (Nov 2025), a dependency bump that rewrote the `future` block. Docusaurus 3.10 renamed the key from `experimental_faster` to `faster`, so the old one would have failed validation on the upgraded version — which looks like the reason it went rather than a decision to stop using it.

`@docusaurus/faster` stayed in `package.json` and is still installed, Rspack binaries and all, so this needs no dependency or lockfile change.

## The second line

`faster: true` enables `ssgWorkerThreads`, which requires `future.v4.removeLegacyPostBuildHeadAttribute`. Nothing in this repo uses the `postBuild({head})` API, so it has no effect here.

## Output

Same 747 pages, 198MB against 200MB. I diffed the two build directories: the 886 non-bundle assets are byte-identical, and every HTML difference is minifier serialisation — attribute quoting, omitted optional closing tags, JSON-LD key order, and the viewport meta value. Visible text is unchanged.

Worth a look at the Vercel preview regardless, since CSS minification moves from cssnano to Lightning CSS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Enabled faster site build processing.

- **Maintenance**
  - Updated generated page markup behavior to use the newer standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->