### PR TITLE
Update Michigan local group listing to Michigan Mesh Network

### DIFF
--- a/docs/community/local-groups.mdx
+++ b/docs/community/local-groups.mdx
@@ -438,7 +438,9 @@ If you run a Discord server for your local community, be sure to follow our anno
 
 ### Michigan
 
-- [Michigan Meshtastic Network](https://discord.gg/3A5RREcBcc)
+- [Michigan Mesh Network](https://michmesh.com/)
+- [Michigan Mesh Network Discord](https://discord.gg/3A5RREcBcc)
+- [Michigan Mesh Network Signal](https://signal.group/#CjQKIG5-o6UUXvto66c1wN4fbinuguy614cJtRPmMxUA6JWyEhBKp6Q70OkA2MpcjsBYU1r9)
 
 ### Minnesota
 - [MSP Mesh](https://mspmesh.org/)


### PR DESCRIPTION
Updates the Michigan entry to point to the Michigan Mesh Network community website (michmesh.com), which covers Meshtastic, MeshCore, and Reticulum across the state, and adds the community Discord and Signal group links. The Discord invite is the existing one. Group name complies with the trademark guidelines (no 'Meshtastic [City]' naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Michigan local group listing to use its current name.
  - Added links to the group’s website and Signal community while retaining the existing Discord link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->