### PR TITLE
Docs/base url

### DIFF
--- a/blog/2024/August/meshtastic-opposition-to-nextnav-proposed-changes.mdx.mdx
+++ b/blog/2024/August/meshtastic-opposition-to-nextnav-proposed-changes.mdx.mdx
@@ -9,6 +9,8 @@ hide_table_of_contents: false
 image: "/design/web/social-preview-1200x630.png"
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 The Federal Communications Commission (FCC) is currently considering a proposal from NextNav that could drastically reshape the 900 MHz band. While this proposal may seem like just another routine reconfiguration, it has significant implications for a broad range of users, particularly those who rely on unlicensed spectrum for innovative, community-driven projects. At the heart of the debate lies the potential impact on open-source initiatives like Meshtastic, an open-source, decentralized communication platform that operates in the 900 MHz ISM band.
 
 {/* truncate */}
@@ -57,7 +59,7 @@ We believe it's vital that the FCC hears from all stakeholders who will be affec
   width="100%"
   height="600px"
 >
-  <p>Your browser does not support PDFs. <a href="/documents/blog/Opposition_Letter.pdf">Download the PDF</a>.</p>
+  <p>Your browser does not support PDFs. <a href={useBaseUrl("/documents/blog/Opposition_Letter.pdf")}>Download the PDF</a>.</p>
 </object>
 
 This document details our stance and the reasons we believe the proposed changes are detrimental to the community. We encourage our readers to review the letter and consider how this issue might affect their own use of the 900 MHz band.

--- a/blog/2025/February/meshtastic-2.6-preview.mdx
+++ b/blog/2025/February/meshtastic-2.6-preview.mdx
@@ -9,6 +9,8 @@ hide_table_of_contents: false
 image: "/img/blog/2_6_Social_Preview.png"
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 Meshtastic 2.6 Preview is here! This has been 1.5 years in the making and includes the first release of our brand new UI for standalone devices, Meshtastic UI or MUI for short. We're also rolling out an all new routing algorithm for Direct Messages. Plus more! We're super excited about this preview and it's probably our most feature-packed release since 2.0 back in November 2022. We can't wait to hear what you think!
 
 {/* truncate */}
@@ -31,7 +33,7 @@ Since we had two unused bytes left in the unencrypted Meshtastic header, we are 
 
 <blockquote>
   <div align="center">
-    <img src="/img/blog/NextHopRouting.webp" alt="Next-Hop Routing" />
+    <img src={useBaseUrl("/img/blog/NextHopRouting.webp")} alt="Next-Hop Routing" />
     Visualization of how next-hop routing for DMs works in Meshtastic.
   </div>
 </blockquote>
@@ -70,7 +72,7 @@ MUI is packed with powerful tools to make managing your Meshtastic network easie
 <blockquote>
   <div align="center">
     <img
-      src="/img/blog/t_deck_mui_map.webp"
+      src={useBaseUrl("/img/blog/t_deck_mui_map.webp")}
       alt="Meshtastic UI (MUI) with Map View"
       width="50%"
       height="auto"
@@ -92,7 +94,7 @@ MUI isn't the only UI we're launching with 2.6! We're also introducing InkHUD, a
 <blockquote>
   <div align="center">
     <img
-      src="/img/blog/inkHUD.webp"
+      src={useBaseUrl("/img/blog/inkHUD.webp")}
       alt="InkHUD in Action!"
       width="50%"
       height="auto"
@@ -148,7 +150,7 @@ Now, because we don't want anyone accidentally flashing this preview release to 
 <blockquote>
   <div align="center">
     <img
-      src="/img/blog/nes_controller.webp"
+      src={useBaseUrl("/img/blog/nes_controller.webp")}
       alt="8-bit NES Controller"
       width="50%"
       height="auto"

--- a/blog/2026/February/tak-server-integration-ios.mdx
+++ b/blog/2026/February/tak-server-integration-ios.mdx
@@ -9,6 +9,8 @@ hide_table_of_contents: false
 image: "/img/blog/tak_ios_blog_cover.png"
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import ReactPlayer from "react-player";
 
 We're excited to announce a major new feature in the Meshtastic iOS app: TAK Server integration. This update bridges two powerful ecosystems—Meshtastic's long-range mesh networking and the Team Awareness Kit (TAK) family of applications such as iTAK and TAK Aware.
@@ -39,7 +41,7 @@ On Android, integrating Meshtastic with ATAK is straightforward. ATAK's plugin a
 iOS tells a different story. Apple's sandboxing and app isolation prevent apps from loading external plugins the way Android/ATAK can. This left iOS users without a path to TAK integration—until now.
 
 <div style={{textAlign: 'center', margin: '2rem 0'}}>
-  <img src="/img/blog/itak-user.png" alt="One does not simply meme" style={{maxWidth: '400px'}} />
+  <img src={useBaseUrl("/img/blog/itak-user.png")} alt="One does not simply meme" style={{maxWidth: '400px'}} />
   <p><em>One does not simply add a plugin to iOS - Boromir</em></p>
 </div>
 

