### PR TITLE
Reorganize Ohio Mesh groups for clarity

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -495,12 +495,14 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ### Ohio
 
-- [Cincy Mesh](https://www.cincymesh.org)
-- [Dayton Mesh](https://daytonmesh.org/)
-- [Central Ohio (Columbus Metro Area) Mesh](https://meshcolumb.us/)
-- [Northeast Ohio (Cleveland/Akron Area) Mesh](https://neome.sh/)
 - [Northwest Ohio (Toledo Area) Mesh](https://nwomesh.org/)
 - [Richland County Ohio Mesh](https://www.facebook.com/groups/710526535393221)
+- [Northeast Ohio (Cleveland/Akron Area) Mesh](https://neome.sh/)
+- [Central Ohio (Columbus Metro Area) Mesh](https://meshcolumb.us/)
+- [Ohio Valley Mesh](https://ovmesh.com/)
+- [Dayton Mesh](https://daytonmesh.org/)
+- [Cincy Mesh](https://www.cincymesh.org)
+- [South East Ohio Mesh](https://www.ohiomesh.net/)
 
 ### Oklahoma
 


### PR DESCRIPTION
Added Ohio Valley Mesh and South East Ohio Mesh and sorted from North to South, West to East.

<!-- Add or remove sections as needed -->
## What did you change
<!-- Describe what your changes will do if merged -->
Added South East Ohio and Ohio Valley Mesh and sorted Ohio North to South, East to West.

## Why did you change it
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord conversations -->

## Screenshots
### Before


### After


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Ohio local groups listing.
  * Added Ohio Valley Mesh and South East Ohio Mesh.
  * Reordered the group list for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->