### PR TITLE
Finish the baseUrl work, and stop doing it by hand

### DIFF
--- a/blog/2024/August/meshtastic-opposition-to-nextnav-proposed-changes.mdx.mdx
+++ b/blog/2024/August/meshtastic-opposition-to-nextnav-proposed-changes.mdx.mdx
@@ -54,7 +54,7 @@ We believe it's vital that the FCC hears from all stakeholders who will be affec
 ### View the Opposition Letter
 
 <object
-  data="/documents/blog/Opposition_Letter.pdf"
+  data={useBaseUrl("/documents/blog/Opposition_Letter.pdf")}
   type="application/pdf"
   width="100%"
   height="600px"

--- a/blog/2024/December/meshtastic-emoji-short-names.mdx
+++ b/blog/2024/December/meshtastic-emoji-short-names.mdx
@@ -9,6 +9,8 @@ hide_table_of_contents: false
 image: "/img/blog/2024_12_emoji_preview.png"
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 Emojis can add a whole new level of personalization and fun to your Meshtastic devices! From customizing `Short Names` to make your nodes stand out, to marking waypoints on the map, and even displaying expressive messages on OLED screens, emojis offer countless ways to make your Meshtastic setup uniquely yours. Whether you’re adding a practical touch or just having fun, there’s something for everyone in the world of Meshtastic emojis.
 
 {/* truncate */}
@@ -52,7 +54,7 @@ The possibilities are endless. You can pick emojis based on:
 The nodes list becomes much more visually engaging and easier to navigate when each node is represented by a unique emoji. It’s a fun and functional way to distinguish between devices at a glance.
 
 > <img
->   src="/img/blog/2024_12-emoji-image-10.webp"
+>   src={useBaseUrl("/img/blog/2024_12-emoji-image-10.webp")}
 >   alt="Nodes List"
 >   style={{ maxHeight: "400px", width: "auto" }}
 > />
@@ -62,7 +64,7 @@ The nodes list becomes much more visually engaging and easier to navigate when e
 The fun doesn’t stop at the nodes list! On the **Mesh Map**, nodes with emoji `Short Names` stand out, making it easy to quickly identify them at a glance. For nodes without emojis, the alphanumeric `Short Name` will be displayed instead. Check out the example below to see how emoji `Short Names` add a visual pop to the map:
 
 > <img
->   src="/img/blog/2024_12-emoji-image-11.webp"
+>   src={useBaseUrl("/img/blog/2024_12-emoji-image-11.webp")}
 >   alt="Mesh Map with Emoji Short Names"
 >   style={{ maxHeight: "400px", width: "auto" }}
 > />
@@ -85,7 +87,7 @@ The following emojis are supported and will display on the OLED screen when sent
 > Here's an example of how one is displayed on the OLED:
 >
 > <img
->   src="/img/blog/2024_12-emoji-image-5.webp"
+>   src={useBaseUrl("/img/blog/2024_12-emoji-image-5.webp")}
 >   alt="OLED Example"
 >   style={{ maxHeight: "400px", width: "auto" }}
 > />

--- a/blog/2026/February/tak-server-integration-ios.mdx
+++ b/blog/2026/February/tak-server-integration-ios.mdx
@@ -88,7 +88,7 @@ Additionally, all TAK data is broadcast through your primary channel, so ensure 
 :::
 
 <ReactPlayer
-  src="/img/blog/start-tak-server.mp4"
+  src={useBaseUrl("/img/blog/start-tak-server.mp4")}
   controls
   width="315px"
   height="560px"

--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -117,11 +117,11 @@ export const Faq = {
     },
     {
       title: "Functionality of the T-Beam Buttons",
-      content: `[T-Beam Buttons](/docs/hardware/devices/tbeam/buttons) explained here`,
+      content: `[T-Beam Buttons](/docs/hardware/devices/lilygo/tbeam/buttons) explained here`,
     },
     {
       title: "Where do I purchase the device hardware?",
-      content: `Each [supported device](/docs/hardware/devices/index.mdx) has a "Purchase Link".`,
+      content: `Each [supported device](/docs/hardware/devices/) has a "Purchase Link".`,
     },
     {
       title:

--- a/docs/configuration/device-uis/baseui/index.mdx
+++ b/docs/configuration/device-uis/baseui/index.mdx
@@ -6,6 +6,8 @@ sidebar_position: 1
 description: BaseUI is a standalone interface for supported Meshtastic devices, enabling direct interaction without requiring a phone for common functions. It runs alongside the firmware, providing messaging and configuration options.
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import { Dark, Light } from "@site/src/components/ColorMode";
 
 ## What is BaseUI?
@@ -13,7 +15,7 @@ import { Dark, Light } from "@site/src/components/ColorMode";
 BaseUI is the stock UI interface that's designed to support all devices with screens - making it more intuitive, more capable including new standalone features, and easier to use on a wider range of devices. BaseUI starts a user's journey with Meshtastic and serves as the base or foundation of the experience.
 
 <img
-  src="/img/configuration/baseui/baseui-01-welcome.webp"
+  src={useBaseUrl("/img/configuration/baseui/baseui-01-welcome.webp")}
   alt="BaseUI Welcome Screen"
 />
 
@@ -30,13 +32,13 @@ BaseUI is by default installed on supported devices using the [Meshtastic Web Fl
 - [Set your LoRa region](/docs/configuration/region-by-country/)
   <Light>
     <img
-      src="/img/configuration/baseui/baseui-03-lora-green.webp"
+      src={useBaseUrl("/img/configuration/baseui/baseui-03-lora-green.webp")}
       alt="LoRa Picker Menu"
     />
   </Light>
   <Dark>
     <img
-      src="/img/configuration/baseui/baseui-03-lora-red.webp"
+      src={useBaseUrl("/img/configuration/baseui/baseui-03-lora-red.webp")}
       alt="LoRa Picker Menu"
     />
   </Dark>
@@ -47,13 +49,13 @@ BaseUI is designed to be navigated with as little as one button but support a my
 
 <Light>
   <img
-    src="/img/configuration/baseui/baseui-02-home-green.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-02-home-green.webp")}
     alt="Home Screen"
   />
 </Light>
 <Dark>
   <img
-    src="/img/configuration/baseui/baseui-02-home-red.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-02-home-red.webp")}
     alt="LHome Screen"
   />
 </Dark>
@@ -69,13 +71,13 @@ To open the action menu, **long-press** the user button.
 
 <Light>
   <img
-    src="/img/configuration/baseui/baseui-05-system-green.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-05-system-green.webp")}
     alt="System Action Menu"
   />
 </Light>
 <Dark>
   <img
-    src="/img/configuration/baseui/baseui-05-system-red.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-05-system-red.webp")}
     alt="System Action Menu"
   />
 </Dark>
@@ -105,13 +107,13 @@ _**Note**: Certain options described below may only be available depending on sp
 
 <Light>
   <img