--- a/docs/about/overview/index.mdx
+++ b/docs/about/overview/index.mdx
@@ -6,6 +6,8 @@ sidebar_position: 2
 description: "Discover the basics of Meshtastic's operation, from sending messages via the companion app to the network's intelligent rebroadcast system for extended reach."
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 ## How it works
 
 When you send a message on your Meshtastic companion app, it is relayed to the radio using Bluetooth, WiFi/Ethernet or serial connection. That message is then broadcasted by the radio. If it hasn't received a confirmation from any other device after a certain timeout, it will retransmit the message up to three times.
@@ -28,7 +30,7 @@ Nodes can belong to a maximum of 8 Channels in the radio mesh. A custom Channel 
 
 ## Meshtastic LoRa Chirp
 
-<img src="/img/about/lora_chirp.webp" alt="LoRa Chirp" />
+<img src={useBaseUrl("/img/about/lora_chirp.webp")} alt="LoRa Chirp" />
 
 At the physical layer, LoRa uses a modulation technique called Chirp Spread Spectrum (CSS). A "chirp" is a signal that sweeps in frequency over time, either upward (up-chirp) or downward (down-chirp) across the configured bandwidth.
 

--- a/docs/about/overview/range-test.mdx
+++ b/docs/about/overview/range-test.mdx
@@ -7,6 +7,8 @@ sidebar_position: 4
 description: "Explore Meshtastic's impressive range achievements with detailed modem settings and device configurations for both ground and air records."
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -46,17 +48,17 @@ Default Very Long Slow
 - **Firmware Version:** 2.4.2
 - **Antenna:** RAKARJ17
 
-<img src="/img/records/MartinR7-XARC.webp" alt="Node A" />
+<img src={useBaseUrl("/img/records/MartinR7-XARC.webp")} alt="Node A" />
 
-<img src="/img/records/MartinR7-Sneznik.webp" alt="Node B" />
+<img src={useBaseUrl("/img/records/MartinR7-Sneznik.webp")} alt="Node B" />
 
-<img src="/img/records/MartinR7-map.webp" alt="Map" />
+<img src={useBaseUrl("/img/records/MartinR7-map.webp")} alt="Map" />
 
-<img src="/img/records/MartinR7-map2.webp" alt="Map2" />
+<img src={useBaseUrl("/img/records/MartinR7-map2.webp")} alt="Map2" />
 
-<img src="/img/records/MartinR7-path.webp" alt="Path" />
+<img src={useBaseUrl("/img/records/MartinR7-path.webp")} alt="Path" />
 
-<img src="/img/records/MartinR7-message-trace.webp" alt="Trace" />
+<img src={useBaseUrl("/img/records/MartinR7-message-trace.webp")} alt="Trace" />
 
 #### Previous Ground Record: 254km
 
@@ -85,11 +87,11 @@ Default Long_Fast
 - **Firmware Version:** 2.1.18
 - **Antenna:** Standard LoRa 915MHz 60mm 2dBi Omnidirectional
 
-<img src="/img/records/kboxlabs_sender.webp" alt="Sending Node" />
+<img src={useBaseUrl("/img/records/kboxlabs_sender.webp")} alt="Sending Node" />
 
-<img src="/img/records/kboxlabs_receiver.webp" alt="Receiving Node" />
+<img src={useBaseUrl("/img/records/kboxlabs_receiver.webp")} alt="Receiving Node" />
 
-<img src="/img/records/kboxlabs_map.webp" alt="Geographic Locations" />
+<img src={useBaseUrl("/img/records/kboxlabs_map.webp")} alt="Geographic Locations" />
 
 #### Previous Record 166km
 
@@ -157,9 +159,9 @@ Default Long_Fast
 - **Firmware Version:** 2.1.10 (modified to place GPS in flight mode)
 - **Antenna:** Stock Antenna
 
-<img src="/img/records/Devices-Balloon.webp" alt="Nodes and Balloon" />
+<img src={useBaseUrl("/img/records/Devices-Balloon.webp")} alt="Nodes and Balloon" />
 
-<img src="/img/records/app-screenshots.webp" alt="App Screenshots" />
+<img src={useBaseUrl("/img/records/app-screenshots.webp")} alt="App Screenshots" />
 
 </TabItem>
 </Tabs>

--- a/docs/community/enclosures/tbeam.mdx
+++ b/docs/community/enclosures/tbeam.mdx
@@ -6,6 +6,8 @@ sidebar_label: T-Beam V1
 sidebar_position: 2
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 ## Created by tropho/TonyG
 
 ### T-Beam V5 Case
@@ -24,6 +26,6 @@ Purchase Links:
 - (x4) M3 nuts
 - (x4) M2x4mm screws (no nuts) to secure T-Beam to the frame
 
-<img src="/img/enclosures/3dp-tropho-tbeam.webp" alt="3D-printed Tropho enclosure for the T-Beam" width="400" align="left" />
+<img src={useBaseUrl("/img/enclosures/3dp-tropho-tbeam.webp")} alt="3D-printed Tropho enclosure for the T-Beam" width="400" align="left" />
 
 <!-- ![TrophoTbeam](/img/enclosures/3dp-tropho-tbeam.webp) -->

