### PR TITLE
Downloads: rename Bleeding to Nightly and unify the buttons

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -188,14 +188,14 @@
   "downloads.firmware.alphaDescription": {
     "message": "Upcoming changes for testing. For those who want new features."
   },
-  "downloads.firmware.bleeding": {
-    "message": "Bleeding"
+  "downloads.firmware.nightly": {
+    "message": "Nightly"
   },
-  "downloads.firmware.bleedingDescription": {
-    "message": "Latest successful CI build. For those who want to break things."
+  "downloads.firmware.nightlyDescription": {
+    "message": "Built each night from the latest development code. For those who want to break things."
   },
-  "downloads.firmware.downloadBleeding": {
-    "message": "Download Bleeding"
+  "downloads.firmware.downloadNightly": {
+    "message": "Download Nightly"
   },
   "theme.NotFound.title": {
     "message": "Page Not Found",

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -63,13 +63,13 @@ const Firmware = (): JSX.Element => {
               </div>
               <div className="card__footer mt-auto">
                 <a
-                  href="https://flasher.meshtastic.org/"
-                  className="m-auto flex rounded-lg border-4 border-transparent bg-accent p-1 font-semibold text-black shadow-md hover:text-black hover:brightness-110 active:border-green-200"
+                  href="https://msh.to/flash"
+                  className="button button--secondary button--block"
                 >
                   <Translate id="downloads.flasher.goToWebFlasher">
                     Go to Web Flasher
                   </Translate>
-                  <ArrowTopRightOnSquareIcon className="m-auto ml-2 h-4" />
+                  <ArrowTopRightOnSquareIcon className="ml-2 inline h-4 align-text-bottom" />
                 </a>
               </div>
             </div>
@@ -92,13 +92,13 @@ const Firmware = (): JSX.Element => {
               </div>
               <div className="card__footer mt-auto">
                 <a
-                  href="https://flasher.meshtastic.org/"
-                  className="m-auto flex rounded-lg border-4 border-transparent bg-accent p-1 font-semibold text-black shadow-md hover:text-black hover:brightness-110 active:border-green-200"
+                  href="https://msh.to/flash"
+                  className="button button--secondary button--block"
                 >
                   <Translate id="downloads.flasher.goToFlasher">
                     Go to Flasher
                   </Translate>
-                  <ArrowTopRightOnSquareIcon className="m-auto ml-2 h-4" />
+                  <ArrowTopRightOnSquareIcon className="ml-2 inline h-4 align-text-bottom" />
                 </a>
               </div>
             </div>
@@ -134,11 +134,11 @@ const Firmware = (): JSX.Element => {
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=1586432531"
-                  className="m-auto flex rounded-lg border-4 border-transparent bg-accent p-1 font-semibold text-black shadow-md hover:text-black hover:brightness-110 active:border-green-200"
+                  href="https://msh.to/ios"
+                  className="button button--secondary button--block"
                 >
                   <Translate id="downloads.apps.appStore">App Store</Translate>
-                  <ArrowTopRightOnSquareIcon className="m-auto ml-2 h-4" />
+                  <ArrowTopRightOnSquareIcon className="ml-2 inline h-4 align-text-bottom" />
                 </a>
               </div>
             </div>
@@ -162,22 +162,22 @@ const Firmware = (): JSX.Element => {
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://f-droid.org/packages/com.geeksville.mesh/"
-                  className="m-auto flex rounded-lg border-4 border-transparent bg-accent p-1 font-semibold text-black shadow-md hover:text-black hover:brightness-110 active:border-green-200"
+                  href="https://msh.to/fdroid"
+                  className="button button--secondary button--block"
                 >
                   <Translate id="downloads.apps.fdroid">F-Droid</Translate>
-                  <ArrowTopRightOnSquareIcon className="m-auto ml-2 h-4" />
+                  <ArrowTopRightOnSquareIcon className="ml-2 inline h-4 align-text-bottom" />
                 </a>
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://play.google.com/store/apps/details?id=com.geeksville.mesh&referrer=utm_source=downloads-page"
-                  className="mt-4 flex rounded-lg border-4 border-transparent bg-accent p-1 font-semibold text-black shadow-md hover:text-black hover:brightness-110 active:border-green-200"
+                  href="https://msh.to/android"
+                  className="button button--secondary button--block margin-top--sm"
                 >
                   <Translate id="downloads.apps.playStore">
                     Play Store
                   </Translate>
-                  <ArrowTopRightOnSquareIcon className="m-auto ml-2 h-4" />
+                  <ArrowTopRightOnSquareIcon className="ml-2 inline h-4 align-text-bottom" />
                 </a>
               </div>
             </div>
@@ -201,11 +201,11 @@ const Firmware = (): JSX.Element => {
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://client.meshtastic.org"
-                  className="m-auto flex rounded-lg border-4 border-transparent bg-accent p-1 font-semibold text-black shadow-md hover:text-black hover:brightness-110 active:border-green-200"
+                  href="https://msh.to/web"
+                  className="button button--secondary button--block !px-2"
                 >
                   client.meshtastic.org
-                  <ArrowTopRightOnSquareIcon className="m-auto ml-2 h-4" />
+                  <ArrowTopRightOnSquareIcon className="ml-2 inline h-4 align-text-bottom" />
                 </a>
               </div>
             </div>
@@ -243,27 +243,28 @@ const Firmware = (): JSX.Element => {
                 <div className="card m-4 border-2 border-secondary">
                   <div className="card__header">
                     <h3>
-                      <Translate id="downloads.firmware.bleeding">
-                        Bleeding
+                      <Translate id="downloads.firmware.nightly">
+                        Nightly
                       </Translate>
                     </h3>
                   </div>
                   <div className="card__body">
                     <p>
-                      <Translate id="downloads.firmware.bleedingDescription">
-                        Latest successful CI build. For those who want to break
-                        things.
+                      <Translate id="downloads.firmware.nightlyDescription">
+                        Built each night from the latest development code. For
+                        those who want to break things.
                       </Translate>
                     </p>
                   </div>
                   <div className="card__footer mt-auto">
                     <a
-                      href="https://nightly.link/meshtastic/firmware/workflows/main_matrix/master"
+                      href="https://msh.to/nightly/"
                       className="button button--secondary button--block"
                     >
-                      <Translate id="downloads.firmware.downloadBleeding">
-                        Download Bleeding
+                      <Translate id="downloads.firmware.downloadNightly">
+                        Download Nightly
                       </Translate>
+                      <ArrowTopRightOnSquareIcon className="ml-2 inline h-4 align-text-bottom" />
                     </a>
                   </div>
                 </div>


### PR DESCRIPTION
## What changed

### Bleeding becomes Nightly

The third firmware card is renamed from **Bleeding** to **Nightly** and now links to <https://msh.to/nightly/>.

The wording follows what actually ships. `main_matrix.yml` in `meshtastic/firmware` carries a `schedule: cron: 0 7 * * *` trigger that builds `develop` and publishes it to the nightly bucket without creating a GitHub release, so the card now reads:

> Built each night from the latest development code. For those who want to break things.

The old destination, a `nightly.link` artifact URL for the last successful `main_matrix` run on `master`, is dropped. No other page in this repository referenced it.

### One button style everywhere

Every button on the page now uses `button button--secondary button--block`, the style the Stable and Alpha cards already used. This replaces the accent-green treatment that pinned black text on `bg-accent`.

The secondary style is theme-aware, so the buttons keep their contrast in both light and dark mode rather than holding one fixed colour across both.

### msh.to short links

| Button | Was | Now |
| --- | --- | --- |
| Go to Web Flasher | `flasher.meshtastic.org` | `msh.to/flash` |
| Go to Flasher | `flasher.meshtastic.org` | `msh.to/flash` |
| App Store | `itunes.apple.com/...id=1586432531` | `msh.to/ios` |
| F-Droid | `f-droid.org/packages/com.geeksville.mesh/` | `msh.to/fdroid` |
| Play Store | `play.google.com/store/apps/details?id=com.geeksville.mesh` | `msh.to/android` |
| Web | `client.meshtastic.org` | `msh.to/web` |
| Nightly | `nightly.link/...main_matrix/master` | `msh.to/nightly/` |

Each short link was followed before use and lands on the destination above.

## Please check before merging

`msh.to/android` redirects to the Play Store listing **without** the `referrer=utm_source=downloads-page` parameter the old direct link carried. Install attribution for this page is lost unless the short link is updated to preserve that parameter. Happy to revert that one row to the direct URL instead if attribution matters more than the indirection.

## Notes

- `i18n/en/code.json` is updated in step with the renamed `Translate` ids, so the three `downloads.firmware.bleeding*` strings become `downloads.firmware.nightly*` rather than being left orphaned for Crowdin.
- The web client button takes a reduced horizontal padding. Infima's default button padding is wider than the old `p-1` treatment, which clipped the external-link icon off the `client.meshtastic.org` label in that narrow card.
- Existing `target="_blank"` behaviour is preserved per link; this change does not add or remove any.

## Testing

- `pnpm run build` passes.
- `oxlint` and `oxfmt --check` clean on the changed file.
- Rendered the built page in Chromium at 1400px and 390px, in both light and dark mode. All nine buttons resolve to the intended href, and no button overflows its box in any of the four combinations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed the “Bleeding” firmware option to “Nightly,” including its label, description, and download action text.
  * Updated the Nightly firmware download link.
  * Shortened download URLs across the downloads page.
  * Standardized download button styling and improved icon alignment for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->