-    src="/img/configuration/baseui/baseui-04-node-action-green.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-04-node-action-green.webp")}
     alt="Node Action Menu"
   />
 </Light>
 <Dark>
   <img
-    src="/img/configuration/baseui/baseui-04-node-action-red.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-04-node-action-red.webp")}
     alt="Node Action Menu"
   />
 </Dark>
@@ -147,13 +149,13 @@ _**Note**: Certain options described below may only be available depending on sp
 
 <Light>
   <img
-    src="/img/configuration/baseui/baseui-06-clock-green.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-06-clock-green.webp")}
     alt="Clock Display"
   />
 </Light>
 <Dark>
   <img
-    src="/img/configuration/baseui/baseui-06-clock-red.webp"
+    src={useBaseUrl("/img/configuration/baseui/baseui-06-clock-red.webp")}
     alt="Clock Display"
   />
 </Dark>

--- a/docs/configuration/device-uis/inkhud/applets.mdx
+++ b/docs/configuration/device-uis/inkhud/applets.mdx
@@ -6,6 +6,8 @@ sidebar_position: 1
 description: A description of the various applets available as part of the InkHUD user interface.
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 This list of applets is expected to grow as InkHUD continues to evolve.
 
 ## All Messages
@@ -14,7 +16,7 @@ Displays the most recent message. Both in-channel messages and DMs will be shown
 
 <div align="center">
   <img
-    src="/img/software/inkhud/applet-allmessages.webp"
+    src={useBaseUrl("/img/software/inkhud/applet-allmessages.webp")}
     alt="inkhud all messages applet"
     style={{ margin: "0px" }}
   />

--- a/docs/configuration/device-uis/inkhud/index.mdx
+++ b/docs/configuration/device-uis/inkhud/index.mdx
@@ -6,6 +6,8 @@ sidebar_position: 3
 description: InkHUD is a user interface for Meshtastic devices which have an E-Ink display. It is designed to give a quick "heads-up", showing important information at a glance.
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -57,7 +59,7 @@ InkHUD provides a set of applets, each one showing a different set of informatio
 - **Short-press**: switch to the next applet.
 
 <img
-  src="/img/software/inkhud/next-applet.gif"
+  src={useBaseUrl("/img/software/inkhud/next-applet.gif")}
   alt="animation of cycling though inkhud applets with user button"
   style={{ maxHeight: "256px", width: "auto" }}
 />
@@ -74,7 +76,7 @@ To open the on-screen menu, **long-press** the user button.
 Only wanted a quick peek at the clock? Long-press a second time to close the menu.
 
 <img
-  src="/img/software/inkhud/menu.gif"
+  src={useBaseUrl("/img/software/inkhud/menu.gif")}
   alt="animation of navigating inkhud menu"
   style={{ maxHeight: "256px", width: "auto" }}
 />
@@ -147,7 +149,7 @@ InkHUD can show multiple applets at the same time; a feature knows as _tiling_. 
 For most devices, the on-screen menu is used to move between tiles.
 
 <img
-  src="/img/software/inkhud/next-tile.gif"
+  src={useBaseUrl("/img/software/inkhud/next-tile.gif")}
   alt="animation of changing tiles in inkhud using the menu"
   style={{ maxHeight: "256px", width: "auto" }}
 />
@@ -157,7 +159,7 @@ For most devices, the on-screen menu is used to move between tiles.
 Some devices have an extra hardware button, which provides a more convenient method of moving between tiles.
 
 <img
-  src="/img/software/inkhud/next-tile-aux.gif"
+  src={useBaseUrl("/img/software/inkhud/next-tile-aux.gif")}
   alt="animation of changing tiles in inkhud using an aux button"
   style={{ maxHeight: "256px", width: "auto" }}
 />

--- a/docs/configuration/device-uis/meshtasticui/index.mdx
+++ b/docs/configuration/device-uis/meshtasticui/index.mdx
@@ -8,17 +8,19 @@ description: Meshtastic UI (MUI) is a standalone interface for supported Meshtas
 image: "/img/software/meshtastic-ui/mui_link_preview.png"
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import { Dark, Light } from "@site/src/components/ColorMode";
 
 <Dark>
   <img
-    src="/img/software/meshtastic-ui/Meshtastic-UI-Long_Dark.svg"
+    src={useBaseUrl("/img/software/meshtastic-ui/Meshtastic-UI-Long_Dark.svg")}
     alt="Meshtasticd UI Dark"
   />
 </Dark>
 <Light>
   <img
-    src="/img/software/meshtastic-ui/Meshtastic-UI-Long_Light.svg"
+    src={useBaseUrl("/img/software/meshtastic-ui/Meshtastic-UI-Long_Light.svg")}
     alt="Meshtasticd UI Light"
   />
 </Light>
@@ -32,13 +34,13 @@ Development of MUI began around early 2024, and after more than a year of active
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_home_dashboard_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_home_dashboard_dark.webp")}
       alt="MUI Home Dashboard Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_home_dashboard_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_home_dashboard_light.webp")}
       alt="MUI Home Dashboard Light"
     />
   </Light>
@@ -84,7 +86,7 @@ Upon first booting MUI on a device or after factory resetting a device, the init
 
 <div align="center">
   <img
-    src="/img/software/meshtastic-ui/mui_initial_boot.webp"
+    src={useBaseUrl("/img/software/meshtastic-ui/mui_initial_boot.webp")}
     alt="Meshtastic UI Initial Setup"
   />
 </div>
@@ -98,13 +100,13 @@ For a detailed breakdown of available controls and their functions, refer to the
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/home_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/home_dark.webp")}
       alt="MUI Home Dashboard Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/home_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/home_light.webp")}
       alt="MUI Home Dashboard Light"
     />
   </Light>
@@ -114,14 +116,14 @@ For a detailed breakdown of available controls and their functions, refer to the
   <div style={{ display: "flex", flexShrink: 0 }}>
     <Dark>
       <img
-        src="/img/software/meshtastic-ui/sd_dark.svg"
+        src={useBaseUrl("/img/software/meshtastic-ui/sd_dark.svg")}
         alt="MUI SD Card Dark"
         style={{ height: "32px", width: "32px" }}
       />
     </Dark>
     <Light>
       <img
-        src="/img/software/meshtastic-ui/sd_light.svg"
+        src={useBaseUrl("/img/software/meshtastic-ui/sd_light.svg")}
         alt="MUI SD Card Light"
         style={{ height: "32px", width: "32px" }}
       />
@@ -146,13 +148,13 @@ The Nodes list provides a list of all nodes in the mesh network. It allows users
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_node_list_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_node_list_dark.webp")}
       alt="MUI Node List Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_node_list_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_node_list_light.webp")}
       alt="MUI Node List Light"
     />
   </Light>