--- a/docs/community/enclosures/techo.mdx
+++ b/docs/community/enclosures/techo.mdx
@@ -6,12 +6,14 @@ sidebar_label: T-Echo
 sidebar_position: 3
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 ## Created by BrianN
 
 ### T-Echo Expedition Case
 
 Download from [Thingiverse](https://www.thingiverse.com/thing:5028720).
 
-<img src="/img/enclosures/3dp-briann-techo-exp.webp" alt="3D-printed T-Echo Expedition enclosure" width="400" align="left" />
+<img src={useBaseUrl("/img/enclosures/3dp-briann-techo-exp.webp")} alt="3D-printed T-Echo Expedition enclosure" width="400" align="left" />
 
 <!-- ![T-Echo Expedition](/img/enclosures/3dp-briann-techo-exp.webp) -->

--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -5,6 +5,8 @@ sidebar_label: Telemetry
 description: This module allows sharing of Device, Environment, Health, and Air Quality metrics from your Meshtastic device.
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import { Icon } from "@iconify/react";
@@ -277,7 +279,7 @@ All telemetry module config options are available in the Web UI.
 
 Setup of a RAK 4631 with Environment Sensor
 
-[<img src="/img/hardware/rak/RAK4631_with_EnvSensor.webp" alt="RAK4631 wired to an environment sensor" style={{zoom:'25%'}} />](/img/hardware/rak/RAK4631_with_EnvSensor.webp)
+[<img src={useBaseUrl("/img/hardware/rak/RAK4631_with_EnvSensor.webp")} alt="RAK4631 wired to an environment sensor" style={{zoom:'25%'}} />](/img/hardware/rak/RAK4631_with_EnvSensor.webp)
 
 Requirements:
 

--- a/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
@@ -6,6 +6,8 @@ sidebar_position: 4
 description: Instructions for converting the RAK4631-R to RAK-4631 using Python and adafruit-nrfutil.
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 The only difference between the _RAK4631-R_ (RUI3) and the _RAK4631_ (Arduino) is the bootloader it is shipped with - the hardware is the same.
 
 Meshtastic requires the Arduino bootloader on RAK WisBlock nRF52-based boards. The process of converting the bootloader only needs to be performed once.
@@ -54,7 +56,7 @@ This conversion requires the use of either a [DAPLink](https://daplink.io/) or [
    ```
 3. Download the required bootloader: [RAK4631 bootloader image (.hex)](https://raw.githubusercontent.com/RAKWireless/WisBlock/master/bootloader/RAK4630/Latest/wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex)
 4. Connect the RAKDAP as follows:
-   [<img src="/img/rak4631-rakdap1.webp" alt="RAK4631 connected to a RAKDAP1 debug probe" style={{zoom:'25%'}} />](/img/rak4631-rakdap1.webp)
+   [<img src={useBaseUrl("/img/rak4631-rakdap1.webp")} alt="RAK4631 connected to a RAKDAP1 debug probe" style={{zoom:'25%'}} />](/img/rak4631-rakdap1.webp)
 5. Flash the bootloader
    ```shell
    pyocd flash -t nrf52840 .\wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex

--- a/docs/hardware/devices/community-supported/lilygo/tbeam/buttons.mdx
+++ b/docs/hardware/devices/community-supported/lilygo/tbeam/buttons.mdx
@@ -5,6 +5,8 @@ sidebar_label: Buttons
 sidebar_position: 1
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -29,9 +31,9 @@ values={[
   - **Double press:** Sends an adhoc ping of the device's position to the network.
   - **Triple press:** Disables the device's GPS. Repeat to re-enable. (_This will be indicated on both information screen pages on the device's display as shown below_)
 
-<img src="/img/hardware/GPS-disabled.webp" alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
+<img src={useBaseUrl("/img/hardware/GPS-disabled.webp")} alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
 <img
-  src="/img/hardware/GPS-disabled-by-button.webp"
+  src={useBaseUrl("/img/hardware/GPS-disabled-by-button.webp")}
   alt="T-Beam second info screen showing the GPS disabled indicator"
   width="200"
   align="center-right"

--- a/docs/hardware/devices/lilygo/lora/gpio.mdx
+++ b/docs/hardware/devices/lilygo/lora/gpio.mdx
@@ -5,14 +5,16 @@ sidebar_label: GPIO
 sidebar_position: 2
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 ## GPIO IO12
 
 For the Lora V2.1-1.8, Shorting IO12 to ground will progress through the screen pages and/or wake up the device. A simple push switch can be added for this purpose.
 
-<img src="/img/hardware/lora32-v2-1.6-button.webp" alt="Push button wired to IO12 on the LILYGO LoRa32 V2.1 board" width="400" align="left" />
+<img src={useBaseUrl("/img/hardware/lora32-v2-1.6-button.webp")} alt="Push button wired to IO12 on the LILYGO LoRa32 V2.1 board" width="400" align="left" />
 
 <img
-  src="/img/hardware/lora32-v2-1.6-button-example.webp"
+  src={useBaseUrl("/img/hardware/lora32-v2-1.6-button-example.webp")}
   alt="Example push button installed on the LILYGO LoRa32 V2.1 board"
   width="400"
   align="left"

--- a/docs/hardware/devices/lilygo/tbeam/buttons.mdx
+++ b/docs/hardware/devices/lilygo/tbeam/buttons.mdx
@@ -5,6 +5,8 @@ sidebar_label: Buttons
 sidebar_position: 1
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -30,9 +32,9 @@ values={[
   - **Double press:** Sends an adhoc ping of the device's position to the network.
   - **Triple press:** Disables the device's GPS. Repeat to re-enable. (_This will be indicated on both information screen pages on the device's display as shown below_)
 
-<img src="/img/hardware/GPS-disabled.webp" alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
+<img src={useBaseUrl("/img/hardware/GPS-disabled.webp")} alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
 <img
-  src="/img/hardware/GPS-disabled-by-button.webp"
+  src={useBaseUrl("/img/hardware/GPS-disabled-by-button.webp")}
   alt="T-Beam second info screen showing the GPS disabled indicator"
   width="200"
   align="center-right"
@@ -53,9 +55,9 @@ values={[
   - **Double press:** Sends an adhoc ping of the device's position to the network.
   - **Triple press:** Disables the device's GPS. Repeat to re-enable. (_This will be indicated on both information screen pages on the device's display as shown below_)
 
-<img src="/img/hardware/GPS-disabled.webp" alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
+<img src={useBaseUrl("/img/hardware/GPS-disabled.webp")} alt="T-Beam display showing the GPS disabled indicator" width="200" align="center-left" />
 <img
-  src="/img/hardware/GPS-disabled-by-button.webp"
+  src={useBaseUrl("/img/hardware/GPS-disabled-by-button.webp")}
   alt="T-Beam second info screen showing the GPS disabled indicator"
   width="200"
   align="center-right"

--- a/docs/hardware/devices/rak-wireless/wisblock/screens.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/screens.mdx
@@ -5,6 +5,8 @@ sidebar_label: Screens
 sidebar_position: 2
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -43,7 +45,7 @@ If pin ordering on the OLED board are swapped, there are some tricks to allow ei
     - [RAKwireless](https://msh.to/rak1921)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-rak1921)
 
-[<img alt="0.96 inch OLED display" src="/img/hardware/screen.webp" style={{zoom:'25%'}} />](/img/hardware/screen.webp)
+[<img alt="0.96 inch OLED display" src={useBaseUrl("/img/hardware/screen.webp")} style={{zoom:'25%'}} />](/img/hardware/screen.webp)
 
 </TabItem>
 <TabItem value="E-Ink">
@@ -72,7 +74,7 @@ Please note only the white-black display is supported at this time, the white-bl
 
 <img
   alt="RAK4631 5005 14000"
-  src="/img/hardware/rak4631_5005_epaper.webp"
+  src={useBaseUrl("/img/hardware/rak4631_5005_epaper.webp")}
   style={{ zoom: "50%" }}
 />
 

--- a/docs/meshtasticd/hardware/radios/spi/wisblock_hat.mdx
+++ b/docs/meshtasticd/hardware/radios/spi/wisblock_hat.mdx
@@ -6,14 +6,16 @@ sidebar_position: 1
 description: WisMesh Pi HAT for Raspberry Pi
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 RAK6421 - WisMesh Pi HAT for Raspberry Pi
-<img src="/img/meshtasticd/hardware/radios/rak6421.webp" alt="rak6421" width="50%" />
+<img src={useBaseUrl("/img/meshtasticd/hardware/radios/rak6421.webp")} alt="rak6421" width="50%" />
 
 RAK13300 LoRa Module
-<img src="/img/meshtasticd/hardware/radios/rak13300.webp" alt="rak13300" width="50%" />
+<img src={useBaseUrl("/img/meshtasticd/hardware/radios/rak13300.webp")} alt="rak13300" width="50%" />
 
 RAK13302 LoRa Module
-<img src="/img/meshtasticd/hardware/radios/rak13302.webp" alt="rak13302" width="50%" />
+<img src={useBaseUrl("/img/meshtasticd/hardware/radios/rak13302.webp")} alt="rak13302" width="50%" />
 
 
 ### Baseboard Purchase Links

--- a/docs/software/integrations/mqtt/nodered.mdx
+++ b/docs/software/integrations/mqtt/nodered.mdx
@@ -5,6 +5,8 @@ sidebar_label: Node-RED
 sidebar_position: 3
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 ## Using MQTT with Node-RED
 
 Node-RED is a free cross-platform programming tool for wiring together hardware, APIs, and online services developed originally by IBM for IOT. It is widely used for home automation by many non-professional programmers and runs well on Pi's. Node-RED has many plug-in modules written by the community.
@@ -93,20 +95,20 @@ https://flows.nodered.org/node/node-red-contrib-protobuf
 
 Drag, drop, and wire the nodes like this. For this example, I ran Node-RED on a Windows machine. Note that file paths might be specified differently on different platforms. MQTT server wild cards are usually the same. A "+" is a single level wildcard for a specific topic level. A "#" is a multiple level wildcard that can be used at the end of a topic filter. The debug messages shown are what happens when the inject button sends a JSON message with a topic designed to be picked up by the specified Meshtastic device and then having it rebroadcast the message.
 
-[<img src="/documents/mqtt/NodeRedTwo.webp" alt="Node-RED flow wiring the MQTT and Meshtastic nodes" style={{zoom:'50%'}} />](/documents/mqtt/NodeRedTwo.webp)
-[<img src="/documents/mqtt/NodeRedThree.webp" alt="Node-RED debug output from the wired flow" style={{zoom:'50%'}} />](/documents/mqtt/NodeRedThree.webp)
-[<img src="/documents/mqtt/NR_nodes.webp" alt="Node-RED node palette for the Meshtastic flow" style={{zoom:'50%'}} />](/documents/mqtt/NR_nodes.webp)
+[<img src={useBaseUrl("/documents/mqtt/NodeRedTwo.webp")} alt="Node-RED flow wiring the MQTT and Meshtastic nodes" style={{zoom:'50%'}} />](/documents/mqtt/NodeRedTwo.webp)
+[<img src={useBaseUrl("/documents/mqtt/NodeRedThree.webp")} alt="Node-RED debug output from the wired flow" style={{zoom:'50%'}} />](/documents/mqtt/NodeRedThree.webp)
+[<img src={useBaseUrl("/documents/mqtt/NR_nodes.webp")} alt="Node-RED node palette for the Meshtastic flow" style={{zoom:'50%'}} />](/documents/mqtt/NR_nodes.webp)
 
 The aedes broker must be set up on the same flow as the other nodes. By activating the Publish debug node, you can see all the published messages.
-[<img src="/documents/mqtt/Broker1.webp" alt="Node-RED aedes MQTT broker node with publish debug output" style={{zoom:'50%'}} />](/documents/mqtt/Broker1.webp)
+[<img src={useBaseUrl("/documents/mqtt/Broker1.webp")} alt="Node-RED aedes MQTT broker node with publish debug output" style={{zoom:'50%'}} />](/documents/mqtt/Broker1.webp)
 Receiving a json mqtt message is very simple.
-[<img src="/documents/mqtt/Consume.webp" alt="Node-RED flow consuming a JSON MQTT message" style={{zoom:'50%'}} />](/documents/mqtt/Consume.webp)
+[<img src={useBaseUrl("/documents/mqtt/Consume.webp")} alt="Node-RED flow consuming a JSON MQTT message" style={{zoom:'50%'}} />](/documents/mqtt/Consume.webp)
 Injecting a json message to be sent by a device is also very simple. You do need the correct envelope.
-[<img src="/documents/mqtt/Inject.webp" alt="Node-RED inject node sending a JSON message to a device" style={{zoom:'50%'}} />](/documents/mqtt/Inject.webp)
+[<img src={useBaseUrl("/documents/mqtt/Inject.webp")} alt="Node-RED inject node sending a JSON message to a device" style={{zoom:'50%'}} />](/documents/mqtt/Inject.webp)
 Forwarding a text message from one device, through a broker, to another broker/device/channel would look like this.
-[<img src="/documents/mqtt/Forward.webp" alt="Node-RED flow forwarding a text message between brokers" style={{zoom:'50%'}} />](/documents/mqtt/Forward.webp)
+[<img src={useBaseUrl("/documents/mqtt/Forward.webp")} alt="Node-RED flow forwarding a text message between brokers" style={{zoom:'50%'}} />](/documents/mqtt/Forward.webp)
 If you want to decode text and position messages without json, it gets complicated:
-[<img src="/documents/mqtt/DecodeNewest.webp" alt="Node-RED flow decoding text and position messages without JSON" style={{zoom:'50%'}} />](/documents/mqtt/DecodeNewest.webp)
+[<img src={useBaseUrl("/documents/mqtt/DecodeNewest.webp")} alt="Node-RED flow decoding text and position messages without JSON" style={{zoom:'50%'}} />](/documents/mqtt/DecodeNewest.webp)
 If you are interested in my flow for this it is here:
 
 ```json
@@ -671,10 +673,10 @@ If you are interested in my flow for this it is here:
 (documents/mqtt/Flow.txt)
 
 Node-RED can rapidly (minutes vs days) put together some pretty impressive output when paired with meshtastic. Here is the output of that flow geofencing and mapping via mqtt data.
-[<img src="/documents/mqtt/Mapping.webp" alt="Node-RED geofencing and mapping output from MQTT data" style={{zoom:'50%'}} />](/documents/mqtt/Mapping.webp)
+[<img src={useBaseUrl("/documents/mqtt/Mapping.webp")} alt="Node-RED geofencing and mapping output from MQTT data" style={{zoom:'50%'}} />](/documents/mqtt/Mapping.webp)
 
 Advanced use, such as encoding Position and sending it to a device via MQTT without using JSON can get a little complicated. An example of how it can be done is below.
-[<img src="/documents/mqtt/EncodingPosition.webp" alt="Node-RED flow encoding a position and sending it over MQTT" style={{zoom:'50%'}} />](/documents/mqtt/EncodingPosition.webp)
+[<img src={useBaseUrl("/documents/mqtt/EncodingPosition.webp")} alt="Node-RED flow encoding a position and sending it over MQTT" style={{zoom:'50%'}} />](/documents/mqtt/EncodingPosition.webp)
 The flow is:
 
 ```json
@@ -1003,4 +1005,4 @@ Sending a position to a device for broadcast to the mesh is much easier with JSO
 ```
 
 An example of doing this in Node-RED:
-[<img src="/documents/mqtt/PosJSON.webp" alt="Node-RED flow building a position JSON message" style={{zoom:'50%'}} />](/documents/mqtt/PosJSON.webp)
+[<img src={useBaseUrl("/documents/mqtt/PosJSON.webp")} alt="Node-RED flow building a position JSON message" style={{zoom:'50%'}} />](/documents/mqtt/PosJSON.webp)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,13 +3,18 @@ require("dotenv").config();
 import path from "node:path";
 import remarkDefList from "remark-deflist";
 
+// Raw HTML in the config and in MDX bypasses Docusaurus link handling, so anything
+// built by hand has to prefix this itself. Overridable for builds served under a
+// path rather than at a domain root.
+const baseUrl = process.env.DOCS_BASE_URL ?? "/";
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Meshtastic",
   tagline:
     "An open source, off-grid, decentralized, mesh network built to run on affordable, low-power devices",
   url: "https://meshtastic.org",
-  baseUrl: "/",
+  baseUrl,
   trailingSlash: true,
   onBrokenLinks: "throw",
   favicon: "img/logo.svg",
@@ -72,7 +77,7 @@ const config = {
       ],
     },
     footer: {
-      copyright: `<a href="https://vercel.com/?utm_source=meshtastic&utm_campaign=oss">Powered by ▲ Vercel</a> | Meshtastic® is a registered trademark of Meshtastic LLC. | <a href="/docs/legal">Legal Information</a>.`,
+      copyright: `<a href="https://vercel.com/?utm_source=meshtastic&utm_campaign=oss">Powered by ▲ Vercel</a> | Meshtastic® is a registered trademark of Meshtastic LLC. | <a href="${baseUrl}docs/legal">Legal Information</a>.`,
     },
     algolia: {
       appId: "IG2GQB8L3V",

--- a/scripts/sync-apple-docs.js
+++ b/scripts/sync-apple-docs.js
@@ -21,7 +21,9 @@ const APPLE_REPO_PATH = args.find((a) => !a.startsWith("--"));
 const CONVERT_WEBP = args.includes("--convert-webp");
 
 if (!APPLE_REPO_PATH) {
-  console.error("Usage: node scripts/sync-apple-docs.js <apple-repo-path> [--convert-webp]");
+  console.error(
+    "Usage: node scripts/sync-apple-docs.js <apple-repo-path> [--convert-webp]",
+  );
   process.exit(1);
 }
 
@@ -34,7 +36,14 @@ const SRC_DOCS_DIR = path.join(APPLE_REPO_PATH, "docs");
 const DEST_DOCS_DIR = path.join(REPO_ROOT, "docs", "software", "apple");
 const DEST_IMAGES_DIR = path.join(REPO_ROOT, "static", "img", "apple");
 
-const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"]);
+const IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".svg",
+  ".webp",
+]);
 const MD_EXTENSIONS = new Set([".md"]);
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -104,6 +113,43 @@ function rewriteImagePaths(content) {
 }
 
 /**
+ * Point raw HTML asset references at useBaseUrl().
+ *
+ * Docusaurus applies baseUrl to Markdown image syntax, but raw HTML is passed
+ * through untouched, so `<img src="/img/apple/x.webp">` resolves against the server
+ * root and breaks anywhere the site is served below one, such as a preview deployed
+ * under a path. These files are generated, so the fix belongs here.
+ */
+function useBaseUrlForAssets(content) {
+  const attr = /\b(src|srcset|poster)=["'](\/(?!\/)[^"']*)["']/g;
+  return content
+    .split(/(```[\s\S]*?```|`[^`]+`)/)
+    .map((seg, i) => {
+      if (i % 2 === 1) return seg; // inside a code span/block - leave as-is
+      return seg.replace(/<(?:img|source|video|audio)\b[^>]*>/gi, (tag) =>
+        tag.replace(attr, (_m, name, url) => `${name}={useBaseUrl("${url}")}`),
+      );
+    })
+    .join("");
+}
+
+/** Add the useBaseUrl import when the page ended up using it. */
+function ensureUseBaseUrlImport(content) {
+  const statement = 'import useBaseUrl from "@docusaurus/useBaseUrl";';
+  if (!content.includes("useBaseUrl(") || content.includes(statement)) {
+    return content;
+  }
+  const frontmatterRe = /^(---\r?\n[\s\S]*?\r?\n---)\r?\n/;
+  const match = content.match(frontmatterRe);
+  if (match) {
+    return content
+      .replace(frontmatterRe, `${match[1]}\n\n${statement}\n\n`)
+      .replace(/\n{3,}/g, "\n\n");
+  }
+  return `${statement}\n\n${content}`;
+}
+
+/**
  * Convert Jekyll/kramdown-specific syntax to Docusaurus-compatible equivalents.
  *
  * Handles:
@@ -138,7 +184,8 @@ function sanitizeForDocusaurus(content) {
       // If the first line matches `**Tip — Title**` or `**Type — Title**`,
       // extract the title and use it as the admonition title.
       // Handles em dash (—), en dash (–), and hyphen (-) separators.
-      const titleMatch = lines[0] && lines[0].match(/^\*\*[^—–\-*]+[—–-]\s*(.+?)\*\*$/);
+      const titleMatch =
+        lines[0] && lines[0].match(/^\*\*[^—–\-*]+[—–-]\s*(.+?)\*\*$/);
       const title = titleMatch ? titleMatch[1].trim() : null;
       const bodyLines = title ? lines.slice(1) : lines;
       const body = bodyLines.join("\n").trim();
@@ -161,10 +208,13 @@ function sanitizeForDocusaurus(content) {
     .split(/(```[\s\S]*?```|`[^`]+`)/)
     .map((seg, i) => {
       if (i % 2 === 1) return seg; // inside a code span/block — leave as-is
-      return seg.replace(/<(img|source)(\s[^>]*?)?\s*>/gi, (match, tag, attrs = "") => {
-        if (match.endsWith("/>")) return match; // already self-closing
-        return `<${tag}${attrs} />`;
-      });
+      return seg.replace(
+        /<(img|source)(\s[^>]*?)?\s*>/gi,
+        (match, tag, attrs = "") => {
+          if (match.endsWith("/>")) return match; // already self-closing
+          return `<${tag}${attrs} />`;
+        },
+      );
     })
     .join("");
 
@@ -176,10 +226,7 @@ function sanitizeForDocusaurus(content) {
   content = segments
     .map((seg, i) => {
       if (i % 2 === 1) return seg; // inside a code span/block — leave as-is
-      return seg.replace(
-        /<(?=[0-9\s\u00BC-\u00BE\u2150-\u215F])/g,
-        "&lt;",
-      );
+      return seg.replace(/<(?=[0-9\s\u00BC-\u00BE\u2150-\u215F])/g, "&lt;");
     })
     .join("");
 
@@ -302,7 +349,9 @@ function rewriteInternalDocLinks(content, dRelPath, knownDestMdPaths) {
     // check if the target is actually a sibling (source used old flat-layout paths).
     if (/^\.\.\//.test(target)) {
       const withoutParent = target.slice(3);
-      const withMd = withoutParent.endsWith(".md") ? withoutParent : `${withoutParent}.md`;
+      const withMd = withoutParent.endsWith(".md")
+        ? withoutParent
+        : `${withoutParent}.md`;
       const targetFile = withMd.split("#")[0];
       if (knownDestMdPaths && knownDestMdPaths.has(`${subdir}/${targetFile}`)) {
         return withoutParent;
@@ -313,18 +362,15 @@ function rewriteInternalDocLinks(content, dRelPath, knownDestMdPaths) {
   }
 
   // Rewrite Markdown links: [text](target) and [text](target "title")
-  content = content.replace(
-    /\[([^\]]*)\]\(([^)]+)\)/g,
-    (match, text, raw) => {
-      // Split off optional title: "path" or "path \"title\""
-      const titleMatch = raw.match(/^(.*?)\s+"([^"]*)"$/);
-      if (titleMatch) {
-        const fixed = fixLink(titleMatch[1].trim());
-        return `[${text}](${fixed} "${titleMatch[2]}")`;
-      }
-      return `[${text}](${fixLink(raw.trim())})`;
-    },
-  );
+  content = content.replace(/\[([^\]]*)\]\(([^)]+)\)/g, (match, text, raw) => {
+    // Split off optional title: "path" or "path \"title\""
+    const titleMatch = raw.match(/^(.*?)\s+"([^"]*)"$/);
+    if (titleMatch) {
+      const fixed = fixLink(titleMatch[1].trim());
+      return `[${text}](${fixed} "${titleMatch[2]}")`;
+    }
+    return `[${text}](${fixLink(raw.trim())})`;
+  });
 
   return content;
 }
@@ -397,7 +443,13 @@ async function main() {
   // Split source files by type.
   const sourceMdFiles = sourceFiles
     .filter((f) => MD_EXTENSIONS.has(path.extname(f).toLowerCase()))
-    .filter((f) => !(path.dirname(f) === "." && SKIP_SOURCE_ROOT_FILES.has(path.basename(f))));
+    .filter(
+      (f) =>
+        !(
+          path.dirname(f) === "." &&
+          SKIP_SOURCE_ROOT_FILES.has(path.basename(f))
+        ),
+    );
   const sourceImageFiles = sourceFiles.filter((f) =>
     IMAGE_EXTENSIONS.has(path.extname(f).toLowerCase()),
   );
@@ -463,15 +515,18 @@ async function main() {
   const CATEGORY_FILES = [
     {
       file: path.join(DEST_DOCS_DIR, "_category_.yml"),
-      content: "label: Apple App\ncollapsible: true\nposition: 2\nlink:\n  type: doc\n  id: software/apple/index\n",
+      content:
+        "label: Apple App\ncollapsible: true\nposition: 2\nlink:\n  type: doc\n  id: software/apple/index\n",
     },
     {
       file: path.join(DEST_DOCS_DIR, "user", "_category_.yml"),
-      content: "label: User Guide\ncollapsible: true\nposition: 1\nlink:\n  type: doc\n  id: software/apple/user/index\n",
+      content:
+        "label: User Guide\ncollapsible: true\nposition: 1\nlink:\n  type: doc\n  id: software/apple/user/index\n",
     },
     {
       file: path.join(DEST_DOCS_DIR, "developer", "_category_.yml"),
-      content: "label: Developer Guide\ncollapsible: true\nposition: 2\nlink:\n  type: doc\n  id: software/apple/developer/index\n",
+      content:
+        "label: Developer Guide\ncollapsible: true\nposition: 2\nlink:\n  type: doc\n  id: software/apple/developer/index\n",
     },
   ];
 
@@ -480,9 +535,13 @@ async function main() {
     const existing = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : null;
     if (existing !== content) {
       fs.writeFileSync(file, content);
-      console.log(`[${existing ? "UPDATE" : "ADD"}]    category: ${path.relative(REPO_ROOT, file)}`);
+      console.log(
+        `[${existing ? "UPDATE" : "ADD"}]    category: ${path.relative(REPO_ROOT, file)}`,
+      );
     } else {
-      console.log(`[SKIP]   category: ${path.relative(REPO_ROOT, file)} (unchanged)`);
+      console.log(
+        `[SKIP]   category: ${path.relative(REPO_ROOT, file)} (unchanged)`,
+      );
     }
   }
 
@@ -497,7 +556,13 @@ async function main() {
     content = ensureFrontmatter(content, relPath);
     content = rewriteImagePaths(content);
     content = sanitizeForDocusaurus(content);
-    content = rewriteInternalDocLinks(content, dRelPath.split(path.sep).join("/"), expectedDestMdPaths);
+    content = rewriteInternalDocLinks(
+      content,
+      dRelPath.split(path.sep).join("/"),
+      expectedDestMdPaths,
+    );
+    content = useBaseUrlForAssets(content);
+    content = ensureUseBaseUrlImport(content);
 
     const exists = fs.existsSync(destFile);
     const existingContent = exists ? fs.readFileSync(destFile, "utf8") : null;

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,4 +1,5 @@
 import Translate from "@docusaurus/Translate";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import Heading from "@theme/Heading";
 import clsx from "clsx";
 export default function NotFoundContent({ className }) {
@@ -32,7 +33,7 @@ export default function NotFoundContent({ className }) {
             </Translate>
           </p>
           <img
-            src="/design/chirpy/chirpy.png"
+            src={useBaseUrl("/design/chirpy/chirpy.png")}
             alt="Chirpy"
             className={clsx("col col--6 col--offset-3")}
             style={{ maxWidth: "300px" }}


### PR DESCRIPTION
## What did you change

Raw HTML in MDX keeps its paths exactly as written. Docusaurus rewrites Markdown image and link paths against `baseUrl`, but it never looks inside an `<img>` tag, so fifty-one references across twenty-one files point at paths like `/img/hardware/screen.webp` and resolve against the server root.

- **20 pages** in `docs/` and `blog/`: raw `src`, `srcset` and `poster` attributes now go through `useBaseUrl`, matching what `docs/about/contributing.mdx` already does.
- **`src/theme/NotFound/Content/index.js`**: the chirpy image on the 404 page, the only instance outside the content directories.
- **`docusaurus.config.js`**: `baseUrl` is hoisted to a const so the footer copyright, which is a raw HTML string, can interpolate it for its Legal link. The const reads `DOCS_BASE_URL`, so a build can be served under a path without editing the config.
- **`scripts/sync-apple-docs.js`**: the generator was itself emitting raw absolute paths, so the five Apple pages are fixed at the source rather than by hand. It now wraps `src`, `srcset` and `poster` in `useBaseUrl` and adds the import, leaving Markdown syntax and fenced code samples alone. Those pages pick the change up on the next sync.

## Why did you change it

Nothing is broken on meshtastic.org, because `baseUrl` is `/` there and these paths happen to be correct. They stop being correct the moment the site is served from anywhere else: a preview under a path, a reverse proxy mounting the docs below `/docs`, a GitHub Pages project site, or an offline export. The site currently only works at a domain root, and nothing in the code says so.

The generator is the part worth a second look. Its Markdown branch was already fine, since `![alt](/img/apple/x.webp)` gets `baseUrl` applied, but its `<img>` branch wrote absolute paths, and its skip rule (`(?!\/img\/)`) meant references that were already absolute were passed over rather than corrected. Every weekly sync therefore reintroduced the pattern, and a hand fix to those pages would have lasted until Sunday.

## Anything to note

- **No rendered change at the current `baseUrl` of `/`.** `useBaseUrl("/img/x")` returns `/img/x` when `baseUrl` is `/`, so today's output is unchanged. The Vercel preview is the check for that.
- `useBaseUrl` will not double-prefix: it early-returns when the URL already starts with `baseUrl`, and leaves anchors and external URLs alone. That is what makes the sweep safe to apply mechanically.
- The `.md` files under `docs/software/apple/` take an `import` because `markdown.format` is unset, so Docusaurus 3 parses `.md` as MDX. They are treated the same as the `.mdx` files.
- Two pre-existing MDX lint complaints in `docs/community/enclosures/techo.mdx` (an HTML `<!-- -->` comment) are untouched and present on `master`. `pnpm run lint:mdx` passes.
- One raw `<a href="/documents/blog/Opposition_Letter.pdf">` in a 2024 blog post is included in the same sweep.
- Separately from this PR: the 404 image lives in the `static/design` submodule, so a clone that has not run `git submodule update --init` renders it broken no matter what `baseUrl` says.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image, video, audio, document, and footer link resolution when the documentation site is hosted under a subpath.
  - Updated blog posts, documentation pages, and the 404 page to display assets correctly across different deployment URLs.

- **Improvements**
  - Added configurable site base URL support through the deployment environment.
  - Updated Apple documentation synchronization to automatically handle asset paths and required imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->