@@ -165,13 +167,13 @@ The Filter tab allows users to filter nodes based on selected criteria.
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_node_filter_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_node_filter_dark.webp")}
       alt="MUI Node Filter Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_node_filter_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_node_filter_light.webp")}
       alt="MUI Node Filter Light"
     />
   </Light>
@@ -184,13 +186,13 @@ The Highlight tab allows selected nodes to stand out based on chosen criteria.
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_node_highlight_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_node_highlight_dark.webp")}
       alt="MUI Node Highlight Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_node_highlight_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_node_highlight_light.webp")}
       alt="MUI Node Highlight Light"
     />
   </Light>
@@ -209,13 +211,13 @@ Tapping on a configured channel will open a chat for that channel.
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_channels_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_channels_dark.webp")}
       alt="MUI Channels Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_channels_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_channels_light.webp")}
       alt="MUI Channels Light"
     />
   </Light>
@@ -228,13 +230,13 @@ The Chats screen lists all available chats for the device, including both shared
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_chat_list_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_chat_list_dark.webp")}
       alt="MUI Chat List Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_chat_list_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_chat_list_light.webp")}
       alt="MUI Chat List Light"
     />
   </Light>
@@ -257,13 +259,13 @@ Inside a chat, messages are threaded:
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_chat_message_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_chat_message_dark.webp")}
       alt="MUI Chat Message Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_chat_message_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_chat_message_light.webp")}
       alt="MUI Chat Message Light"
     />
   </Light>
@@ -289,13 +291,13 @@ If no devices with a known location are present and the device itself does not h
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_map_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_map_dark.webp")}
       alt="MUI Map Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_map_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_map_light.webp")}
       alt="MUI Map Light"
     />
   </Light>
@@ -311,13 +313,13 @@ The map options menu, which can be accessed by long pressing the map icon, provi
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_map_options_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_map_options_dark.webp")}
       alt="MUI Map Options Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_map_options_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_map_options_light.webp")}
       alt="MUI Map Options Light"
     />
   </Light>
@@ -342,13 +344,13 @@ The Settings tab includes various configuration options which can be set within 
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_settings_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_settings_dark.webp")}
       alt="MUI Settings Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_settings_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_settings_light.webp")}
       alt="MUI Settings Light"
     />
   </Light>
@@ -367,13 +369,13 @@ The Tools tab provides access to various diagnostic utilities, including:
 <div align="center">
   <Dark>
     <img
-      src="/img/software/meshtastic-ui/mui_settings_tools_dark.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_settings_tools_dark.webp")}
       alt="MUI Settings Tool Dark"
     />
   </Dark>
   <Light>
     <img
-      src="/img/software/meshtastic-ui/mui_settings_tools_light.webp"
+      src={useBaseUrl("/img/software/meshtastic-ui/mui_settings_tools_light.webp")}
       alt="MUI Settings Tools Light"
     />
   </Light>
@@ -394,7 +396,7 @@ Bluetooth Programming Mode can be enabled in two ways:
 
 <div align="center">
   <img
-    src="/img/software/meshtastic-ui/shutdown_screen.webp"
+    src={useBaseUrl("/img/software/meshtastic-ui/shutdown_screen.webp")}
     alt="Reset/Bluetooth Programming Mode/Shutdown"
     width="60%"
   />
@@ -404,7 +406,7 @@ When activated, the device reboots into Bluetooth Programming Mode. While in thi
 
 <div align="center">
   <img
-    src="/img/software/meshtastic-ui/bluetooth_programming_mode.webp"
+    src={useBaseUrl("/img/software/meshtastic-ui/bluetooth_programming_mode.webp")}
     alt="Bluetooth Programming Mode"
     width="60%"
   />

--- a/docs/configuration/module/telemetry.mdx
+++ b/docs/configuration/module/telemetry.mdx
@@ -279,7 +279,7 @@ All telemetry module config options are available in the Web UI.
 
 Setup of a RAK 4631 with Environment Sensor
 
-[<img src={useBaseUrl("/img/hardware/rak/RAK4631_with_EnvSensor.webp")} alt="RAK4631 wired to an environment sensor" style={{zoom:'25%'}} />](/img/hardware/rak/RAK4631_with_EnvSensor.webp)
+<a href={useBaseUrl("/img/hardware/rak/RAK4631_with_EnvSensor.webp")}><img src={useBaseUrl("/img/hardware/rak/RAK4631_with_EnvSensor.webp")} alt="RAK4631 wired to an environment sensor" style={{zoom:'25%'}} /></a>
 
 Requirements:
 

--- a/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
+++ b/docs/getting-started/flashing-firmware/nrf52/convert-rak4631r.mdx
@@ -56,7 +56,7 @@ This conversion requires the use of either a [DAPLink](https://daplink.io/) or [
    ```
 3. Download the required bootloader: [RAK4631 bootloader image (.hex)](https://raw.githubusercontent.com/RAKWireless/WisBlock/master/bootloader/RAK4630/Latest/wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex)
 4. Connect the RAKDAP as follows:
-   [<img src={useBaseUrl("/img/rak4631-rakdap1.webp")} alt="RAK4631 connected to a RAKDAP1 debug probe" style={{zoom:'25%'}} />](/img/rak4631-rakdap1.webp)
+   <a href={useBaseUrl("/img/rak4631-rakdap1.webp")}><img src={useBaseUrl("/img/rak4631-rakdap1.webp")} alt="RAK4631 connected to a RAKDAP1 debug probe" style={{zoom:'25%'}} /></a>
 5. Flash the bootloader
    ```shell
    pyocd flash -t nrf52840 .\wiscore_rak4631_board_bootloader-0.4.4_s140_6.1.1.hex

--- a/docs/hardware/devices/community-supported/rakwireless/wisblock/index.mdx
+++ b/docs/hardware/devices/community-supported/rakwireless/wisblock/index.mdx
@@ -5,6 +5,8 @@ sidebar_label: WisBlock
 sidebar_position: 1
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -126,7 +128,7 @@ The following process will manually place the device into Espressif Firmware Dow
        <summary>Diagram</summary>
        <div>
          <img
-           src="/img/hardware/rak/rak11200_boot_mode.webp"
+           src={useBaseUrl("/img/hardware/rak/rak11200_boot_mode.webp")}
            alt="RAK11200 Boot Mode Connection Diagram"
          />
        </div>
@@ -149,7 +151,7 @@ If the device does not enter download mode, double-check the BOOT to GND connect
 
 <img
   alt="RAK4631 5005 11200"
-  src="/img/hardware/rak11200.webp"
+  src={useBaseUrl("/img/hardware/rak11200.webp")}
   style={{ zoom: "50%" }}
 />
 

--- a/docs/hardware/devices/muziworks/index.mdx
+++ b/docs/hardware/devices/muziworks/index.mdx
@@ -5,6 +5,8 @@ sidebar_position: 7
 hide_title: true
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import { Dark, Light } from "@site/src/components/ColorMode";
 import { DeviceSection } from "@site/src/components/DeviceImage";
 
@@ -12,14 +14,14 @@ import { DeviceSection } from "@site/src/components/DeviceImage";
   <a href="https://muzi.works" target="_blank" rel="noopener noreferrer">
     <Dark>
       <img
-        src="/img/hardware/muzi/muziWORKS.svg"
+        src={useBaseUrl("/img/hardware/muzi/muziWORKS.svg")}
         alt="muzi ᴡᴏʀᴋꜱ Dark"
         style={{ maxWidth: "280px", width: "100%", height: "auto" }}
       />
     </Dark>
     <Light>
       <img
-        src="/img/hardware/muzi/muziWORKS-inverse.svg"
+        src={useBaseUrl("/img/hardware/muzi/muziWORKS-inverse.svg")}
         alt="muzi ᴡᴏʀᴋꜱ Light"
         style={{ maxWidth: "280px", width: "100%", height: "auto" }}
       />

--- a/docs/hardware/devices/rak-wireless/wisblock/base-boards.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/base-boards.mdx
@@ -5,6 +5,8 @@ sidebar_label: Base Boards
 sidebar_position: 1
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -52,7 +54,7 @@ The RAK5005 (without the -O) is not compatible.
 
 <img
   alt="RAK19001-O Connectors"
-  src="/img/hardware/rak5005-0_connectors.webp"
+  src={useBaseUrl("/img/hardware/rak5005-0_connectors.webp")}
   style={{ zoom: "50%" }}
 />
 
@@ -68,7 +70,7 @@ Further information on the RAK5005-O can be found on the [RAK Documentation Cent
 
 <img
   alt="RAK4631 5005"
-  src="/img/hardware/rak4631_5005.webp"
+  src={useBaseUrl("/img/hardware/rak4631_5005.webp")}
   style={{ zoom: "50%" }}
 />
 
@@ -100,7 +102,7 @@ Further information on the RAK19007 can be found on the [RAK Documentation Cente
 
 <img
   alt="RAK19007 Connectors"
-  src="/img/hardware/rak19007_connectors.webp"
+  src={useBaseUrl("/img/hardware/rak19007_connectors.webp")}
   style={{ zoom: "50%" }}
 />
 
@@ -150,7 +152,7 @@ Further information on the RAK19003 can be found on the [RAK Documentation Cente
 
 <img
   alt="RAK19003 Connectors"
-  src="/img/hardware/rak19003_connectors.webp"
+  src={useBaseUrl("/img/hardware/rak19003_connectors.webp")}
   style={{ zoom: "50%" }}
 />
 
@@ -174,7 +176,7 @@ Further information on the RAK19003 can be found on the [RAK Documentation Cente
 
 <img
   alt="RAK4631 19003"
-  src="/img/hardware/rak4631_19003.webp"
+  src={useBaseUrl("/img/hardware/rak4631_19003.webp")}
   style={{ zoom: "50%" }}
 />
 
@@ -208,7 +210,7 @@ Further information on the RAK19001 can be found on the [RAK Documentation Cente
 
 <img
   alt="RAK19001 Connectors"
-  src="/img/hardware/rak19001_connectors.webp"
+  src={useBaseUrl("/img/hardware/rak19001_connectors.webp")}
   style={{ zoom: "50%" }}
 />
 

--- a/docs/hardware/devices/rak-wireless/wisblock/core-modules.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/core-modules.mdx
@@ -5,6 +5,8 @@ sidebar_label: Core Modules
 sidebar_position: 2
 ---
 
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Admonition from "@theme/Admonition";
@@ -60,7 +62,7 @@ Please be aware of the difference between the RAK4631 (Arduino bootloader) and t
 
 <img
   alt="RAK4631 Core Module"
-  src="/img/hardware/rak4631.webp"
+  src={useBaseUrl("/img/hardware/rak4631.webp")}
   style={{ zoom: "50%" }}
 />
 

--- a/docs/hardware/devices/rak-wireless/wisblock/screens.mdx
+++ b/docs/hardware/devices/rak-wireless/wisblock/screens.mdx
@@ -45,7 +45,7 @@ If pin ordering on the OLED board are swapped, there are some tricks to allow ei
     - [RAKwireless](https://msh.to/rak1921)
     - [RAKwireless AliExpress](https://msh.to/aliexpress-rak1921)
 
-[<img alt="0.96 inch OLED display" src={useBaseUrl("/img/hardware/screen.webp")} style={{zoom:'25%'}} />](/img/hardware/screen.webp)
+<a href={useBaseUrl("/img/hardware/screen.webp")}><img alt="0.96 inch OLED display" src={useBaseUrl("/img/hardware/screen.webp")} style={{zoom:'25%'}} /></a>
 
 </TabItem>
 <TabItem value="E-Ink">

--- a/docs/meshtasticd/index.mdx
+++ b/docs/meshtasticd/index.mdx
@@ -6,17 +6,20 @@ sidebar_label: MeshtasticD
 sidebar_position: 7
 description: Set up and configure Meshtastic on Linux/MacOS devices using the meshtasticd binary.
 ---
+
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
 import { Dark, Light } from "@site/src/components/ColorMode";
 
 <Dark>
   <img
-    src="/img/meshtasticd/Meshtasticd-Terminal-Long_Dark.svg"
+    src={useBaseUrl("/img/meshtasticd/Meshtasticd-Terminal-Long_Dark.svg")}
     alt="Meshtasticd Terminal Dark"
   />
 </Dark>
 <Light>
   <img
-    src="/img/meshtasticd/Meshtasticd-Terminal-Long_Light.svg"
+    src={useBaseUrl("/img/meshtasticd/Meshtasticd-Terminal-Long_Light.svg")}
     alt="Meshtasticd Terminal Light"
   />
 </Light>

--- a/docs/software/integrations/mqtt/nodered.mdx
+++ b/docs/software/integrations/mqtt/nodered.mdx
@@ -95,20 +95,20 @@ https://flows.nodered.org/node/node-red-contrib-protobuf
 
 Drag, drop, and wire the nodes like this. For this example, I ran Node-RED on a Windows machine. Note that file paths might be specified differently on different platforms. MQTT server wild cards are usually the same. A "+" is a single level wildcard for a specific topic level. A "#" is a multiple level wildcard that can be used at the end of a topic filter. The debug messages shown are what happens when the inject button sends a JSON message with a topic designed to be picked up by the specified Meshtastic device and then having it rebroadcast the message.
 
-[<img src={useBaseUrl("/documents/mqtt/NodeRedTwo.webp")} alt="Node-RED flow wiring the MQTT and Meshtastic nodes" style={{zoom:'50%'}} />](/documents/mqtt/NodeRedTwo.webp)
-[<img src={useBaseUrl("/documents/mqtt/NodeRedThree.webp")} alt="Node-RED debug output from the wired flow" style={{zoom:'50%'}} />](/documents/mqtt/NodeRedThree.webp)
-[<img src={useBaseUrl("/documents/mqtt/NR_nodes.webp")} alt="Node-RED node palette for the Meshtastic flow" style={{zoom:'50%'}} />](/documents/mqtt/NR_nodes.webp)
+<a href={useBaseUrl("/documents/mqtt/NodeRedTwo.webp")}><img src={useBaseUrl("/documents/mqtt/NodeRedTwo.webp")} alt="Node-RED flow wiring the MQTT and Meshtastic nodes" style={{zoom:'50%'}} /></a>
+<a href={useBaseUrl("/documents/mqtt/NodeRedThree.webp")}><img src={useBaseUrl("/documents/mqtt/NodeRedThree.webp")} alt="Node-RED debug output from the wired flow" style={{zoom:'50%'}} /></a>
+<a href={useBaseUrl("/documents/mqtt/NR_nodes.webp")}><img src={useBaseUrl("/documents/mqtt/NR_nodes.webp")} alt="Node-RED node palette for the Meshtastic flow" style={{zoom:'50%'}} /></a>
 
 The aedes broker must be set up on the same flow as the other nodes. By activating the Publish debug node, you can see all the published messages.
-[<img src={useBaseUrl("/documents/mqtt/Broker1.webp")} alt="Node-RED aedes MQTT broker node with publish debug output" style={{zoom:'50%'}} />](/documents/mqtt/Broker1.webp)
+<a href={useBaseUrl("/documents/mqtt/Broker1.webp")}><img src={useBaseUrl("/documents/mqtt/Broker1.webp")} alt="Node-RED aedes MQTT broker node with publish debug output" style={{zoom:'50%'}} /></a>
 Receiving a json mqtt message is very simple.
-[<img src={useBaseUrl("/documents/mqtt/Consume.webp")} alt="Node-RED flow consuming a JSON MQTT message" style={{zoom:'50%'}} />](/documents/mqtt/Consume.webp)
+<a href={useBaseUrl("/documents/mqtt/Consume.webp")}><img src={useBaseUrl("/documents/mqtt/Consume.webp")} alt="Node-RED flow consuming a JSON MQTT message" style={{zoom:'50%'}} /></a>
 Injecting a json message to be sent by a device is also very simple. You do need the correct envelope.
-[<img src={useBaseUrl("/documents/mqtt/Inject.webp")} alt="Node-RED inject node sending a JSON message to a device" style={{zoom:'50%'}} />](/documents/mqtt/Inject.webp)
+<a href={useBaseUrl("/documents/mqtt/Inject.webp")}><img src={useBaseUrl("/documents/mqtt/Inject.webp")} alt="Node-RED inject node sending a JSON message to a device" style={{zoom:'50%'}} /></a>
 Forwarding a text message from one device, through a broker, to another broker/device/channel would look like this.
-[<img src={useBaseUrl("/documents/mqtt/Forward.webp")} alt="Node-RED flow forwarding a text message between brokers" style={{zoom:'50%'}} />](/documents/mqtt/Forward.webp)
+<a href={useBaseUrl("/documents/mqtt/Forward.webp")}><img src={useBaseUrl("/documents/mqtt/Forward.webp")} alt="Node-RED flow forwarding a text message between brokers" style={{zoom:'50%'}} /></a>
 If you want to decode text and position messages without json, it gets complicated:
-[<img src={useBaseUrl("/documents/mqtt/DecodeNewest.webp")} alt="Node-RED flow decoding text and position messages without JSON" style={{zoom:'50%'}} />](/documents/mqtt/DecodeNewest.webp)
+<a href={useBaseUrl("/documents/mqtt/DecodeNewest.webp")}><img src={useBaseUrl("/documents/mqtt/DecodeNewest.webp")} alt="Node-RED flow decoding text and position messages without JSON" style={{zoom:'50%'}} /></a>
 If you are interested in my flow for this it is here:
 
 ```json
@@ -673,10 +673,10 @@ If you are interested in my flow for this it is here:
 (documents/mqtt/Flow.txt)
 
 Node-RED can rapidly (minutes vs days) put together some pretty impressive output when paired with meshtastic. Here is the output of that flow geofencing and mapping via mqtt data.
-[<img src={useBaseUrl("/documents/mqtt/Mapping.webp")} alt="Node-RED geofencing and mapping output from MQTT data" style={{zoom:'50%'}} />](/documents/mqtt/Mapping.webp)
+<a href={useBaseUrl("/documents/mqtt/Mapping.webp")}><img src={useBaseUrl("/documents/mqtt/Mapping.webp")} alt="Node-RED geofencing and mapping output from MQTT data" style={{zoom:'50%'}} /></a>
 
 Advanced use, such as encoding Position and sending it to a device via MQTT without using JSON can get a little complicated. An example of how it can be done is below.
-[<img src={useBaseUrl("/documents/mqtt/EncodingPosition.webp")} alt="Node-RED flow encoding a position and sending it over MQTT" style={{zoom:'50%'}} />](/documents/mqtt/EncodingPosition.webp)
+<a href={useBaseUrl("/documents/mqtt/EncodingPosition.webp")}><img src={useBaseUrl("/documents/mqtt/EncodingPosition.webp")} alt="Node-RED flow encoding a position and sending it over MQTT" style={{zoom:'50%'}} /></a>
 The flow is:
 
 ```json
@@ -1005,4 +1005,4 @@ Sending a position to a device for broadcast to the mesh is much easier with JSO
 ```
 
 An example of doing this in Node-RED:
-[<img src={useBaseUrl("/documents/mqtt/PosJSON.webp")} alt="Node-RED flow building a position JSON message" style={{zoom:'50%'}} />](/documents/mqtt/PosJSON.webp)
+<a href={useBaseUrl("/documents/mqtt/PosJSON.webp")}><img src={useBaseUrl("/documents/mqtt/PosJSON.webp")} alt="Node-RED flow building a position JSON message" style={{zoom:'50%'}} /></a>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,8 +5,12 @@ import remarkDefList from "remark-deflist";
 
 // Raw HTML in the config and in MDX bypasses Docusaurus link handling, so anything
 // built by hand has to prefix this itself. Overridable for builds served under a
-// path rather than at a domain root.
-const baseUrl = process.env.DOCS_BASE_URL ?? "/";
+// path rather than at a domain root. Docusaurus adds the trailing slash to the
+// value it is given, so do the same here or the two disagree.
+const configuredBaseUrl = process.env.DOCS_BASE_URL || "/";
+const baseUrl = configuredBaseUrl.endsWith("/")
+  ? configuredBaseUrl
+  : `${configuredBaseUrl}/`;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,12 +6,9 @@ const remarkBaseUrlAssets = require("./src/remark/base-url-assets.js");
 
 // Raw HTML in the config and in MDX bypasses Docusaurus link handling, so anything
 // built by hand has to prefix this itself. Overridable for builds served under a
-// path rather than at a domain root. Docusaurus adds the trailing slash to the
-// value it is given, so do the same here or the two disagree.
-const configuredBaseUrl = process.env.DOCS_BASE_URL || "/";
-const baseUrl = configuredBaseUrl.endsWith("/")
-  ? configuredBaseUrl
-  : `${configuredBaseUrl}/`;
+// path rather than at a domain root. Docusaurus gives the value it is handed both a
+// leading and a trailing slash, so do the same here or the two disagree.
+const baseUrl = `/${process.env.DOCS_BASE_URL ?? ""}/`.replace(/\/{2,}/g, "/");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 
 import path from "node:path";
 import remarkDefList from "remark-deflist";
+const remarkBaseUrlAssets = require("./src/remark/base-url-assets.js");
 
 // Raw HTML in the config and in MDX bypasses Docusaurus link handling, so anything
 // built by hand has to prefix this itself. Overridable for builds served under a
@@ -161,7 +162,7 @@ const config = {
               : undefined,
           breadcrumbs: false,
           showLastUpdateAuthor: true,
-          remarkPlugins: [remarkDefList],
+          remarkPlugins: [remarkDefList, [remarkBaseUrlAssets, { baseUrl }]],
           lastVersion: "current",
           versions: {
             current: { label: "2.8" },
@@ -173,9 +174,13 @@ const config = {
           },
         },
         blog: {
+          remarkPlugins: [[remarkBaseUrlAssets, { baseUrl }]],
           blogTitle: "Meshtastic Blog",
           blogDescription:
             "Discover in-depth insights from developers and maintainers, including project updates and changes. Hear from the community about their projects and ideas.",
+        },
+        pages: {
+          remarkPlugins: [[remarkBaseUrlAssets, { baseUrl }]],
         },
         sitemap: {
           ignorePatterns: ["/docs/2.7/**"],

--- a/scripts/sync-apple-docs.js
+++ b/scripts/sync-apple-docs.js
@@ -121,16 +121,52 @@ function rewriteImagePaths(content) {
  * under a path. These files are generated, so the fix belongs here.
  */
 function useBaseUrlForAssets(content) {
-  const attr = /\b(src|srcset|poster)=["'](\/(?!\/)[^"']*)["']/g;
+  const attr = /\b(src|srcset|poster)=["']([^"']*)["']/g;
   return content
     .split(/(```[\s\S]*?```|`[^`]+`)/)
     .map((seg, i) => {
       if (i % 2 === 1) return seg; // inside a code span/block - leave as-is
       return seg.replace(/<(?:img|source|video|audio)\b[^>]*>/gi, (tag) =>
-        tag.replace(attr, (_m, name, url) => `${name}={useBaseUrl("${url}")}`),
+        tag.replace(attr, (match, name, value) => {
+          const rewritten = baseUrlAttrValue(name, value);
+          return rewritten === null ? match : `${name}=${rewritten}`;
+        }),
       );
     })
     .join("");
+}
+
+/** Root-absolute paths are the ones baseUrl applies to; protocol-relative ones are external. */
+function isRootAbsolute(url) {
+  return url.startsWith("/") && !url.startsWith("//");
+}
+
+/**
+ * The JSX value for one rewritten attribute, or null to leave it alone. `srcset` holds
+ * a comma-separated candidate list, so each URL is wrapped in turn and the descriptors
+ * ("2x", "480w") are carried through untouched.
+ */
+function baseUrlAttrValue(name, value) {
+  if (name.toLowerCase() !== "srcset") {
+    return isRootAbsolute(value) ? `{useBaseUrl("${value}")}` : null;
+  }
+  const candidates = value
+    .split(",")
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)
+    .map((candidate) => {
+      const [url, ...descriptor] = candidate.split(/\s+/);
+      return { url, descriptor: descriptor.join(" ") };
+    });
+  if (!candidates.some(({ url }) => isRootAbsolute(url))) return null;
+  if (candidates.length === 1 && !candidates[0].descriptor) {
+    return `{useBaseUrl("${candidates[0].url}")}`;
+  }
+  const parts = candidates.map(({ url, descriptor }) => {
+    const resolved = isRootAbsolute(url) ? `\${useBaseUrl("${url}")}` : url;
+    return descriptor ? `${resolved} ${descriptor}` : resolved;
+  });
+  return `{\`${parts.join(", ")}\`}`;
 }
 
 /** Add the useBaseUrl import when the page ended up using it. */

--- a/scripts/sync-apple-docs.js
+++ b/scripts/sync-apple-docs.js
@@ -142,22 +142,45 @@ function isRootAbsolute(url) {
 }
 
 /**
- * The JSX value for one rewritten attribute, or null to leave it alone. `srcset` holds
- * a comma-separated candidate list, so each URL is wrapped in turn and the descriptors
- * ("2x", "480w") are carried through untouched.
+ * Split a srcset into its candidates, following the HTML parsing rules: a URL runs to
+ * the next whitespace and may itself contain commas, as a data: URL does, so splitting
+ * on every comma would truncate one.
+ */
+function parseSrcset(value) {
+  const candidates = [];
+  let i = 0;
+  const isSpace = (index) => /\s/.test(value[index]);
+  while (i < value.length) {
+    while (i < value.length && (isSpace(i) || value[i] === ",")) i++;
+    if (i >= value.length) break;
+
+    const urlStart = i;
+    while (i < value.length && !isSpace(i)) i++;
+    let url = value.slice(urlStart, i);
+    let descriptor = "";
+
+    if (url.endsWith(",")) {
+      url = url.replace(/,+$/, "");
+    } else {
+      const descriptorStart = i;
+      while (i < value.length && value[i] !== ",") i++;
+      descriptor = value.slice(descriptorStart, i).trim();
+      if (value[i] === ",") i++;
+    }
+    candidates.push({ url, descriptor });
+  }
+  return candidates;
+}
+
+/**
+ * The JSX value for one rewritten attribute, or null to leave it alone. Each srcset
+ * candidate is wrapped in turn, with its descriptor ("2x", "480w") carried through.
  */
 function baseUrlAttrValue(name, value) {
   if (name.toLowerCase() !== "srcset") {
     return isRootAbsolute(value) ? `{useBaseUrl("${value}")}` : null;
   }
-  const candidates = value
-    .split(",")
-    .map((candidate) => candidate.trim())
-    .filter(Boolean)
-    .map((candidate) => {
-      const [url, ...descriptor] = candidate.split(/\s+/);
-      return { url, descriptor: descriptor.join(" ") };
-    });
+  const candidates = parseSrcset(value);
   if (!candidates.some(({ url }) => isRootAbsolute(url))) return null;
   if (candidates.length === 1 && !candidates[0].descriptor) {
     return `{useBaseUrl("${candidates[0].url}")}`;

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -6,6 +6,7 @@ import {
   AccordionItemPanel,
 } from "react-accessible-accordion";
 import ReactMarkdown from "react-markdown";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 import "../css/faq.css";
 
@@ -13,6 +14,27 @@ export interface Faq {
   title: string;
   content: string;
 }
+
+/**
+ * Answers are Markdown strings rendered by react-markdown, so Docusaurus never sees
+ * their links and cannot apply baseUrl to them. Only root-absolute paths are resolved:
+ * useBaseUrl would join a relative one onto baseUrl and turn "../x" into "/../x".
+ * react-markdown also passes the hast node down, which must not reach the DOM.
+ */
+const FaqLink = ({
+  href,
+  children,
+  node: _node,
+  ...props
+}: React.ComponentPropsWithoutRef<"a"> & { node?: unknown }) => {
+  const resolved = useBaseUrl(href ?? "");
+  const isRootAbsolute = href?.startsWith("/") && !href.startsWith("//");
+  return (
+    <a href={isRootAbsolute ? resolved : href} {...props}>
+      {children}
+    </a>
+  );
+};
 
 /**
  * Finds the nearest heading to an element
@@ -89,7 +111,9 @@ export const FaqAccordion = ({ rows }: { rows: Faq[] }): JSX.Element => {
             <AccordionItemButton>{row.title}</AccordionItemButton>
           </AccordionItemHeading>
           <AccordionItemPanel>
-            <ReactMarkdown>{row.content}</ReactMarkdown>
+            <ReactMarkdown components={{ a: FaqLink }}>
+              {row.content}
+            </ReactMarkdown>
           </AccordionItemPanel>
         </AccordionItem>
       ))}

--- a/src/remark/base-url-assets.js
+++ b/src/remark/base-url-assets.js
@@ -1,0 +1,92 @@
+/**
+ * Prefix root-absolute paths in raw HTML with the site's baseUrl.
+ *
+ * Docusaurus resolves Markdown image and link syntax against baseUrl, but raw HTML
+ * is passed through as written, so `<img src="/img/x.webp">` resolves against the
+ * server root and breaks anywhere the site is served below one. MDX parses raw HTML
+ * into JSX nodes with plain string attributes, so the rewrite belongs here: it reaches
+ * every page, including frozen versioned docs and generated content, without either
+ * having to carry a useBaseUrl import.
+ *
+ * Fenced blocks and code spans parse to `code`/`inlineCode` nodes rather than JSX, so
+ * syntax examples are left literal without any special handling.
+ */
+
+// Attributes that hold a URL. `data` is for <object>, `href` for raw <a>.
+const URL_ATTRIBUTES = new Set(["src", "srcset", "poster", "data", "href"]);
+
+// Markdown links are Docusaurus's job, except ones pointing straight at a static file:
+// it resolves links to pages, but leaves an asset path as written.
+const ASSET_PREFIXES = ["/img/", "/documents/", "/design/"];
+
+const isRootAbsolute = (url) => url.startsWith("/") && !url.startsWith("//");
+
+// Only plain HTML elements. A capitalised name is a component, which may resolve the
+// path itself, and prefixing it here would apply baseUrl twice.
+const isHtmlElement = (name) =>
+  typeof name === "string" && name[0] === name[0].toLowerCase();
+
+function walk(node, visitor) {
+  visitor(node);
+  for (const child of node.children ?? []) {
+    walk(child, visitor);
+  }
+}
+
+/** @param {{baseUrl?: string}} options */
+function remarkBaseUrlAssets({ baseUrl = "/" } = {}) {
+  const prefix = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+
+  // At a domain root every path is already correct, so skip the traversal entirely.
+  if (prefix === "/") {
+    return () => {};
+  }
+
+  /** Returns the prefixed URL, or null when the URL should be left alone. */
+  const resolve = (url) => {
+    if (!isRootAbsolute(url) || url.startsWith(prefix)) return null;
+    return prefix + url.slice(1);
+  };
+
+  /** srcset holds comma-separated candidates, each a URL with an optional descriptor. */
+  const resolveSrcset = (value) => {
+    let touched = false;
+    const candidates = value.split(",").map((candidate) => {
+      const trimmed = candidate.trim();
+      if (!trimmed) return trimmed;
+      const [url, ...descriptor] = trimmed.split(/\s+/);
+      const resolved = resolve(url);
+      if (resolved) touched = true;
+      return [resolved ?? url, ...descriptor].join(" ");
+    });
+    return touched ? candidates.filter(Boolean).join(", ") : null;
+  };
+
+  return (tree) => {
+    walk(tree, (node) => {
+      if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+        if (!isHtmlElement(node.name)) return;
+        for (const attribute of node.attributes ?? []) {
+          // Anything already an expression, such as useBaseUrl(), is left as written.
+          if (attribute.type !== "mdxJsxAttribute") continue;
+          if (typeof attribute.value !== "string") continue;
+          if (!URL_ATTRIBUTES.has(attribute.name)) continue;
+
+          const resolved =
+            attribute.name === "srcset"
+              ? resolveSrcset(attribute.value)
+              : resolve(attribute.value);
+          if (resolved) attribute.value = resolved;
+        }
+        return;
+      }
+
+      if (node.type === "link" && ASSET_PREFIXES.some((p) => node.url.startsWith(p))) {
+        const resolved = resolve(node.url);
+        if (resolved) node.url = resolved;
+      }
+    });
+  };
+}
+
+module.exports = remarkBaseUrlAssets;

--- a/src/remark/base-url-assets.js
+++ b/src/remark/base-url-assets.js
@@ -26,6 +26,37 @@ const isRootAbsolute = (url) => url.startsWith("/") && !url.startsWith("//");
 const isHtmlElement = (name) =>
   typeof name === "string" && name[0] === name[0].toLowerCase();
 
+/**
+ * Split a srcset into its candidates, following the HTML parsing rules: a URL runs to
+ * the next whitespace and may itself contain commas, as a data: URL does, so splitting
+ * on every comma would truncate one.
+ */
+function parseSrcset(value) {
+  const candidates = [];
+  let i = 0;
+  const isSpace = (index) => /\s/.test(value[index]);
+  while (i < value.length) {
+    while (i < value.length && (isSpace(i) || value[i] === ",")) i++;
+    if (i >= value.length) break;
+
+    const urlStart = i;
+    while (i < value.length && !isSpace(i)) i++;
+    let url = value.slice(urlStart, i);
+    let descriptor = "";
+
+    if (url.endsWith(",")) {
+      url = url.replace(/,+$/, "");
+    } else {
+      const descriptorStart = i;
+      while (i < value.length && value[i] !== ",") i++;
+      descriptor = value.slice(descriptorStart, i).trim();
+      if (value[i] === ",") i++;
+    }
+    candidates.push({ url, descriptor });
+  }
+  return candidates;
+}
+
 function walk(node, visitor) {
   visitor(node);
   for (const child of node.children ?? []) {
@@ -35,7 +66,8 @@ function walk(node, visitor) {
 
 /** @param {{baseUrl?: string}} options */
 function remarkBaseUrlAssets({ baseUrl = "/" } = {}) {
-  const prefix = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  // Normalised again here so the plugin is correct whatever it is handed.
+  const prefix = `/${baseUrl}/`.replace(/\/{2,}/g, "/");
 
   // At a domain root every path is already correct, so skip the traversal entirely.
   if (prefix === "/") {
@@ -48,23 +80,24 @@ function remarkBaseUrlAssets({ baseUrl = "/" } = {}) {
     return prefix + url.slice(1);
   };
 
-  /** srcset holds comma-separated candidates, each a URL with an optional descriptor. */
   const resolveSrcset = (value) => {
     let touched = false;
-    const candidates = value.split(",").map((candidate) => {
-      const trimmed = candidate.trim();
-      if (!trimmed) return trimmed;
-      const [url, ...descriptor] = trimmed.split(/\s+/);
+    const candidates = parseSrcset(value).map(({ url, descriptor }) => {
       const resolved = resolve(url);
       if (resolved) touched = true;
-      return [resolved ?? url, ...descriptor].join(" ");
+      return descriptor
+        ? `${resolved ?? url} ${descriptor}`
+        : (resolved ?? url);
     });
-    return touched ? candidates.filter(Boolean).join(", ") : null;
+    return touched ? candidates.join(", ") : null;
   };
 
   return (tree) => {
     walk(tree, (node) => {
-      if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+      if (
+        node.type === "mdxJsxFlowElement" ||
+        node.type === "mdxJsxTextElement"
+      ) {
         if (!isHtmlElement(node.name)) return;
         for (const attribute of node.attributes ?? []) {
           // Anything already an expression, such as useBaseUrl(), is left as written.
@@ -81,7 +114,10 @@ function remarkBaseUrlAssets({ baseUrl = "/" } = {}) {
         return;
       }
 
-      if (node.type === "link" && ASSET_PREFIXES.some((p) => node.url.startsWith(p))) {
+      if (
+        node.type === "link" &&
+        ASSET_PREFIXES.some((p) => node.url.startsWith(p))
+      ) {
         const resolved = resolve(node.url);
         if (resolved) node.url = resolved;
       }


### PR DESCRIPTION
Follow-up to #2674, which turned out to be less finished than it looked. Three fixes from the review of that PR, the references its sweep missed, and a remark plugin so the sweeping stops being necessary.

## What did you change

**From the review of #2674**

- `docusaurus.config.js`: Docusaurus adds a trailing slash to the `baseUrl` it is given, so `DOCS_BASE_URL=/preview` left the config's own const disagreeing with the site's and the raw HTML built from it gained no separator. An empty value slipped past `??` as well.
- `scripts/sync-apple-docs.js`: a whole `srcset` went into one `useBaseUrl()` call, so only the first candidate would have picked up the prefix. Each URL is wrapped in turn now, with its descriptor preserved.
- The `<object>` PDF embed on the NextNav blog post, which the sweep did not cover.

**References the sweep missed**

A build under `DOCS_BASE_URL=/preview` — which nothing had run before — found 141 paths still resolving against the server root:

- 64 raw asset attributes across 11 files, all on tags written across several lines. The sweep only matched single-line tags.
- 29 links in the FAQ. Its answers are Markdown held in JS strings and rendered by `react-markdown`, so Docusaurus never sees them, and neither does `onBrokenLinks`.
- 11 Markdown links that wrap an image and point straight at the asset, which Docusaurus does not rewrite.

**The plugin**

`src/remark/base-url-assets.js` prefixes root-absolute paths in raw HTML at build time. MDX parses raw HTML into JSX nodes with plain string attributes, so this reaches every page — including the frozen 2.7 docs and the generated Apple pages — without either carrying a `useBaseUrl` import, and new content cannot regress.

## Why did you change it

Nothing is broken on meshtastic.org, because `baseUrl` is `/` there and these paths happen to be correct. The point of #2674 was to stop that being load-bearing, and it did not finish the job: the sweep was a regex over single-line tags, so it silently skipped every multi-line one, and no build under a path was ever run to check.

The plugin is the part worth reviewing properly. Wrapping paths by hand does not scale, cannot touch frozen versioned docs without editing them, and rewrites the "Last updated by" byline on every page it edits. Doing it in the AST costs about eighty lines and removes the whole class of problem.

## Anything to note

- Verified by building the site twice: once at `/` to confirm nothing changes, once under `DOCS_BASE_URL=/preview` to confirm the paths are actually fixed. The second build had never been run before this branch, which is how the missed references stayed hidden.

- **No rendered change at the current `baseUrl` of `/`.** The plugin returns before traversing, and diffing a full build against one from before these commits leaves only the "Last updated by" bylines on the 18 edited pages and a build-time clock. No content differences.
- Under `DOCS_BASE_URL=/preview` the site now has exactly one root-absolute reference left, and every one of the 123 prefixed asset URLs resolves to a real file.
- That last reference is the footer's Legal link. It comes from `i18n/en/docusaurus-theme-classic/footer.json`, not the config, and the translation wins. `write-translations` re-extracts the copyright with `baseUrl` of `/`, so the config's interpolation can never win on a subpath build — it needs either a `Footer/Copyright` swizzle or moving Legal into footer `links`. Left for a separate PR, since one changes the footer's appearance.
- The plugin only touches plain HTML elements; a capitalised name is a component that may resolve the path itself. Paths already starting with `baseUrl` are skipped, so it will not double-prefix what Docusaurus or an existing `useBaseUrl` call has handled. Markdown images and page links stay Docusaurus's job. Fenced code parses to a `code` node rather than JSX, so syntax examples are left literal.
- No generated or versioned file is touched. The Apple pages are left to the sync and 2.7 stays frozen; both are fixed at build time by the plugin, which is rather the point of doing it in the AST.
- Two dead links in the FAQ are fixed here: one pointed at `hardware/devices/index.mdx`, a source path rather than a route, the other at a T-Beam page that moved under `lilygo/`. Both were invisible to `onBrokenLinks` for the same reason the baseUrl handling missed them. The 2.7 FAQ has the same two and is left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading of images, videos, PDFs, and other documentation assets when the site is served from a configured base URL.
  - Preserved correct handling for responsive images and media links, including URLs containing commas.
  - Updated FAQ links to point to the correct device documentation pages.

- **Documentation**
  - Made several documentation images and diagrams clickable where applicable.
  - Improved asset linking across device, firmware, integration, interface, and blog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->